### PR TITLE
DATAMONGO-501: Initial push for Tailable Cursor Support (Review Only)

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -41,7 +41,7 @@ import com.mongodb.WriteResult;
  * Interface that specifies a basic set of MongoDB operations. Implemented by {@link MongoTemplate}. Not often used but
  * a useful option for extensibility and testability (as it can be easily mocked, stubbed, or be the target of a JDK
  * proxy).
- * 
+ *
  * @author Thomas Risberg
  * @author Mark Pollack
  * @author Oliver Gierke
@@ -50,7 +50,7 @@ public interface MongoOperations {
 
 	/**
 	 * The collection name used for the specified class by this template.
-	 * 
+	 *
 	 * @param entityClass must not be {@literal null}.
 	 * @return
 	 */
@@ -60,7 +60,7 @@ public interface MongoOperations {
 	 * Execute the a MongoDB command expressed as a JSON string. This will call the method JSON.parse that is part of the
 	 * MongoDB driver to convert the JSON string to a DBObject. Any errors that result from executing this command will be
 	 * converted into Spring's DAO exception hierarchy.
-	 * 
+	 *
 	 * @param jsonCommand a MongoDB command expressed as a JSON string.
 	 */
 	CommandResult executeCommand(String jsonCommand);
@@ -68,7 +68,7 @@ public interface MongoOperations {
 	/**
 	 * Execute a MongoDB command. Any errors that result from executing this command will be converted into Spring's DAO
 	 * exception hierarchy.
-	 * 
+	 *
 	 * @param command a MongoDB command
 	 */
 	CommandResult executeCommand(DBObject command);
@@ -76,7 +76,7 @@ public interface MongoOperations {
 	/**
 	 * Execute a MongoDB command. Any errors that result from executing this command will be converted into Spring's DAO
 	 * exception hierarchy.
-	 * 
+	 *
 	 * @param command a MongoDB command
 	 * @param options query options to use
 	 */
@@ -84,7 +84,7 @@ public interface MongoOperations {
 
 	/**
 	 * Execute a MongoDB query and iterate over the query results on a per-document basis with a DocumentCallbackHandler.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param collectionName name of the collection to retrieve the objects from
@@ -96,7 +96,7 @@ public interface MongoOperations {
 	 * Executes a {@link DbCallback} translating any exceptions as necessary.
 	 * <p/>
 	 * Allows for returning a result object, that is a domain object or a collection of domain objects.
-	 * 
+	 *
 	 * @param <T> return type
 	 * @param action callback object that specifies the MongoDB actions to perform on the passed in DB instance.
 	 * @return a result object returned by the action or <tt>null</tt>
@@ -107,7 +107,7 @@ public interface MongoOperations {
 	 * Executes the given {@link CollectionCallback} on the entity collection of the specified class.
 	 * <p/>
 	 * Allows for returning a result object, that is a domain object or a collection of domain objects.
-	 * 
+	 *
 	 * @param entityClass class that determines the collection to use
 	 * @param <T> return type
 	 * @param action callback object that specifies the MongoDB action
@@ -119,7 +119,7 @@ public interface MongoOperations {
 	 * Executes the given {@link CollectionCallback} on the collection of the given name.
 	 * <p/>
 	 * Allows for returning a result object, that is a domain object or a collection of domain objects.
-	 * 
+	 *
 	 * @param <T> return type
 	 * @param collectionName the name of the collection that specifies which DBCollection instance will be passed into
 	 * @param action callback object that specifies the MongoDB action the callback action.
@@ -133,7 +133,7 @@ public interface MongoOperations {
 	 * href=http://www.mongodb.org/display/DOCS/Java+Driver+Concurrency>Java Driver Concurrency</a>}
 	 * <p/>
 	 * Allows for returning a result object, that is a domain object or a collection of domain objects.
-	 * 
+	 *
 	 * @param <T> return type
 	 * @param action callback that specified the MongoDB actions to perform on the DB instance
 	 * @return a result object returned by the action or <tt>null</tt>
@@ -142,7 +142,7 @@ public interface MongoOperations {
 
 	/**
 	 * Create an uncapped collection with a name based on the provided entity class.
-	 * 
+	 *
 	 * @param entityClass class that determines the collection to create
 	 * @return the created collection
 	 */
@@ -150,7 +150,7 @@ public interface MongoOperations {
 
 	/**
 	 * Create a collect with a name based on the provided entity class using the options.
-	 * 
+	 *
 	 * @param entityClass class that determines the collection to create
 	 * @param collectionOptions options to use when creating the collection.
 	 * @return the created collection
@@ -159,7 +159,7 @@ public interface MongoOperations {
 
 	/**
 	 * Create an uncapped collection with the provided name.
-	 * 
+	 *
 	 * @param collectionName name of the collection
 	 * @return the created collection
 	 */
@@ -167,7 +167,7 @@ public interface MongoOperations {
 
 	/**
 	 * Create a collect with the provided name and options.
-	 * 
+	 *
 	 * @param collectionName name of the collection
 	 * @param collectionOptions options to use when creating the collection.
 	 * @return the created collection
@@ -176,7 +176,7 @@ public interface MongoOperations {
 
 	/**
 	 * A set of collection names.
-	 * 
+	 *
 	 * @return list of collection names
 	 */
 	Set<String> getCollectionNames();
@@ -185,7 +185,7 @@ public interface MongoOperations {
 	 * Get a collection by name, creating it if it doesn't exist.
 	 * <p/>
 	 * Translate any exceptions as necessary.
-	 * 
+	 *
 	 * @param collectionName name of the collection
 	 * @return an existing collection or a newly created one.
 	 */
@@ -195,7 +195,7 @@ public interface MongoOperations {
 	 * Check to see if a collection with a name indicated by the entity class exists.
 	 * <p/>
 	 * Translate any exceptions as necessary.
-	 * 
+	 *
 	 * @param entityClass class that determines the name of the collection
 	 * @return true if a collection with the given name is found, false otherwise.
 	 */
@@ -205,7 +205,7 @@ public interface MongoOperations {
 	 * Check to see if a collection with a given name exists.
 	 * <p/>
 	 * Translate any exceptions as necessary.
-	 * 
+	 *
 	 * @param collectionName name of the collection
 	 * @return true if a collection with the given name is found, false otherwise.
 	 */
@@ -215,7 +215,7 @@ public interface MongoOperations {
 	 * Drop the collection with the name indicated by the entity class.
 	 * <p/>
 	 * Translate any exceptions as necessary.
-	 * 
+	 *
 	 * @param entityClass class that determines the collection to drop/delete.
 	 */
 	<T> void dropCollection(Class<T> entityClass);
@@ -224,21 +224,21 @@ public interface MongoOperations {
 	 * Drop the collection with the given name.
 	 * <p/>
 	 * Translate any exceptions as necessary.
-	 * 
+	 *
 	 * @param collectionName name of the collection to drop/delete.
 	 */
 	void dropCollection(String collectionName);
 
 	/**
 	 * Returns the operations that can be performed on indexes
-	 * 
+	 *
 	 * @return index operations on the named collection
 	 */
 	IndexOperations indexOps(String collectionName);
 
 	/**
 	 * Returns the operations that can be performed on indexes
-	 * 
+	 *
 	 * @return index operations on the named collection associated with the given entity class
 	 */
 	IndexOperations indexOps(Class<?> entityClass);
@@ -251,7 +251,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * If your collection does not contain a homogeneous collection of types, this operation will not be an efficient way
 	 * to map objects since the test for class type is done in the client and not on the server.
-	 * 
+	 *
 	 * @param entityClass the parameterized type of the returned list
 	 * @return the converted collection
 	 */
@@ -265,7 +265,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * If your collection does not contain a homogeneous collection of types, this operation will not be an efficient way
 	 * to map objects since the test for class type is done in the client and not on the server.
-	 * 
+	 *
 	 * @param entityClass the parameterized type of the returned list.
 	 * @param collectionName name of the collection to retrieve the objects from
 	 * @return the converted collection
@@ -275,7 +275,7 @@ public interface MongoOperations {
 	/**
 	 * Execute a group operation over the entire collection. The group operation entity class should match the 'shape' of
 	 * the returned object that takes int account the initial document structure as well as any finalize functions.
-	 * 
+	 *
 	 * @param criteria The criteria that restricts the row that are considered for grouping. If not specified all rows are
 	 *          considered.
 	 * @param inputCollectionName the collection where the group operation will read from
@@ -290,7 +290,7 @@ public interface MongoOperations {
 	 * Execute a group operation restricting the rows to those which match the provided Criteria. The group operation
 	 * entity class should match the 'shape' of the returned object that takes int account the initial document structure
 	 * as well as any finalize functions.
-	 * 
+	 *
 	 * @param criteria The criteria that restricts the row that are considered for grouping. If not specified all rows are
 	 *          considered.
 	 * @param inputCollectionName the collection where the group operation will read from
@@ -303,7 +303,7 @@ public interface MongoOperations {
 
 	/**
 	 * Execute a map-reduce operation. The map-reduce operation will be formed with an output type of INLINE
-	 * 
+	 *
 	 * @param inputCollectionName the collection where the map-reduce will read from
 	 * @param mapFunction The JavaScript map function
 	 * @param reduceFunction The JavaScript reduce function
@@ -316,7 +316,7 @@ public interface MongoOperations {
 
 	/**
 	 * Execute a map-reduce operation that takes additional map-reduce options.
-	 * 
+	 *
 	 * @param inputCollectionName the collection where the map-reduce will read from
 	 * @param mapFunction The JavaScript map function
 	 * @param reduceFunction The JavaScript reduce function
@@ -330,7 +330,7 @@ public interface MongoOperations {
 	/**
 	 * Execute a map-reduce operation that takes a query. The map-reduce operation will be formed with an output type of
 	 * INLINE
-	 * 
+	 *
 	 * @param query The query to use to select the data for the map phase
 	 * @param inputCollectionName the collection where the map-reduce will read from
 	 * @param mapFunction The JavaScript map function
@@ -344,7 +344,7 @@ public interface MongoOperations {
 
 	/**
 	 * Execute a map-reduce operation that takes a query and additional map-reduce options
-	 * 
+	 *
 	 * @param query The query to use to select the data for the map phase
 	 * @param inputCollectionName the collection where the map-reduce will read from
 	 * @param mapFunction The JavaScript map function
@@ -359,7 +359,7 @@ public interface MongoOperations {
 	/**
 	 * Returns {@link GeoResult} for all entities matching the given {@link NearQuery}. Will consider entity mapping
 	 * information to determine the collection the query is ran against.
-	 * 
+	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @return
@@ -368,7 +368,7 @@ public interface MongoOperations {
 
 	/**
 	 * Returns {@link GeoResult} for all entities matching the given {@link NearQuery}.
-	 * 
+	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @param collectionName the collection to trigger the query against. If no collection name is given the entity class
@@ -386,7 +386,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
@@ -403,12 +403,12 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
 	 * @param collectionName name of the collection to retrieve the objects from
-	 * 
+	 *
 	 * @return the converted object
 	 */
 	<T> T findOne(Query query, Class<T> entityClass, String collectionName);
@@ -421,7 +421,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
@@ -437,12 +437,12 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
 	 * @param collectionName name of the collection to retrieve the objects from
-	 * 
+	 *
 	 * @return the List of converted objects
 	 */
 	<T> List<T> find(Query query, Class<T> entityClass, String collectionName);
@@ -450,7 +450,7 @@ public interface MongoOperations {
 	/**
 	 * Returns a document with the given id mapped onto the given class. The collection the query is ran against will be
 	 * derived from the given target class as well.
-	 * 
+	 *
 	 * @param <T>
 	 * @param id the id of the document to return.
 	 * @param entityClass the type the document shall be converted into.
@@ -460,11 +460,11 @@ public interface MongoOperations {
 
 	/**
 	 * Returns the document with the given id from the given collection mapped onto the given target class.
-	 * 
+	 *
 	 * @param id the id of the document to return
 	 * @param entityClass the type to convert the document to
 	 * @param collectionName the collection to query for the document
-	 * 
+	 *
 	 * @param <T>
 	 * @return
 	 */
@@ -488,7 +488,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
@@ -505,19 +505,19 @@ public interface MongoOperations {
 	 * <p/>
 	 * The query is specified as a {@link Query} which can be created either using the {@link BasicQuery} or the more
 	 * feature rich {@link Query}.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification
 	 * @param entityClass the parameterized type of the returned list.
 	 * @param collectionName name of the collection to retrieve the objects from
-	 * 
+	 *
 	 * @return the converted object
 	 */
 	<T> T findAndRemove(Query query, Class<T> entityClass, String collectionName);
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.
-	 * 
+	 *
 	 * @param query
 	 * @param entityClass must not be {@literal null}.
 	 * @return
@@ -526,7 +526,7 @@ public interface MongoOperations {
 
 	/**
 	 * Returns the number of documents for the given {@link Query} querying the given collection.
-	 * 
+	 *
 	 * @param query
 	 * @param collectionName must not be {@literal null} or empty.
 	 * @return
@@ -546,7 +546,7 @@ public interface MongoOperations {
 	 * <p/>
 	 * <p/>
 	 * Insert is used to initially store the object into the database. To update an existing object use the save method.
-	 * 
+	 *
 	 * @param objectToSave the object to store in the collection.
 	 */
 	void insert(Object objectToSave);
@@ -558,7 +558,7 @@ public interface MongoOperations {
 	 * configured otherwise, an instance of SimpleMongoConverter will be used.
 	 * <p/>
 	 * Insert is used to initially store the object into the database. To update an existing object use the save method.
-	 * 
+	 *
 	 * @param objectToSave the object to store in the collection
 	 * @param collectionName name of the collection to store the object in
 	 */
@@ -566,7 +566,7 @@ public interface MongoOperations {
 
 	/**
 	 * Insert a Collection of objects into a collection in a single batch write to the database.
-	 * 
+	 *
 	 * @param batchToSave the list of objects to save.
 	 * @param entityClass class that determines the collection to use
 	 */
@@ -574,7 +574,7 @@ public interface MongoOperations {
 
 	/**
 	 * Insert a list of objects into the specified collection in a single batch write to the database.
-	 * 
+	 *
 	 * @param batchToSave the list of objects to save.
 	 * @param collectionName name of the collection to store the object in
 	 */
@@ -583,7 +583,7 @@ public interface MongoOperations {
 	/**
 	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
 	 * class.
-	 * 
+	 *
 	 * @param collectionToSave the list of objects to save.
 	 */
 	void insertAll(Collection<? extends Object> objectsToSave);
@@ -600,7 +600,7 @@ public interface MongoOperations {
 	 * property type will be handled by Spring's BeanWrapper class that leverages Spring 3.0's new Type Conversion API.
 	 * See <a href="http://static.springsource.org/spring/docs/3.0.x/reference/validation.html#core-convert">Spring 3 Type
 	 * Conversion"</a> for more details.
-	 * 
+	 *
 	 * @param objectToSave the object to store in the collection
 	 */
 	void save(Object objectToSave);
@@ -617,7 +617,7 @@ public interface MongoOperations {
 	 * property type will be handled by Spring's BeanWrapper class that leverages Spring 3.0's new Type Cobnversion API.
 	 * See <a href="http://static.springsource.org/spring/docs/3.0.x/reference/validation.html#core-convert">Spring 3 Type
 	 * Conversion"</a> for more details.
-	 * 
+	 *
 	 * @param objectToSave the object to store in the collection
 	 * @param collectionName name of the collection to store the object in
 	 */
@@ -626,7 +626,7 @@ public interface MongoOperations {
 	/**
 	 * Performs an upsert. If no document is found that matches the query, a new document is created and inserted by
 	 * combining the query document and the update document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be upserted
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing object
 	 * @param entityClass class that determines the collection to use
@@ -637,7 +637,7 @@ public interface MongoOperations {
 	/**
 	 * Performs an upsert. If no document is found that matches the query, a new document is created and inserted by
 	 * combining the query document and the update document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be updated
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing
 	 *          object.
@@ -649,7 +649,7 @@ public interface MongoOperations {
 	/**
 	 * Updates the first object that is found in the collection of the entity class that matches the query document with
 	 * the provided update document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be updated
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing
 	 *          object.
@@ -661,7 +661,7 @@ public interface MongoOperations {
 	/**
 	 * Updates the first object that is found in the specified collection that matches the query document criteria with
 	 * the provided updated document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be updated
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing
 	 *          object.
@@ -673,7 +673,7 @@ public interface MongoOperations {
 	/**
 	 * Updates all objects that are found in the collection for the entity class that matches the query document criteria
 	 * with the provided updated document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be updated
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing
 	 *          object.
@@ -685,7 +685,7 @@ public interface MongoOperations {
 	/**
 	 * Updates all objects that are found in the specified collection that matches the query document criteria with the
 	 * provided updated document.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to select a record to be updated
 	 * @param update the update document that contains the updated object or $ operators to manipulate the existing
 	 *          object.
@@ -696,14 +696,14 @@ public interface MongoOperations {
 
 	/**
 	 * Remove the given object from the collection by id.
-	 * 
+	 *
 	 * @param object
 	 */
 	void remove(Object object);
 
 	/**
 	 * Removes the given object from the given collection.
-	 * 
+	 *
 	 * @param object
 	 * @param collection must not be {@literal null} or empty.
 	 */
@@ -712,7 +712,7 @@ public interface MongoOperations {
 	/**
 	 * Remove all documents that match the provided query document criteria from the the collection used to store the
 	 * entityClass. The Class parameter is also used to help convert the Id of the object if it is present in the query.
-	 * 
+	 *
 	 * @param <T>
 	 * @param query
 	 * @param entityClass
@@ -722,7 +722,7 @@ public interface MongoOperations {
 	/**
 	 * Remove all documents from the specified collection that match the provided query document criteria. There is no
 	 * conversion/mapping done for any criteria using the id field.
-	 * 
+	 *
 	 * @param query the query document that specifies the criteria used to remove a record
 	 * @param collectionName name of the collection where the objects will removed
 	 */
@@ -730,8 +730,41 @@ public interface MongoOperations {
 
 	/**
 	 * Returns the underlying {@link MongoConverter}.
-	 * 
+	 *
 	 * @return
 	 */
 	MongoConverter getConverter();
+
+	/**
+	 * Helper method that tells whether the given collection is capped or not.
+	 *
+	 * @param 	collection
+	 * @return 	boolean value that indicates if the collection is capped or not, true if the
+	 * 			collection is capped
+	 */
+	 boolean isCollectionCapped(String collection);
+
+	 /**
+	  * The convenience method that delegates call to {@link #tailCollection(TailingCursorConfig, TailingCursorDocumentListener)}
+	  *
+	  * @param collection
+	  * @param increasingKey
+	  * @return
+	  */
+	 TailingCursorHandle tailCollection(String collection,String increasingKey,
+			 						TailingCursorDocumentListener listener);
+
+
+	 /**
+	  * This method starts a new thread which will tail a capped collection in the background and
+	  * will invoke the {@link TailingCursorDocumentListener#processDocument(DBObject)} with the
+	  * latest document at the tail of the cursor
+	  *
+	  * @param config The instance of {@link TailingCursorConfig} that contains the configuration
+	  * @param listener An instance if {@link TailingCursorDocumentListener} which receives the
+	  * 		notifications for new documents.
+	  * @return
+	  */
+	 TailingCursorHandle tailCollection(TailingCursorConfig config,TailingCursorDocumentListener listener);
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.springframework.data.mongodb.core.SerializationUtils.*;
-import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.SerializationUtils.serializeToJsonSafely;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -29,6 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
@@ -86,6 +89,7 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.Bytes;
 import com.mongodb.CommandResult;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -95,6 +99,7 @@ import com.mongodb.MapReduceCommand;
 import com.mongodb.MapReduceOutput;
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
+import com.mongodb.MongoException.CursorNotFound;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
@@ -102,18 +107,22 @@ import com.mongodb.util.JSON;
 
 /**
  * Primary implementation of {@link MongoOperations}.
- * 
+ *
  * @author Thomas Risberg
  * @author Graeme Rocher
  * @author Mark Pollack
  * @author Oliver Gierke
  * @author Amol Nayak
+ *
  */
 public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MongoTemplate.class);
 	private static final String ID = "_id";
 	private static final WriteResultChecking DEFAULT_WRITE_RESULT_CHECKING = WriteResultChecking.NONE;
+	//TODO: Currently setting the max number of threads to 100, finalize on an approach
+	private final ExecutorService executorService = Executors.newFixedThreadPool(100);
+
 	@SuppressWarnings("serial")
 	private static final List<String> ITERABLE_CLASSES = new ArrayList<String>() {
 		{
@@ -155,7 +164,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Constructor used for a basic template configuration
-	 * 
+	 *
 	 * @param mongo
 	 * @param databaseName
 	 */
@@ -166,7 +175,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Constructor used for a template configuration with user credentials in the form of
 	 * {@link org.springframework.data.authentication.UserCredentials}
-	 * 
+	 *
 	 * @param mongo
 	 * @param databaseName
 	 * @param userCredentials
@@ -177,7 +186,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Constructor used for a basic template configuration
-	 * 
+	 *
 	 * @param mongoDbFactory
 	 */
 	public MongoTemplate(MongoDbFactory mongoDbFactory) {
@@ -186,7 +195,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Constructor used for a basic template configuration.
-	 * 
+	 *
 	 * @param mongoDbFactory
 	 * @param mongoConverter
 	 */
@@ -208,13 +217,12 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 				((ApplicationEventPublisherAware) mappingContext).setApplicationEventPublisher(eventPublisher);
 			}
 		}
-
 	}
 
 	/**
 	 * Configures the {@link WriteResultChecking} to be used with the template. Setting {@literal null} will reset the
 	 * default of {@value #DEFAULT_WRITE_RESULT_CHECKING}.
-	 * 
+	 *
 	 * @param resultChecking
 	 */
 	public void setWriteResultChecking(WriteResultChecking resultChecking) {
@@ -223,7 +231,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Configures the {@link WriteConcern} to be used with the template.
-	 * 
+	 *
 	 * @param writeConcern
 	 */
 	public void setWriteConcern(WriteConcern writeConcern) {
@@ -232,7 +240,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Configures the {@link WriteConcernResolver} to be used with the template.
-	 * 
+	 *
 	 * @param writeConcernResolver
 	 */
 	public void setWriteConcernResolver(WriteConcernResolver writeConcernResolver) {
@@ -242,7 +250,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Used by @{link {@link #prepareCollection(DBCollection)} to set the {@link ReadPreference} before any operations are
 	 * performed.
-	 * 
+	 *
 	 * @param readPreference
 	 */
 	public void setReadPreference(ReadPreference readPreference) {
@@ -263,7 +271,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Returns the default {@link org.springframework.data.mongodb.core.core.convert.MongoConverter}.
-	 * 
+	 *
 	 * @return
 	 */
 	public MongoConverter getConverter() {
@@ -320,7 +328,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Execute a MongoDB query and iterate over the query results on a per-document basis with a
 	 * {@link DocumentCallbackHandler} using the provided CursorPreparer.
-	 * 
+	 *
 	 * @param query the query class that specifies the criteria used to find a record and also an optional fields
 	 *          specification, must not be {@literal null}.
 	 * @param collectionName name of the collection to retrieve the objects from
@@ -601,7 +609,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Prepare the collection before any processing is done using it. This allows a convenient way to apply settings like
 	 * slaveOk() etc. Can be overridden in sub-classes.
-	 * 
+	 *
 	 * @param collection
 	 */
 	protected void prepareCollection(DBCollection collection) {
@@ -613,7 +621,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Prepare the WriteConcern before any processing is done using it. This allows a convenient way to apply custom
 	 * settings in sub-classes.
-	 * 
+	 *
 	 * @param writeConcern any WriteConcern already configured or null
 	 * @return The prepared WriteConcern or null
 	 */
@@ -1151,12 +1159,173 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		return commandObject;
 	}
 
+
+
 	public Set<String> getCollectionNames() {
 		return execute(new DbCallback<Set<String>>() {
 			public Set<String> doInDB(DB db) throws MongoException, DataAccessException {
 				return db.getCollectionNames();
 			}
 		});
+	}
+
+	/**
+	 * Helper method that tells whether the given collection is capped or not.
+	 *
+	 * @param 	collection
+	 * @return 	boolean value that indicates if the collection is capped or not, true if the
+	 * 			collection is capped
+	 */
+	public boolean isCollectionCapped(String collection) {
+		DBCollection dbCol = getDb().getCollection(collection);
+		if(dbCol != null) {
+			return dbCol.isCapped();
+		}
+		return false;
+	}
+
+
+	/**
+	  * The convenience method that delegates call to {@link #tailCollection(TailingCursorConfig, TailingCursorDocumentListener)}
+	  *
+	  * @param collection
+	  * @param increasingKey
+	  * @return
+	  */
+	public TailingCursorHandle tailCollection(String collection,
+			String increasingKey, TailingCursorDocumentListener listener) {
+		return tailCollection(new TailingCursorConfig()
+									.withCollectionName(collection)
+									.withIncreasingKey(increasingKey), listener);
+	}
+
+	 /**
+	  * This method starts a new thread which will tail a capped collection in the background and
+	  * will invoke the {@link TailingCursorDocumentListener#processDocument(DBObject)} with the
+	  * latest document at the tail of the cursor
+	  *
+	  * @param config The instance of {@link TailingCursorConfig} that contains the configuration
+	  * @param listener An instance if {@link TailingCursorDocumentListener} which receives the
+	  * 		notifications for new documents.
+	  * @return
+	  */
+	public TailingCursorHandle tailCollection(TailingCursorConfig config,
+			TailingCursorDocumentListener listener) {
+		Assert.notNull(config,"Provide a non null instance of TailingCursorConfig");
+		Assert.notNull(listener, "Provide a non null instance of TailingCursorDocumentListener");
+		final String collectionName = config.getCollectionName();
+		final String increasingKey = config.getIncreasingKey();
+		Assert.isTrue(StringUtils.hasText(collectionName),"Provide a non null and non empty collection name");
+		Assert.isTrue(StringUtils.hasText(increasingKey),"Provide a non null and non empty increasing key");
+		Assert.notNull(listener, "Provide a non null instance of TailingCursorDocumentListener");
+		Assert.isTrue(isCollectionCapped(collectionName),"Tail can be invoked only on capped collections, "
+				+ collectionName + " is not a capped collection");
+
+		final AtomicBoolean running = doTailCollection(config,listener);
+
+		TailingCursorHandle handle = new TailingCursorHandle() {
+			public void stopTailing() {
+				running.set(false);
+			}
+
+			public String getCollectionName() {
+				return collectionName;
+			}
+
+			public String getIncreasingKey() {
+				return increasingKey;
+			}
+
+		};
+
+		return handle;
+	}
+
+	/**
+	 * The method starts a new thread and tails a capped collection
+	 * @param config
+	 * @param listener
+	 *
+	 */
+	private AtomicBoolean doTailCollection(final TailingCursorConfig config,
+					final TailingCursorDocumentListener listener) {
+		final AtomicBoolean running = new AtomicBoolean(true);
+		executorService.execute(new Runnable() {
+			public void run() {
+				DBCollection cappedCollection = getDb().getCollection(config.getCollectionName());
+				String increasingKey = config.getIncreasingKey();
+				Object lastVal = null;
+
+				//find if there are already records present in the collection and get its tail
+				DBCursor curs = cappedCollection.find()
+					.sort(new BasicDBObject("$natural", -1)).limit(1);
+				if(curs.hasNext()) {
+					lastVal = curs.next().get(increasingKey);
+				}
+
+				while(running.get()) {
+					DBCursor cursor = getCursor(cappedCollection,increasingKey,lastVal);
+					try {
+						while(cursor.hasNext() && cursor.getCursorId() != 0 && running.get()) {
+							DBObject object = cursor.next();
+							if(running.get()) {
+								try {
+									listener.processDocument(object);
+									lastVal = object.get(increasingKey);
+								} catch (Exception e) {
+									LOGGER.warn("Caught exception while processing document",e);
+								}
+							}
+							else {
+								break;
+							}
+						}
+					} catch(CursorNotFound e) {
+
+					}
+					try {
+						cursor.close();
+					} catch (Exception e) {
+						LOGGER.info("Caught exception while trying to close the cursor");
+					}
+
+					if(running.get()) {
+						try {
+							Thread.sleep(config.getCursorRegenerationInterval());
+						} catch (InterruptedException e) {
+							LOGGER.error("Thread Interrupted", e);
+						}
+					}
+					else {
+						break;
+					}
+
+				}
+			}
+		});
+		return running;
+	}
+
+	private DBCursor getCursor(DBCollection cappedCollection,String increasingKey,Object lastVal) {
+		DBCursor cursor;
+		//if this is still null, it means the collection in empty initially
+		if(lastVal == null) {
+			cursor =
+				cappedCollection.find()
+							.sort(new BasicDBObject("$natural", 1))
+							.addOption(Bytes.QUERYOPTION_TAILABLE)
+							.addOption(Bytes.QUERYOPTION_AWAITDATA);
+		}
+		else {
+			cursor =
+				cappedCollection.find(new BasicDBObject(increasingKey,
+											new BasicDBObject("$gt", lastVal)))
+							.sort(new BasicDBObject("$natural", 1))
+							.addOption(Bytes.QUERYOPTION_TAILABLE)
+							.addOption(Bytes.QUERYOPTION_AWAITDATA);
+		}
+
+		return cursor;
 	}
 
 	public DB getDb() {
@@ -1419,7 +1588,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	 * <li>Iterate over the {@link DBCursor} and applies the given {@link DbObjectCallback} to each of the
 	 * {@link DBObject}s collecting the actual result {@link List}.</li>
 	 * <ol>
-	 * 
+	 *
 	 * @param <T>
 	 * @param collectionCallback the callback to retrieve the {@link DBCursor} with
 	 * @param preparer the {@link CursorPreparer} to potentially modify the {@link DBCursor} before ireating over it
@@ -1536,7 +1705,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Tries to convert the given {@link RuntimeException} into a {@link DataAccessException} but returns the original
 	 * exception if the conversation failed. Thus allows safe rethrowing of the return value.
-	 * 
+	 *
 	 * @param ex
 	 * @return
 	 */
@@ -1548,7 +1717,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Inspects the given {@link CommandResult} for erros and potentially throws an
 	 * {@link InvalidDataAccessApiUsageException} for that error.
-	 * 
+	 *
 	 * @param result must not be {@literal null}.
 	 * @param source must not be {@literal null}.
 	 */
@@ -1577,7 +1746,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Simple {@link CollectionCallback} that takes a query {@link DBObject} plus an optional fields specification
 	 * {@link DBObject} and executes that against the {@link DBCollection}.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 * @author Thomas Risberg
 	 */
@@ -1610,7 +1779,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Simple {@link CollectionCallback} that takes a query {@link DBObject} plus an optional fields specification
 	 * {@link DBObject} and executes that against the {@link DBCollection}.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 * @author Thomas Risberg
 	 */
@@ -1641,7 +1810,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Simple {@link CollectionCallback} that takes a query {@link DBObject} plus an optional fields specification
 	 * {@link DBObject} and executes that against the {@link DBCollection}.
-	 * 
+	 *
 	 * @author Thomas Risberg
 	 */
 	private static class FindAndRemoveCallback implements CollectionCallback<DBObject> {
@@ -1686,7 +1855,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	/**
 	 * Simple internal callback to allow operations on a {@link DBObject}.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 
@@ -1698,7 +1867,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * Simple {@link DbObjectCallback} that will transform {@link DBObject} into the given target type using the given
 	 * {@link MongoReader}.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	private class ReadDbObjectCallback<T> implements DbObjectCallback<T> {
@@ -1782,7 +1951,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * {@link DbObjectCallback} that assumes a {@link GeoResult} to be created, delegates actual content unmarshalling to
 	 * a delegate and creates a {@link GeoResult} from the result.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	static class GeoNearResultDbObjectCallback<T> implements DbObjectCallback<GeoResult<T>> {
@@ -1793,7 +1962,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		/**
 		 * Creates a new {@link GeoNearResultDbObjectCallback} using the given {@link DbObjectCallback} delegate for
 		 * {@link GeoResult} content unmarshalling.
-		 * 
+		 *
 		 * @param delegate
 		 */
 		public GeoNearResultDbObjectCallback(DbObjectCallback<T> delegate, Metric metric) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorConfig.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2010-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import com.mongodb.MongoException.CursorNotFound;
+
+/**
+ * The class that will be holding various configuration parameter values for the tailing cursor.
+ *
+ * @author Amol Nayak
+ *
+ * @since 1.1
+ *
+ */
+public class TailingCursorConfig {
+
+	private long cursorRegenerationInterval = 100L;	//defaults to 100 ms
+
+	private String collectionName;
+
+	private String increasingKey;
+
+	/**
+	 * The interval after which the cursor will be reopened on the collection if it reached
+	 * the end on previous occasion or threw a {@link CursorNotFound} exception.
+	 *
+	 * @param cursorRegenerationInterval
+	 * @return
+	 */
+	public TailingCursorConfig withRegenerationDelay(long cursorRegenerationInterval) {
+		Assert.isTrue(cursorRegenerationInterval > 0,"Provide a non negative value for cursor regeneration interval");
+		this.cursorRegenerationInterval = cursorRegenerationInterval;
+		return this;
+	}
+
+	/**
+	 * The name of the capped collection to be tailed.
+	 *
+	 * @param collectionName
+	 * @return
+	 */
+	public TailingCursorConfig withCollectionName(String collectionName) {
+		Assert.isTrue(StringUtils.hasText(collectionName), "Provide a non null non empty string for collection name");
+		this.collectionName = collectionName;
+		return this;
+	}
+
+	/**
+	 * The name of the increasing key that would be used for comparison for tailing
+	 * the collection.
+	 *
+	 * @return
+	 */
+	public TailingCursorConfig withIncreasingKey(String increasingKey) {
+		Assert.isTrue(StringUtils.hasText(increasingKey),"The increasing key should be a non null non empty string");
+		this.increasingKey = increasingKey;
+		return this;
+	}
+
+	/**
+	 * Gets the cursor regeneration interval.
+	 *
+	 * @return
+	 */
+	public long getCursorRegenerationInterval() {
+		return cursorRegenerationInterval;
+	}
+
+
+	/**
+	 * Gets the name of the collection that is to be tailed.
+	 *
+	 * @return
+	 */
+	public String getCollectionName() {
+		return collectionName;
+	}
+
+
+	/**
+	 * Gets the key which is in a naturally increasing order in the collection. This key will
+	 * be used for comparison while tailing the collection.
+	 *
+	 * @return
+	 */
+	public String getIncreasingKey() {
+		return increasingKey;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorDocumentListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorDocumentListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import com.mongodb.DBObject;
+
+/**
+ * The implementation of the interface acts as a listener for the capped collection being tailed.
+ * The method <i>processDocument</i> would be called for a new document found at the tail
+ * of the collection.
+ *
+ * @author Amol Nayak
+ *
+ * @since 1.1
+ *
+ */
+public interface TailingCursorDocumentListener {
+
+	/**
+	 * Invoked to notify with a new document being added to the tail of the collection
+	 *
+	 * @param doc The {@link DBObject} representing the document added to the tail of the collection
+	 *
+	 */
+	void processDocument(DBObject doc);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorHandle.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/TailingCursorHandle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import com.mongodb.DBObject;
+
+/**
+ * The handle returned on calling the tailCollection method in {@link MongoTemplate}
+ * for tailing a capped collection. The instance needs to be stored by the calling application
+ * if it desires to stop the tailing process
+ *
+ * @author Amol Nayak
+ *
+ * @since 1.1
+ *
+ */
+public interface TailingCursorHandle {
+
+	/**
+	 * The collection name on which the tail is being called
+	 * @return the name of the capped collection which is being tailed
+	 */
+	String getCollectionName();
+
+	/**
+	 * The increasing key in the collection that is being tailed
+	 * @return the name of the increasing key
+	 */
+	String getIncreasingKey();
+
+
+	/**
+	 * Tailing process happens asynchronously on calling the tailCollection method
+	 * in {@link MongoTemplate}. Invoking this method stops the tailing process.
+	 * Please note that the tailing thread may not stop immediately but no new records
+	 * will be delivered to the callback handler registered to receive the tailed {@link DBObject}s
+	 */
+	void stopTailing();
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/TailingCursorConfigTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/TailingCursorConfigTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * The test class for {@link TailingCursorConfig}
+ *
+ * @author Amol Nayak
+ *
+ * @since 1.1
+ */
+public class TailingCursorConfigTests {
+
+	@Test
+	public void withThousandMilliInterval() {
+		TailingCursorConfig config = new TailingCursorConfig()
+										.withRegenerationDelay(1000L);
+		Assert.assertEquals(1000L, config.getCursorRegenerationInterval());
+	}
+
+	@Test
+	public void withNegativeMilliInterval() {
+		try {
+			@SuppressWarnings("unused")
+			TailingCursorConfig config = new TailingCursorConfig()
+											.withRegenerationDelay(-1L);
+		} catch (IllegalArgumentException e) {
+			Assert.assertEquals("Provide a non negative value for cursor regeneration interval", e.getMessage());
+		}
+	}
+
+
+	@Test
+	public void withNonNullCollectionName() {
+		TailingCursorConfig config = new TailingCursorConfig()
+											.withCollectionName("CollectionName");
+		Assert.assertEquals("CollectionName", config.getCollectionName());
+	}
+
+
+	@Test
+	public void withNullCollection() {
+		try {
+			@SuppressWarnings("unused")
+			TailingCursorConfig config = new TailingCursorConfig()
+										.withCollectionName(null);
+		} catch (IllegalArgumentException e) {
+			Assert.assertEquals("Provide a non null non empty string for collection name", e.getMessage());
+		}
+	}
+
+	@Test
+	public void withNonNullIncreasingKey() {
+		TailingCursorConfig config = new TailingCursorConfig()
+			.withIncreasingKey("IncreasingKey");
+		Assert.assertEquals("IncreasingKey", config.getIncreasingKey());
+	}
+
+	@Test
+	public void withNullIncreasingKey() {
+		try {
+			@SuppressWarnings("unused")
+			TailingCursorConfig config = new TailingCursorConfig()
+				.withIncreasingKey(null);
+		} catch (IllegalArgumentException e) {
+			Assert.assertEquals("The increasing key should be a non null non empty string", e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
This pull request is meant for review purpose only and to demonstrate the prototype developed, and collecting opinions and views about the new feature that is planned to be added to MongoTemplate to tail a capped collection.

Some information about tailable cursors can be found here

http://www.mongodb.org/display/DOCS/Tailable+Cursors

The feature included in mongo template looks like this

``` java
TailingCursorHandle handle = template.tailCollection("SomeTestCappedCollection", "id",
      new TailingCursorDocumentListener() {
          public void processDocument(DBObject doc) {
              //process the doc here
          }
});
```

The first two parameters are the name of the capped collection to be tailed and the increasing key which forms the basis for tailing the collection.
The third parameter is an implementation of  <i>TailingCursorDocumentListener</i> which is the callback interface whose <i>processDocument</i> is invoked when a new document is found at the tail of the collection.

The handle is primarily used to let the invoking process stop the tailing that happens asynchronously.

See <code>MongoTemplateTests</code>  for some test cases written around tailable cursor.
