### PR TITLE
DATAMONGO-362 - initial support for Specification

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Join.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Join.java
@@ -1,0 +1,47 @@
+package org.springframework.data.mongodb.domain;
+
+import com.mysema.query.types.Path;
+import com.mysema.query.types.Predicate;
+
+public class Join<T> {
+
+
+	private QueryDslMongodbPredicate<T> queryDslMongodbPredicate;
+	private Path<?> ref;
+	private Path<?> target;
+	private Predicate[] predicate;
+	
+	<K> Join(Path<K> ref,
+			Path<K> target,QueryDslMongodbPredicate<T> queryDslMongodbPredicate) {
+		this.queryDslMongodbPredicate = queryDslMongodbPredicate;
+		this.ref = ref;
+		this.target = target;
+	}
+
+	
+	/**
+	 * Apply {@link Predicate} on query to filter {@link T} documents based on joined DBRef properties.  
+	 * 
+	 * @param conditions
+	 * @return
+	 */
+	public QueryDslMongodbPredicate<T> on(Predicate... conditions) {
+		predicate = conditions;
+		return this.queryDslMongodbPredicate;
+	}
+	
+	@SuppressWarnings("unchecked")
+	<K> Path<K> getRef() {
+		return (Path<K>) ref;
+	}
+	
+	@SuppressWarnings("unchecked")
+	<K> Path<K> getTarget() {
+		return (Path<K>) target;
+	}
+	
+	Predicate[] getPredicate() {
+		return predicate;
+	}
+	
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/PredicateBuilder.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/PredicateBuilder.java
@@ -1,0 +1,41 @@
+package org.springframework.data.mongodb.domain;
+
+import com.mysema.query.types.ExpressionUtils;
+import com.mysema.query.types.Predicate;
+
+public class PredicateBuilder<T> {
+	
+	private QueryDslMongodbPredicate<T> queryDslMongodbPredicate;
+	
+	/**
+	 * Apply {@link Predicate}s (if any) on query to filter on {@link T} document properties
+	 * 
+	 * @param predicate
+	 * @return
+	 */
+	public QueryDslMongodbPredicate<T> where(Predicate... predicate) {
+		queryDslMongodbPredicate = new QueryDslMongodbPredicate<T>(this);
+		queryDslMongodbPredicate.predicate = ExpressionUtils.allOf(predicate);
+		return queryDslMongodbPredicate;
+	}
+	
+	/**
+	 * Create a conjunction of the given expressions
+	 * 
+	 * @param first
+	 * @param second
+	 * @return
+	 */
+	public QueryDslMongodbPredicate<T> and(QueryDslMongodbPredicate<T> first,QueryDslMongodbPredicate<T> second) {
+		queryDslMongodbPredicate = new QueryDslMongodbPredicate<T>(this);
+		for (Join<?> join : first.joins) {
+			queryDslMongodbPredicate.join(join.getRef(), join.getTarget()).on(join.getPredicate());
+		}
+		for (Join<?> join : second.joins) {
+			queryDslMongodbPredicate.join(join.getRef(), join.getTarget()).on(join.getPredicate());
+		}
+		queryDslMongodbPredicate.predicate = ExpressionUtils.allOf(new Predicate[]{first.predicate,second.predicate});
+		return queryDslMongodbPredicate;
+	}
+	
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/QueryDslMongodbPredicate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/QueryDslMongodbPredicate.java
@@ -1,0 +1,48 @@
+package org.springframework.data.mongodb.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.DBRef;
+
+import com.mysema.query.mongodb.MongodbQuery;
+import com.mysema.query.types.Path;
+import com.mysema.query.types.Predicate;
+
+public class QueryDslMongodbPredicate<T> {
+	PredicateBuilder<T> predicateBuilder;
+	
+	QueryDslMongodbPredicate(PredicateBuilder<T> predicateBuilder) {
+		this.predicateBuilder = predicateBuilder;
+	}
+
+	Predicate predicate;
+	List<Join<?>> joins = new ArrayList<Join<?>>();
+	
+	private <K> Join<T> addJoin(Path<K> ref, Path<K> target){
+		Join<T> join = new Join<T>(ref, target,this);
+		joins.add(join);
+		return join;
+	}
+	
+	/**
+	 * Create a pathway to {@link DBRef} properties on {@link T} document
+	 * 
+	 * @param ref
+	 * @param target
+	 * @return
+	 */
+	public <K> Join<T> join(Path<K> ref, Path<K> target) {
+		return addJoin(ref, target);
+	}
+	
+	public void applyPredicate(MongodbQuery<T> mongodbQuery) {
+		for (Join<?> join : joins) {
+			mongodbQuery.join(join.getRef(), join.getTarget()).on(join.getPredicate());
+		}
+		if(predicate != null){
+			mongodbQuery.where(predicate);
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Specification.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Specification.java
@@ -1,0 +1,15 @@
+package org.springframework.data.mongodb.domain;
+
+
+
+
+public interface Specification<T> {
+	
+	/**
+	 * Build WHERE clause based on related Document.
+	 * 
+	 * @param predicateBuilder
+	 */
+	QueryDslMongodbPredicate<T> buildPredicate(PredicateBuilder<T> predicateBuilder); 
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Specifications.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/domain/Specifications.java
@@ -1,0 +1,26 @@
+package org.springframework.data.mongodb.domain;
+
+public class Specifications<T>  implements Specification<T> {
+	
+	private Specification<T> specification;
+	
+	public Specifications(Specification<T> specification) {
+		this.specification = specification;
+	}
+	
+	public static <T> Specifications<T> where(Specification<T> specification) {
+		return new Specifications<T>(specification);
+	}
+	public Specifications<T> and(final Specification<T> spec) {
+		return new Specifications<T>(new Specification<T>() {
+			public QueryDslMongodbPredicate<T> buildPredicate(PredicateBuilder<T> predicateBuilder) {
+				return predicateBuilder.and(specification.buildPredicate(predicateBuilder), spec.buildPredicate(predicateBuilder));
+			}
+		});
+	}
+
+	public QueryDslMongodbPredicate<T> buildPredicate(PredicateBuilder<T> predicateBuilder) {
+			return specification.buildPredicate(predicateBuilder);
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/QueryDslMongoSpecificationExecutor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/QueryDslMongoSpecificationExecutor.java
@@ -1,0 +1,59 @@
+package org.springframework.data.mongodb.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.domain.Specification;
+
+
+/**
+ * Interface to allow execution of {@link Specification}s based on the QueryDSL DbRef predicate.
+ * 
+ * @author Patryk Wasik
+ */
+public interface QueryDslMongoSpecificationExecutor<T> {
+
+	/**
+	 * Returns a single entity matching the given {@link Specification}.
+	 * 
+	 * @param spec
+	 * @return
+	 */
+	T findOne(Specification<T> spec);
+
+	/**
+	 * Returns all entities matching the given {@link Specification}.
+	 * 
+	 * @param spec
+	 * @return
+	 */
+	List<T> findAll(Specification<T> spec);
+
+	/**
+	 * Returns a {@link Page} of entities matching the given {@link Specification}.
+	 * 
+	 * @param spec
+	 * @param pageable
+	 * @return
+	 */
+	Page<T> findAll(Specification<T> spec, Pageable pageable);
+
+	/**
+	 * Returns all entities matching the given {@link Specification} and {@link Sort}.
+	 * 
+	 * @param spec
+	 * @param sort
+	 * @return
+	 */
+	List<T> findAll(Specification<T> spec, Sort sort);
+
+	/**
+	 * Returns the number of instances that the given {@link Specification} will return.
+	 * 
+	 * @param spec the {@link Specification} to count instances for
+	 * @return the number of instances
+	 */
+	long count(Specification<T> spec);
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Boss.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Boss.java
@@ -1,0 +1,13 @@
+package org.springframework.data.mongodb.repository;
+
+import java.math.BigInteger;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class Boss {
+
+	BigInteger id;
+	String name;
+	
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
@@ -53,6 +53,9 @@ public class Person extends Contact {
 
 	@DBRef
 	User creator;
+	
+	@DBRef
+	Boss boss;
 
 	public Person() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -37,7 +37,7 @@ import org.springframework.data.querydsl.QueryDslPredicateExecutor;
  * 
  * @author Oliver Gierke
  */
-public interface PersonRepository extends MongoRepository<Person, String>, QueryDslPredicateExecutor<Person> {
+public interface PersonRepository extends MongoRepository<Person, String>, QueryDslPredicateExecutor<Person>, QueryDslMongoSpecificationExecutor<Person> {
 
 	/**
 	 * Returns all {@link Person}s with the given lastname.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
@@ -15,6 +15,16 @@
  */
 package org.springframework.data.mongodb.repository;
 
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.mongodb.domain.PredicateBuilder;
+import org.springframework.data.mongodb.domain.QueryDslMongodbPredicate;
+import org.springframework.data.mongodb.domain.Specification;
+import org.springframework.data.mongodb.domain.Specifications;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -23,5 +33,97 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Oliver Gierke
  */
 @ContextConfiguration
-public class PersonRepositoryIntegrationTests extends AbstractPersonRepositoryIntegrationTests {
+public class PersonRepositoryIntegrationTests extends
+		AbstractPersonRepositoryIntegrationTests {
+
+	@Test
+	public void testSpecification() {
+
+		User user = new User();
+		user.username = "Patryk";
+		operations.save(user);
+
+		Boss jozef = new Boss();
+		jozef.name = "Jozef";
+		operations.save(jozef);
+
+		Boss maks = new Boss();
+		maks.name = "Maks";
+		operations.save(maks);
+
+		Person wojtek = new Person("Wojtek", "Krzaklewski", 29);
+		wojtek.creator = user;
+		wojtek.boss = jozef;
+		repository.save(wojtek);
+		
+		Person jacek = new Person("Jacek", "Mroz", 29);
+		jacek.creator = user;
+		jacek.boss = jozef;
+		repository.save(jacek);
+
+		Person michal = new Person("Michal", "Ktostam", 31);
+		michal.creator = user;
+		michal.boss = maks;
+		repository.save(michal);
+
+		Specification<Person> specCreatorPatryk = new Specification<Person>() {
+
+			public QueryDslMongodbPredicate<Person> buildPredicate(
+					PredicateBuilder<Person> predicateBuilder) {
+				return predicateBuilder.where().join(QPerson.person.creator, QUser.user)
+						.on(QUser.user.username.eq("Patryk"));
+			}
+		};
+		List<Person> findAll = repository.findAll(specCreatorPatryk);
+
+		assertThat(findAll, hasSize(3));
+		assertThat(findAll, hasItem(wojtek));
+		assertThat(findAll, hasItem(michal));
+		assertThat(findAll, hasItem(jacek));
+		
+		Specification<Person> specPersonWojtek = new Specification<Person>() {
+
+			public QueryDslMongodbPredicate<Person> buildPredicate(
+					PredicateBuilder<Person> predicateBuilder) {
+				return predicateBuilder.where(QPerson.person.firstname.eq("Wojtek"));
+			}
+		};
+		
+		findAll = repository.findAll(specPersonWojtek);
+
+		assertThat(findAll, hasSize(1));
+		assertThat(findAll, hasItem(wojtek));
+		
+		findAll = repository.findAll(Specifications.where(specCreatorPatryk).and(specPersonWojtek));
+		
+		assertThat(findAll, hasSize(1));
+		assertThat(findAll, hasItem(wojtek));
+		
+
+		Specification<Person> specBossJozef = new Specification<Person>() {
+
+			public QueryDslMongodbPredicate<Person> buildPredicate(
+					PredicateBuilder<Person> predicateBuilder) {
+				return predicateBuilder.where().join(QPerson.person.boss, QBoss.boss)
+						.on(QBoss.boss.name.eq("Jozef"));
+			}
+		};
+		findAll = repository.findAll(specBossJozef);
+		
+		assertThat(findAll, hasSize(2));
+		assertThat(findAll, hasItem(wojtek));
+		assertThat(findAll, hasItem(jacek));
+		
+		findAll = repository.findAll(Specifications.where(specCreatorPatryk).and(new Specification<Person>() {
+
+			public QueryDslMongodbPredicate<Person> buildPredicate(
+					PredicateBuilder<Person> predicateBuilder) {
+				return predicateBuilder.where().join(QPerson.person.boss, QBoss.boss).on(QBoss.boss.name.eq("Maks"));
+			}
+		}));
+		
+		assertThat(findAll, hasSize(1));
+		assertThat(findAll, hasItem(michal));
+
+	}
 }


### PR DESCRIPTION
This pull request is for initial review purpose to fix DATAMONGO-362.

Because there is a little different syntax in QueryDSL to query documents based on 'DBRef'. I adapted 'Specification' solution from Spring Data JPA to solve this.

There is currently a limitation in QueryDSL, that can be only conjunction between joins predicates.

Do you think is a good idea or is there a better way? Can we implements something else based on 'Specification' ?
