### PR TITLE
Remove password from CannotGetMongoDbConnectionException message

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
@@ -112,7 +112,7 @@ public abstract class MongoDbUtils {
 			synchronized (db) {
 				if (!db.authenticate(username, password == null ? null : password.toCharArray())) {
 					throw new CannotGetMongoDbConnectionException("Failed to authenticate to database [" + databaseName
-							+ "], username = [" + username + "], password = [" + password + "]", databaseName, credentials);
+							+ "], username = [" + username + "]", databaseName, credentials);
 				}
 			}
 		}


### PR DESCRIPTION
Since we log all uncaught exceptions to the log file it would be nice if the password was not logged at all.

Example:
org.springframework.data.mongodb.CannotGetMongoDbConnectionException: Failed to authenticate to database [myDatabase], username = [myUsername], password = [myPassword]

should just be
org.springframework.data.mongodb.CannotGetMongoDbConnectionException: Failed to authenticate to database [myDatabase], username = [myUsername]
