### PR TITLE
Fix: attempt to insert in system namespace error

### DIFF
--- a/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
+++ b/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
@@ -170,7 +170,7 @@ public class MongoChangeSetPersister implements ChangeSetPersister<Object> {
 	}
 
 	private String getCollectionNameForEntity(Class<? extends ChangeSetBacked> entityClass) {
-		return ClassUtils.getQualifiedName(entityClass);
+		return mongoTemplate.getCollectionName(entityClass);
 	}
 
 }


### PR DESCRIPTION
During entity save using the cross-store feature the module throws an exception: "nested exception is com.mongodb.MongoException: attempt to insert in system namespace '<dbname>.<full-package>.<class-name>'".
