### PR TITLE
DATAMONGO-140 - add mongo:template namespace support

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/BeanNames.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/BeanNames.java
@@ -28,4 +28,6 @@ public abstract class BeanNames {
 	static final String VALIDATING_EVENT_LISTENER = "validatingMongoEventListener";
 	static final String IS_NEW_STRATEGY_FACTORY = "isNewStrategyFactory";
 	static final String DEFAULT_CONVERTER_BEAN_NAME = "mappingConverter";
+	// TODO or mongoOperations?
+	static final String MONGO_TEMPLATE = "mongoTemplate";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoNamespaceHandler.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoNamespaceHandler.java
@@ -42,5 +42,6 @@ public class MongoNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("db-factory", new MongoDbFactoryParser());
 		registerBeanDefinitionParser("jmx", new MongoJmxParser());
 		registerBeanDefinitionParser("auditing", new MongoAuditingBeanDefinitionParser());
+		registerBeanDefinitionParser("template", new MongoTemplateParser());
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoTemplateParser.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoTemplateParser.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.config;
+
+import static org.springframework.data.config.ParsingUtils.setPropertyValue;
+import static org.springframework.data.mongodb.config.MongoParsingUtils.getWriteConcernPropertyEditorBuilder;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.data.config.BeanComponentDefinitionBuilder;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * {@link BeanDefinitionParser} to parse {@code template} elements into {@link BeanDefinition}s.
+ * 
+ * @author Martin Baumgartner
+ */
+public class MongoTemplateParser extends AbstractBeanDefinitionParser {
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+
+		String id = super.resolveId(element, definition, parserContext);
+		return StringUtils.hasText(id) ? id : BeanNames.MONGO_TEMPLATE;
+	}
+	// Supports the MongoTemplate(MongoDbFactory mongoDbFactory) and MongoTemplate(MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) Constructors
+	// TODO Are other constructors useful? ( MongoTemplate(Mongo mongo, String databaseName) and MongoTemplate(Mongo mongo, String databaseName, UserCredentials userCredentials)
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element,
+			ParserContext parserContext) {
+
+		BeanComponentDefinitionBuilder helper = new BeanComponentDefinitionBuilder(element, parserContext);
+
+		String converterRef = element.getAttribute("converter-ref");
+		String dbFactoryRef = element.getAttribute("db-factory-ref");
+
+		// Common setup
+		BeanDefinitionBuilder mongoTemplateBuilder = BeanDefinitionBuilder.genericBeanDefinition(MongoTemplate.class);
+
+		// Defaulting
+		if (StringUtils.hasText(dbFactoryRef)) {
+			mongoTemplateBuilder.addConstructorArgReference(dbFactoryRef);
+		} 
+		else {
+			mongoTemplateBuilder.addConstructorArgReference(BeanNames.DB_FACTORY);
+		}
+
+		if (StringUtils.hasText(converterRef)) {
+			mongoTemplateBuilder.addConstructorArgReference(converterRef);
+		}
+
+		setPropertyValue(mongoTemplateBuilder, element, "write-concern", "writeConcern");
+
+		BeanDefinitionBuilder writeConcernPropertyEditorBuilder = getWriteConcernPropertyEditorBuilder();
+
+		BeanComponentDefinition component = helper.getComponent(writeConcernPropertyEditorBuilder);
+		parserContext.registerBeanComponent(component);
+
+		return (AbstractBeanDefinition) helper.getComponentIdButFallback(mongoTemplateBuilder, BeanNames.MONGO_TEMPLATE)
+				.getBeanDefinition();
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -771,8 +771,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 		// Fresh instance -> initialize version property
 		if (version == null) {
-			beanWrapper.setProperty(versionProperty, 0);
-			doSave(collectionName, objectToSave, this.mongoConverter);
+			doInsert(collectionName, objectToSave, this.mongoConverter);
 		} else {
 
 			assertUpdateableIdIfNotSet(objectToSave);

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.2.xsd
@@ -280,6 +280,17 @@ The name of the Mongo object that determines what server to monitor. (by default
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
 
+		<xsd:simpleType name="converterRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
 	<xsd:simpleType name="writeConcernEnumeration">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="NONE" />
@@ -479,5 +490,56 @@ This controls if the driver is allowed to read from secondaries or slaves.  Defa
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongoconverter instance.
+					]]> 
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string"
+				use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
 </xsd:schema>

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
@@ -26,11 +26,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.authentication.UserCredentials;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoFactoryBean;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.mongodb.Mongo;
 import com.mongodb.MongoOptions;
+import com.mongodb.WriteConcern;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -67,6 +70,27 @@ public class MongoNamespaceTests {
 		assertEquals(new UserCredentials("joe", "secret"), getField(dbf, "credentials"));
 		assertEquals("database", getField(dbf, "databaseName"));
 	}
+	
+	@Test
+	public void testMongoTemplateFactory() throws Exception {
+		assertTrue(ctx.containsBean("mongoTemplate"));
+		MongoOperations operations = (MongoOperations) ctx.getBean("mongoTemplate");
+		MongoDbFactory dbf = (MongoDbFactory) getField(operations, "mongoDbFactory");
+		assertEquals("database", getField(dbf, "databaseName"));
+		MongoConverter converter = (MongoConverter) getField(operations, "mongoConverter");
+		// may improve the converter check?
+		assertNotNull(converter);
+	}
+	
+	@Test
+	public void testSecondMongoTemplateFactory() throws Exception {
+		assertTrue(ctx.containsBean("anotherMongoTemplate"));
+		MongoOperations operations = (MongoOperations) ctx.getBean("anotherMongoTemplate");
+		MongoDbFactory dbf = (MongoDbFactory) getField(operations, "mongoDbFactory");
+		assertEquals("database", getField(dbf, "databaseName"));
+		WriteConcern writeConcern = (WriteConcern) getField(operations, "writeConcern");
+		assertEquals(WriteConcern.SAFE, writeConcern);
+		}
 
 	@Test
 	@SuppressWarnings("deprecation")

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.annotation.Id;
@@ -1496,6 +1497,24 @@ public class MongoTemplateTests {
 
 		template.save(person);
 		assertThat(person.version, is(0L));
+	}
+
+	/**
+	 * @see DATAMONGO-622
+	 */
+	@Test(expected = DuplicateKeyException.class)
+	public void preventsDuplicateInsert() {
+
+		template.setWriteConcern(WriteConcern.SAFE);
+
+		PersonWithVersionPropertyOfTypeInteger person = new PersonWithVersionPropertyOfTypeInteger();
+		person.firstName = "Dave";
+
+		template.save(person);
+		assertThat(person.version, is(0));
+
+		person.version = null;
+		template.save(person);
 	}
 
 	static class MyId {

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
@@ -51,13 +51,6 @@
 
 	<bean id="readConverter" class="org.springframework.data.mongodb.core.PersonReadConverter"/>
 
-	<bean id="mongoTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">
-		<constructor-arg name="mongoDbFactory" ref="mongoDbFactory"/>
-		<constructor-arg name="mongoConverter" ref="mappingConverter"/>
-	</bean>
-	
-	<bean id="anotherMongoTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">
-		<constructor-arg name="mongoDbFactory" ref="mongoDbFactory"/>
-	</bean>
-
+	<mongo:template id="mongoTemplate" db-factory-ref="mongoDbFactory" converter-ref="mappingConverter"/>
+	<mongo:template id="anotherMongoTemplate" db-factory-ref="mongoDbFactory" write-concern="SAFE" />
 </beans>


### PR DESCRIPTION
Added namespace support for mongo:template

parameters: db-factory, converter, write-concern

what should be the prefered default bean name, mongoTemplate or mongoOperations?
