### PR TITLE
Improve performance of indexed starts-with queries.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -269,10 +269,10 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 
 		switch (type) {
 			case STARTING_WITH:
-				source = source + "*";
+				source = "^" + source;
 				break;
 			case ENDING_WITH:
-				source = "*" + source;
+				source = source + "$";
 				break;
 			case CONTAINING:
 				source = "*" + source + "*";

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -263,7 +263,7 @@ public class MongoQueryCreatorUnitTests {
 		MongoQueryCreator creator = new MongoQueryCreator(tree, getAccessor(converter, "Matt"), context);
 		Query query = creator.createQuery();
 
-		assertThat(query, is(query(where("foo").regex("Matt.*"))));
+		assertThat(query, is(query(where("foo").regex("^Matt"))));
 	}
 
 	/**
@@ -276,7 +276,7 @@ public class MongoQueryCreatorUnitTests {
 		MongoQueryCreator creator = new MongoQueryCreator(tree, getAccessor(converter, "ews"), context);
 		Query query = creator.createQuery();
 
-		assertThat(query, is(query(where("foo").regex(".*ews"))));
+		assertThat(query, is(query(where("foo").regex("ews$"))));
 	}
 
 	/**


### PR DESCRIPTION
Hi.  I was having trouble with slow starts-with queries which was due to the type of regex being used.  This commit changes MongoQueryCreator to use the ^ anchor form to allow the use of an index and that has solved my problem.  

Should I report this separately as a JIRA issue?

Thanks,

Andy Duncan
