### PR TITLE
DATAMONGO-737 - Register TransactionSynchronization holder once per Mong...

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
@@ -131,8 +131,11 @@ public abstract class MongoDbUtils {
 				holderToUse.addDB(databaseName, db);
 			}
 
-			TransactionSynchronizationManager.registerSynchronization(new MongoSynchronization(holderToUse, mongo));
-			holderToUse.setSynchronizedWithTransaction(true);
+			// synchronize holder only if not yet synchronized
+			if (!holderToUse.isSynchronizedWithTransaction()) {
+				TransactionSynchronizationManager.registerSynchronization(new MongoSynchronization(holderToUse, mongo));
+				holderToUse.setSynchronizedWithTransaction(true);
+			}
 
 			if (holderToUse != dbHolder) {
 				TransactionSynchronizationManager.bindResource(mongo, holderToUse);


### PR DESCRIPTION
Pull Request for DATAMONGO-737 fix. This change includes the fix and test cases simulating a transaction completion run against the Mongo TransactionSynchronizations registered in with the TransactionSynchronizationManager. The fix itself is straightforward: only register the TransactionSynchronization for a Mongo instance once, not for each database accessed within the transaction. Testing for this issue requires accessing more than one database within a transaction: this explains why it is not a common scenario that would have surfaced prior. 
