### PR TITLE
DATAMONGO-445 - Allow to skip uncesseary elements in NearQuery.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -566,8 +566,26 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 				mongoConverter, entityClass), near.getMetric());
 		List<GeoResult<T>> result = new ArrayList<GeoResult<T>>(results.size());
 
+		int index = 0;
+		int elementsToSkip = near.getSkip() != null ? near.getSkip() : 0;
+
 		for (Object element : results) {
-			result.add(callback.doWith((DBObject) element));
+
+			/*
+			 * As MongoDB currently (2.4.4) doesn't support the skipping of elements in near queries
+			 * we skip the elements ourselves to avoid at least the document 2 object mapping overhead.
+			 * 
+			 * @see https://jira.mongodb.org/browse/SERVER-3925
+			 */
+			if (index >= elementsToSkip) {
+				result.add(callback.doWith((DBObject) element));
+			}
+			index++;
+		}
+
+		if (elementsToSkip > 0) {
+			// as we skipped some elements we have to calculate the averageDistance ourselves:
+			return new GeoResults<T>(result, near.getMetric());
 		}
 
 		DBObject stats = (DBObject) commandResult.get("stats");

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoResults.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoResults.java
@@ -131,7 +131,7 @@ public class GeoResults<T> implements Iterable<GeoResult<T>> {
 	private static Distance calculateAverageDistance(List<? extends GeoResult<?>> results, Metric metric) {
 
 		if (results.isEmpty()) {
-			return new Distance(0, null);
+			return new Distance(0, metric);
 		}
 
 		double averageDistance = 0;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.query;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.geo.CustomMetric;
 import org.springframework.data.mongodb.core.geo.Distance;
 import org.springframework.data.mongodb.core.geo.Metric;
@@ -29,6 +30,7 @@ import com.mongodb.DBObject;
  * Builder class to build near-queries.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class NearQuery {
 
@@ -38,6 +40,7 @@ public class NearQuery {
 	private Metric metric;
 	private boolean spherical;
 	private Integer num;
+	private Integer skip;
 
 	/**
 	 * Creates a new {@link NearQuery}.
@@ -116,13 +119,36 @@ public class NearQuery {
 	}
 
 	/**
-	 * Configures the number of results to return.
+	 * Configures the maximum number of results to return.
 	 * 
 	 * @param num
 	 * @return
 	 */
 	public NearQuery num(int num) {
 		this.num = num;
+		return this;
+	}
+
+	/**
+	 * Configures the number of results to skip.
+	 * 
+	 * @param skip
+	 * @return
+	 */
+	public NearQuery skip(int skip) {
+		this.skip = skip;
+		return this;
+	}
+
+	/**
+	 * Configures the {@link Pageable} to use.
+	 * 
+	 * @param pageable
+	 * @return
+	 */
+	public NearQuery with(Pageable pageable) {
+		this.num = (pageable.getPageNumber() + 1) * pageable.getPageSize();
+		this.skip = pageable.getPageNumber() * pageable.getPageSize();
 		return this;
 	}
 
@@ -290,7 +316,16 @@ public class NearQuery {
 	 */
 	public NearQuery query(Query query) {
 		this.query = query;
+		this.skip = query.getSkip();
+		this.num = query.getLimit();
 		return this;
+	}
+
+	/**
+	 * @return the number of elements to skip.
+	 */
+	public Integer getSkip() {
+		return skip;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * Base class for {@link RepositoryQuery} implementations for Mongo.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public abstract class AbstractMongoQuery implements RepositoryQuery {
 
@@ -285,6 +286,11 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 			Distance maxDistance = accessor.getMaxDistance();
 			if (maxDistance != null) {
 				nearQuery.maxDistance(maxDistance).in(maxDistance.getMetric());
+			}
+
+			Pageable pageable = accessor.getPageable();
+			if (pageable != null) {
+				nearQuery.with(pageable);
 			}
 
 			MongoEntityMetadata<?> metadata = method.getEntityInformation();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -406,6 +406,104 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	}
 
 	/**
+	 * @see DATAMONGO-445
+	 */
+	@Test
+	public void executesGeoPageQueryForWithPageRequestForPageInBetween() {
+
+		Point farAway = new Point(-73.9, 40.7);
+		Point here = new Point(-73.99, 40.73);
+		dave.setLocation(farAway);
+		repository.save(dave);
+		oliver.setLocation(here);
+		repository.save(oliver);
+		carter.setLocation(here);
+		repository.save(carter);
+		boyd.setLocation(here);
+		repository.save(boyd);
+		leroi.setLocation(here);
+		repository.save(leroi);
+
+		GeoPage<Person> results = repository.findByLocationNear(new Point(-73.99, 40.73), new Distance(2000,
+				Metrics.KILOMETERS), new PageRequest(1, 2));
+		assertThat(results.getContent().isEmpty(), is(false));
+		assertThat(results.getNumberOfElements(), is(2));
+		assertThat(results.isFirstPage(), is(false));
+		assertThat(results.isLastPage(), is(false));
+
+		// DATAMONGO-607
+		assertThat(results.getAverageDistance().getMetric(), is((Metric) Metrics.KILOMETERS));
+		assertThat(results.getAverageDistance().getNormalizedValue(), is(0.0));
+	}
+
+	/**
+	 * @see DATAMONGO-445
+	 */
+	@Test
+	public void executesGeoPageQueryForWithPageRequestForPageAtTheEnd() {
+
+		Point point = new Point(-73.99171, 40.738868);
+		dave.setLocation(point);
+		repository.save(dave);
+		oliver.setLocation(point);
+		repository.save(oliver);
+		carter.setLocation(point);
+		repository.save(carter);
+
+		GeoPage<Person> results = repository.findByLocationNear(new Point(-73.99, 40.73), new Distance(2000,
+				Metrics.KILOMETERS), new PageRequest(1, 2));
+		assertThat(results.getContent().isEmpty(), is(false));
+		assertThat(results.getNumberOfElements(), is(1));
+		assertThat(results.isFirstPage(), is(false));
+		assertThat(results.isLastPage(), is(true));
+
+		// DATAMONGO-607
+		assertThat(results.getAverageDistance().getMetric(), is((Metric) Metrics.KILOMETERS));
+	}
+
+	/**
+	 * @see DATAMONGO-445
+	 */
+	@Test
+	public void executesGeoPageQueryForWithPageRequestForJustOneElement() {
+
+		Point point = new Point(-73.99171, 40.738868);
+		dave.setLocation(point);
+		repository.save(dave);
+
+		GeoPage<Person> results = repository.findByLocationNear(new Point(-73.99, 40.73), new Distance(2000,
+				Metrics.KILOMETERS), new PageRequest(0, 2));
+		assertThat(results.getContent().isEmpty(), is(false));
+		assertThat(results.getNumberOfElements(), is(1));
+		assertThat(results.isFirstPage(), is(true));
+		assertThat(results.isLastPage(), is(true));
+
+		// DATAMONGO-607
+		assertThat(results.getAverageDistance().getMetric(), is((Metric) Metrics.KILOMETERS));
+	}
+
+	/**
+	 * @see DATAMONGO-445
+	 */
+	@Test
+	public void executesGeoPageQueryForWithPageRequestForJustOneElementEmptyPage() {
+
+		Point point = new Point(-73.99171, 40.738868);
+		dave.setLocation(point);
+		repository.save(dave);
+
+		GeoPage<Person> results = repository.findByLocationNear(new Point(-73.99, 40.73), new Distance(2000,
+				Metrics.KILOMETERS), new PageRequest(1, 2));
+		assertThat(results.getContent().isEmpty(), is(true));
+		assertThat(results.getNumberOfElements(), is(0));
+		assertThat(results.isFirstPage(), is(false));
+		assertThat(results.isLastPage(), is(true));
+
+		// DATAMONGO-607
+		assertThat(results.getAverageDistance().getMetric(), is((Metric) Metrics.KILOMETERS));
+	}
+
+	/**
 	 * @see DATAMONGO-323
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012 the original author or authors.
+ * Copyright 2010-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.test.context.ContextConfiguration;
  * Integration test for {@link PersonRepository}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @ContextConfiguration
-public class PersonRepositoryIntegrationTests extends AbstractPersonRepositoryIntegrationTests {
-}
+public class PersonRepositoryIntegrationTests extends AbstractPersonRepositoryIntegrationTests {}


### PR DESCRIPTION
Added support for skipping elements for NearQuery in MongoTemplate. As mongodb currently (2.4.4) doesn't support he skipping of elements in geoNear-Queries we skip the unnecessary elements ourselves. We use the limit & skip information from the given query or an explicitly passed Pageable.
