### PR TITLE
DATAMONGO-749 and DATAMONGO-750

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/SimpleMongoConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/SimpleMongoConfiguration.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.authentication.UserCredentials;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.CustomConversions;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.util.StringUtils;
+
+import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
+
+/**
+ * Allows for the creation of a {@link MongoTemplate} with custom converters in Java.  If no
+ * database is provided, it will write to the database "test" that is default on MongoDB.  If the
+ * server address(es) are not provided, it will connect to the localhost on the default port.
+ * 
+ * @author Chuong Ngo
+ */
+public class SimpleMongoConfiguration extends AbstractMongoConfiguration {
+	protected String databaseName;
+	protected List<Converter<?, ?>> converters;
+	protected UserCredentials userCredentials;
+	protected Mongo mongo;
+
+	/**
+	 * Sets the database that the {@link MongoTemplate} will connect to.
+	 * 
+	 * @param databaseName -	the name of the database to connect to.
+	 */
+	public void setDatabaseName(String databaseName) {
+		this.databaseName = databaseName;
+	}
+	
+	@Override
+	protected String getDatabaseName() {
+		if(!StringUtils.hasText(databaseName)) {
+			databaseName = "test";
+		}
+		
+		return databaseName;
+	}
+
+	@Override
+	public Mongo mongo() throws Exception {
+		if(mongo == null) {
+			mongo = new MongoClient();
+		}
+		
+		return mongo;
+	}
+	
+	/**
+	 * Sets the {@link Mongo} to be used by the {@link MongoTemplate}.  This determines the servers
+	 * that will be connected to, the {@link WriteConcern}, etc...
+	 * 
+	 * @param mongo	-	the {@link Mongo} to be used.
+	 */
+	public void setMongo(Mongo mongo) {
+		this.mongo = mongo;
+	}
+	
+	@Override
+	public MongoTemplate mongoTemplate() throws Exception {
+		MappingMongoConverter converter = mappingMongoConverter();
+		converter.afterPropertiesSet();
+		return new MongoTemplate(mongoDbFactory(), converter);
+	}
+	
+	@Override
+	public CustomConversions customConversions() {
+		return new CustomConversions(getConverters());
+	}
+
+	/**
+	 * Returns the list of custom converters to be registered with the {@link MongoTemplate}.
+	 * 
+	 * @return	a list of converters to be registered with the {@link MongoTemplate}.
+	 */
+	public List<Converter<?, ?>> getConverters() {
+		if(converters == null) {
+			converters = new ArrayList<Converter<?, ?>>();
+		}
+		
+		return converters;
+	}
+	
+	/**
+	 * Adds a custom converter to the list to be registered with the {@link MongoTemplate}.
+	 * 
+	 * @param converter -	the converter to be added to the list.
+	 */
+	public void addConverter(Converter<?, ?> converter) {
+		if(converters == null) {
+			converters = new ArrayList<Converter<?, ?>>();
+		}
+		
+		if(converter != null) {
+			converters.add(converter);
+		}
+	}
+
+	/**
+	 * Sets the converters to be registered with the {@link MongoTemplate}
+	 * 
+	 * @param converters -	the list of converters to be used.
+	 */
+	public void setConverters(List<Converter<?, ?>> converters) {
+		this.converters = converters;
+	}
+
+	@Override
+	public UserCredentials getUserCredentials() {
+		return userCredentials;
+	}
+
+	/**
+	 * Sets the credentials to be used by {@link Mongo} to connect to the MongoDB servers.
+	 * 
+	 * @param userCredentials -	the credentials to be used.
+	 */
+	public void setUserCredentials(UserCredentials userCredentials) {
+		this.userCredentials = userCredentials;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -715,6 +715,18 @@ public interface MongoOperations {
 	 * @return the WriteResult which lets you access the results of the previous write.
 	 */
 	WriteResult upsert(Query query, Update update, Class<?> entityClass, String collectionName);
+	
+	/**
+	 * Performs an upsert. If no document is found that matches the query, a new document is created and inserted by
+	 * combining the query document and the update document.
+	 * 
+	 * @param query the query document that specifies the criteria used to select a record to be upserted
+	 * @param entity	the pojo to be operated on.
+	 * @param entityClass class of the pojo to be operated on
+	 * @param collectionName name of the collection to update the object in
+	 * @return the WriteResult which lets you access the results of the previous write.
+	 */
+	WriteResult upsert(Query query, Object entity, Class<?> entityClass, String collectionName);
 
 	/**
 	 * Updates the first object that is found in the collection of the entity class that matches the query document with
@@ -752,6 +764,18 @@ public interface MongoOperations {
 	 * @return the WriteResult which lets you access the results of the previous write.
 	 */
 	WriteResult updateFirst(Query query, Update update, Class<?> entityClass, String collectionName);
+	
+	/**
+	 * Updates the first object that is found in the specified collection that matches the query document criteria with
+	 * the provided updated document.
+	 * 
+	 * @param query the query document that specifies the criteria used to select a record to be updated
+	 * @param entity	the pojo to be operated on.
+	 * @param entityClass class of the pojo to be operated on.  This determines the converter to be used.
+	 * @param collectionName name of the collection to update the object in
+	 * @return the WriteResult which lets you access the results of the previous write.
+	 */
+	WriteResult updateFirst(Query query, Object entity, Class<?> entityClass, String collectionName);
 
 	/**
 	 * Updates all objects that are found in the collection for the entity class that matches the query document criteria
@@ -790,6 +814,18 @@ public interface MongoOperations {
 	 */
 	WriteResult updateMulti(final Query query, final Update update, Class<?> entityClass, String collectionName);
 
+	/**
+	 * Updates all objects that are found in the specified collection that matches the query document criteria with the
+	 * provided updated document.
+	 * 
+	 * @param query the query document that specifies the criteria used to select a record to be updated
+	 * @param entity	the pojo to be operated on
+	 * @param entityClass class of the pojo to be operated on
+	 * @param collectionName name of the collection to update the object in
+	 * @return the WriteResult which lets you access the results of the previous write.
+	 */
+	WriteResult updateMulti(Query query, Object entity, Class<?> entityClass, String collectionName);
+	
 	/**
 	 * Remove the given object from the collection by id.
 	 * 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -950,6 +950,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	public WriteResult upsert(Query query, Update update, Class<?> entityClass, String collectionName) {
 		return doUpdate(collectionName, query, update, entityClass, true, false);
 	}
+	
+	@Override
+	public WriteResult upsert(Query query, Object entity, Class<?> entityClass, String collectionName) {
+		DBObject dbDoc = new BasicDBObject();
+		this.getConverter().write(entity, dbDoc);
+		
+		Update update = Update.fromDBObject(dbDoc);
+		
+		return doUpdate(collectionName, query, update, entityClass, true, false);
+	}
 
 	public WriteResult updateFirst(Query query, Update update, Class<?> entityClass) {
 		return doUpdate(determineCollectionName(entityClass), query, update, entityClass, false, false);
@@ -962,6 +972,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	public WriteResult updateFirst(Query query, Update update, Class<?> entityClass, String collectionName) {
 		return doUpdate(collectionName, query, update, entityClass, false, false);
 	}
+	
+	@Override
+	public WriteResult updateFirst(Query query, Object entity, Class<?> entityClass,
+			String collectionName) {
+		DBObject dbDoc = new BasicDBObject();
+		this.getConverter().write(entity, dbDoc);
+		Update update = Update.fromDBObject(dbDoc);
+		
+		return doUpdate(collectionName, query, update, entityClass, false, false);
+	}
 
 	public WriteResult updateMulti(Query query, Update update, Class<?> entityClass) {
 		return doUpdate(determineCollectionName(entityClass), query, update, entityClass, false, true);
@@ -972,6 +992,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	}
 
 	public WriteResult updateMulti(final Query query, final Update update, Class<?> entityClass, String collectionName) {
+		return doUpdate(collectionName, query, update, entityClass, false, true);
+	}
+	
+	@Override
+	public WriteResult updateMulti(Query query, Object entity, Class<?> entityClass,
+			String collectionName) {
+		DBObject dbDoc = new BasicDBObject();
+		this.getConverter().write(entity, dbDoc);
+		Update update = Update.fromDBObject(dbDoc);
+		
 		return doUpdate(collectionName, query, update, entityClass, false, true);
 	}
 
@@ -2088,5 +2118,4 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 			return new GeoResult<T>(doWith, new Distance(distance, metric));
 		}
 	}
-
 }


### PR DESCRIPTION
Added 3 methods to MongoTemplate and their declarations to MongoOperations to allow the passing in an entity object along with a collection name. The methods then converts the entity object using regisitered converters.

updateMulti(Query query, Object entity, class<?> entityClass, String collectionName)
updateFirst(Query query, Object entity, class<?> entityClass, String collectionName)
upsert(Query query, Object entity, class<?> entityClass, String collectionName)

Created a new class that extends AbstractMongoConfiguration and allows for the creation of a MongoTemplate with custom converters in Java. If no Mongo is provided, a default one accessing the localhost on the default port will be used. If no database is specified, the database "test" will be used.

/src/main/java/org/springframework/data/mongodb/config/SimpleMongoConfiguration.java
