### PR TITLE
DATAMONGO-758 - Current mongodb Versions only support to explicitly excl...

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -117,23 +117,34 @@ public class ProjectionOperation extends ExposedFieldsAggregationOperationContex
 	/**
 	 * Excludes the given fields from the projection.
 	 * 
-	 * @param fields must not be {@literal null}.
+	 * @param fieldNames must not be {@literal null}.
 	 * @return
 	 */
-	public ProjectionOperation andExclude(String... fields) {
-		List<FieldProjection> excludeProjections = FieldProjection.from(Fields.fields(fields), false);
+	public ProjectionOperation andExclude(String... fieldNames) {
+
+		for (String fieldName : fieldNames) {
+			Assert
+					.isTrue(
+							Fields.UNDERSCORE_ID.equals(fieldName),
+							String
+									.format(
+											"Exclusion of field %s not allowed. Projections by the mongodb aggregation framework only support the exclusion of the %s field!",
+											fieldName, Fields.UNDERSCORE_ID));
+		}
+
+		List<FieldProjection> excludeProjections = FieldProjection.from(Fields.fields(fieldNames), false);
 		return new ProjectionOperation(this.projections, excludeProjections);
 	}
 
 	/**
 	 * Includes the given fields into the projection.
 	 * 
-	 * @param fields must not be {@literal null}.
+	 * @param fieldNames must not be {@literal null}.
 	 * @return
 	 */
-	public ProjectionOperation andInclude(String... fields) {
+	public ProjectionOperation andInclude(String... fieldNames) {
 
-		List<FieldProjection> projections = FieldProjection.from(Fields.fields(fields), true);
+		List<FieldProjection> projections = FieldProjection.from(Fields.fields(fieldNames), true);
 		return new ProjectionOperation(this.projections, projections);
 	}
 
@@ -362,6 +373,7 @@ public class ProjectionOperation extends ExposedFieldsAggregationOperationContex
 		 * A {@link FieldProjection} to map a result of a previous {@link AggregationOperation} to a new field.
 		 * 
 		 * @author Oliver Gierke
+		 * @author Thomas Darimont
 		 */
 		static class FieldProjection extends Projection {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -31,6 +31,7 @@ import com.mongodb.DBObject;
  * Unit tests for {@link ProjectionOperation}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class ProjectionOperationUnitTests {
 
@@ -181,6 +182,27 @@ public class ProjectionOperationUnitTests {
 
 		assertThat(oper.containsField(MOD), is(true));
 		assertThat(oper.get(MOD), is((Object) Arrays.<Object> asList("$a", 3)));
+	}
+
+	/**
+	 * @see DATAMONGO-758
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void excludeShouldThrowExceptionForFieldsOtherThanUnderscoreId() {
+		new ProjectionOperation().andExclude("foo");
+	}
+
+	/**
+	 * @see DATAMONGO-758
+	 */
+	@Test
+	public void andExcludeShouldSupportTheExclusionOfUnderscoreId() {
+
+		ProjectionOperation projectionOp = new ProjectionOperation().andExclude(Fields.UNDERSCORE_ID);
+		DBObject dbObject = projectionOp.toDBObject(Aggregation.DEFAULT_CONTEXT);
+		DBObject projectClause = DBObjectUtils.getAsDBObject(dbObject, PROJECT);
+
+		assertThat((Integer) projectClause.get(Fields.UNDERSCORE_ID), is(0));
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
...ude the _id property in a projection.

Added guard to FieldProjection.from within ProjectionOption to prevent users from excluding fields other than "_id".
