### PR TITLE
Add support for geospatial 2Dsphere and geohaystack index types

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeoSpatialIndexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeoSpatialIndexed.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * Mark a field to be indexed using MongoDB's geospatial indexing feature.
  * 
  * @author Jon Brisbin <jbrisbin@vmware.com>
+ * @author Laurent Canet
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -64,5 +65,26 @@ public @interface GeoSpatialIndexed {
 	 * @return
 	 */
 	int bits() default 26;
+
+	/**
+	 * The type of the geospatial index. Default is {@link GeospatialIndexType#GEO_2D}
+	 * 
+	 * @return
+	 */
+	GeospatialIndexType type() default GeospatialIndexType.GEO_2D;
+
+	/**
+	 * The bucket size for {@link GeospatialIndexType#GEO_HAYSTACK} indexes, in coordinate units.
+	 * 
+	 * @return
+	 */
+	double bucketSize() default 1.0;
+
+	/**
+	 * The name of the additional field to use for {@link GeospatialIndexType#GEO_HAYSTACK} indexes
+	 * 
+	 * @return
+	 */
+	String additionalField() default "";
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeospatialIndexType.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeospatialIndexType.java
@@ -1,0 +1,24 @@
+package org.springframework.data.mongodb.core.index;
+
+/**
+ * Geoposatial index type
+ * @author Laurent Canet
+ *
+ */
+public enum GeospatialIndexType {
+
+	/**
+	 * Simple 2-Dimensional index for legacy-format points
+	 */
+	GEO_2D,
+	
+	/**
+	 * 2D Index for GeoJSON-formatted data over a sphere. Only available in Mongo 2.4
+	 */
+	GEO_2DSPHERE,
+	
+	/**
+	 * An haystack index for grouping results over small results
+	 */
+	GEO_HAYSTACK
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexCreator.java
@@ -157,6 +157,8 @@ public class MongoPersistentEntityIndexCreator implements
 						GeospatialIndex indexObject = new GeospatialIndex(persistentProperty.getFieldName());
 						indexObject.withMin(index.min()).withMax(index.max());
 						indexObject.named(StringUtils.hasText(index.name()) ? index.name() : field.getName());
+						indexObject.typed(index.type()).withBucketSize(index.bucketSize())
+								.withAdditionalField(index.additionalField());
 
 						String collection = StringUtils.hasText(index.collection()) ? index.collection() : entity.getCollection();
 						mongoDbFactory.getDb().getCollection(collection)

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatialIndexTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatialIndexTests.java
@@ -1,0 +1,138 @@
+package org.springframework.data.mongodb.core.geo;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.CollectionCallback;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.WriteResultChecking;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
+import org.springframework.data.mongodb.core.index.GeospatialIndexType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+import com.mongodb.WriteConcern;
+
+/**
+ * Tests spatial index creation
+ * 
+ * @author Laurent Canet
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class })
+@ContextConfiguration(classes = { GeoSpatialAppConfig.class })
+public class GeoSpatialIndexTests {
+
+	@Autowired private MongoTemplate template;
+
+	@Before
+	public void setUp() throws Exception {
+		template.setWriteConcern(WriteConcern.FSYNC_SAFE);
+		template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
+	}
+
+	static class GeoSpatialEntity2D {
+		public String id;
+		@GeoSpatialIndexed(type = GeospatialIndexType.GEO_2D) public Point location;
+
+		public GeoSpatialEntity2D(double x, double y) {
+			this.location = new Point(x, y);
+		}
+	}
+
+	static class GeoSpatialEntityHaystack {
+		public String id;
+		public String name;
+		@GeoSpatialIndexed(type = GeospatialIndexType.GEO_HAYSTACK, additionalField = "name") public Point location;
+
+		public GeoSpatialEntityHaystack(double x, double y, String name) {
+			this.location = new Point(x, y);
+			this.name = name;
+		}
+	}
+
+	static class GeoJsonPoint {
+		String type = "Point";
+		double coordinates[];
+	}
+
+	static class GeoSpatialEntity2DSphere {
+		public String id;
+		@GeoSpatialIndexed(type = GeospatialIndexType.GEO_2DSPHERE) public GeoJsonPoint location;
+
+		public GeoSpatialEntity2DSphere(double x, double y) {
+			this.location = new GeoJsonPoint();
+			this.location.coordinates = new double[] { x, y };
+		}
+	}
+
+	@Test
+	public void test2dIndex() {
+		try {
+			template.save(new GeoSpatialEntity2D(45.2, 4.6));
+			assertThat(hasIndexOfType(GeoSpatialEntity2D.class, "2d"), is(true));
+		} finally {
+			template.dropCollection(GeoSpatialEntity2D.class);
+		}
+	}
+
+	@Test
+	public void test2dSphereIndex() {
+		try {
+			template.save(new GeoSpatialEntity2DSphere(45.2, 4.6));
+			assertThat(hasIndexOfType(GeoSpatialEntity2DSphere.class, "2dsphere"), is(true));
+		} finally {
+			template.dropCollection(GeoSpatialEntity2DSphere.class);
+		}
+	}
+
+	@Test
+	public void testHaystackIndex() {
+		try {
+			template.save(new GeoSpatialEntityHaystack(45.2, 4.6, "Paris"));
+			assertThat(hasIndexOfType(GeoSpatialEntityHaystack.class, "geoHaystack"), is(true));
+		} finally {
+			template.dropCollection(GeoSpatialEntityHaystack.class);
+		}
+	}
+
+	/**
+	 * Returns whether an index with the given name exists for the given entity type.
+	 * 
+	 * @param indexName
+	 * @param entityType
+	 * @return
+	 */
+	private boolean hasIndexOfType(Class<?> entityType, final String type) {
+
+		return template.execute(entityType, new CollectionCallback<Boolean>() {
+			@SuppressWarnings("unchecked")
+			public Boolean doInCollection(DBCollection collection) throws MongoException, DataAccessException {
+				for (DBObject indexInfo : collection.getIndexInfo()) {
+					DBObject keys = (DBObject) indexInfo.get("key");
+					Map<String, Object> keysMap = keys.toMap();
+					for (String key : keysMap.keySet()) {
+						Object indexType = keys.get(key);
+						if (type.equals(indexType)) {
+							return true;
+						}
+					}
+				}
+				return false;
+			}
+		});
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/IndexTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/IndexTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.index.GeospatialIndex;
+import org.springframework.data.mongodb.core.index.GeospatialIndexType;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.Index.Duplicates;
 
@@ -67,6 +68,21 @@ public class IndexTests {
 		GeospatialIndex i = new GeospatialIndex("location").withMin(0);
 		assertEquals("{ \"location\" : \"2d\"}", i.getIndexKeys().toString());
 		assertEquals("{ \"min\" : 0}", i.getIndexOptions().toString());
+	}
+
+	@Test
+	public void testGeospatialIndex2DSphere() {
+		GeospatialIndex i = new GeospatialIndex("location").typed(GeospatialIndexType.GEO_2DSPHERE);
+		assertEquals("{ \"location\" : \"2dsphere\"}", i.getIndexKeys().toString());
+		assertEquals("{ }", i.getIndexOptions().toString());
+	}
+
+	@Test
+	public void testGeospatialIndexGeoHaystack() {
+		GeospatialIndex i = new GeospatialIndex("location").typed(GeospatialIndexType.GEO_HAYSTACK)
+				.withAdditionalField("name").withBucketSize(40);
+		assertEquals("{ \"location\" : \"geoHaystack\" , \"name\" : 1}", i.getIndexKeys().toString());
+		assertEquals("{ \"bucketSize\" : 40.0}", i.getIndexOptions().toString());
 	}
 
 	@Test


### PR DESCRIPTION
This patch add support for creating 2dsphere and geoHaystack indexes using the @GeospatialIndexed annotation on fields
