### PR TITLE
DATAMONGO-764 - Added SSL support to Mongo configuration options.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.w3c.dom.Element;
  * 
  * @author Mark Pollack
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 abstract class MongoParsingUtils {
 
@@ -79,6 +80,8 @@ abstract class MongoParsingUtils {
 		setPropertyValue(optionsDefBuilder, optionsElement, "write-timeout", "writeTimeout");
 		setPropertyValue(optionsDefBuilder, optionsElement, "write-fsync", "writeFsync");
 		setPropertyValue(optionsDefBuilder, optionsElement, "slave-ok", "slaveOk");
+		setPropertyValue(optionsDefBuilder, optionsElement, "ssl", "ssl");
+		setPropertyReference(optionsDefBuilder, optionsElement, "ssl-socket-factory-ref", "sslSocketFactory");
 
 		mongoBuilder.addPropertyValue("mongoOptions", optionsDefBuilder.getBeanDefinition());
 		return true;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,129 +15,146 @@
  */
 package org.springframework.data.mongodb.core;
 
-import com.mongodb.MongoOptions;
+import javax.net.ssl.SSLSocketFactory;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 
+import com.mongodb.MongoOptions;
+
 /**
- * A factory bean for construction of a MongoOptions instance
+ * A factory bean for construction of a {@link MongoOptions} instance.
  * 
  * @author Graeme Rocher
- * @Author Mark Pollack
+ * @author Mark Pollack
+ * @author Mike Saavedra
+ * @author Thomas Darimont
  */
 public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, InitializingBean {
 
-	private static final MongoOptions MONGO_OPTIONS = new MongoOptions();
+	private final MongoOptions MONGO_OPTIONS = new MongoOptions();
+
 	/**
-	 * number of connections allowed per host will block if run out
+	 * The number of connections allowed per host will block if run out.
 	 */
 	private int connectionsPerHost = MONGO_OPTIONS.connectionsPerHost;
 
 	/**
-	 * multiplier for connectionsPerHost for # of threads that can block if connectionsPerHost is 10, and
-	 * threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an exception will
-	 * be throw
+	 * A multiplier for connectionsPerHost for # of threads that can block a connection.
+	 * <p>
+	 * If connectionsPerHost is {@literal 10}, and threadsAllowedToBlockForConnectionMultiplier is {@literal 5}, then
+	 * {@literal 50} threads can block. If more threads try to block an exception will be thrown.
 	 */
 	private int threadsAllowedToBlockForConnectionMultiplier = MONGO_OPTIONS.threadsAllowedToBlockForConnectionMultiplier;
 
 	/**
-	 * max wait time of a blocking thread for a connection
+	 * Max wait time of a blocking thread for a connection.
 	 */
 	private int maxWaitTime = MONGO_OPTIONS.maxWaitTime;
 
 	/**
-	 * connect timeout in milliseconds. 0 is default and infinite
+	 * Connect timeout in milliseconds. {@literal 0} is default and means infinite time.
 	 */
 	private int connectTimeout = MONGO_OPTIONS.connectTimeout;
 
 	/**
-	 * socket timeout. 0 is default and infinite
+	 * The socket timeout. {@literal 0} is default and means infinite time.
 	 */
 	private int socketTimeout = MONGO_OPTIONS.socketTimeout;
 
 	/**
-	 * This controls whether or not to have socket keep alive turned on (SO_KEEPALIVE).
-	 * 
-	 * defaults to false
+	 * This controls whether or not to have socket keep alive turned on (SO_KEEPALIVE). This defaults to {@literal false}.
 	 */
 	public boolean socketKeepAlive = MONGO_OPTIONS.socketKeepAlive;
 
 	/**
-	 * this controls whether or not on a connect, the system retries automatically
+	 * This controls whether or not the system retries automatically on a failed connect. This defaults to
+	 * {@literal false}.
 	 */
 	private boolean autoConnectRetry = MONGO_OPTIONS.autoConnectRetry;
 
 	private long maxAutoConnectRetryTime = MONGO_OPTIONS.maxAutoConnectRetryTime;
 
 	/**
-	 * This specifies the number of servers to wait for on the write operation, and exception raising behavior.
-	 * 
-	 * Defaults to 0.
+	 * This specifies the number of servers to wait for on the write operation, and exception raising behavior. This
+	 * defaults to {@literal 0}.
 	 */
 	private int writeNumber;
 
 	/**
-	 * This controls timeout for write operations in milliseconds.
-	 * 
-	 * Defaults to 0 (indefinite). Greater than zero is number of milliseconds to wait.
+	 * This controls timeout for write operations in milliseconds. This defaults to {@literal 0} (indefinite). Greater
+	 * than zero is number of milliseconds to wait.
 	 */
 	private int writeTimeout;
 
 	/**
-	 * This controls whether or not to fsync.
-	 * 
-	 * Defaults to false.
+	 * This controls whether or not to fsync. This defaults to {@literal false}.
 	 */
 	private boolean writeFsync;
 
 	/**
-	 * Specifies if the driver is allowed to read from secondaries or slaves.
-	 * 
-	 * Defaults to false
+	 * Specifies if the driver is allowed to read from secondaries or slaves. This defaults to {@literal false}.
 	 */
-	@SuppressWarnings("deprecation")
-	private boolean slaveOk = MONGO_OPTIONS.slaveOk;
+	@SuppressWarnings("deprecation") private boolean slaveOk = MONGO_OPTIONS.slaveOk;
 
 	/**
-	 * number of connections allowed per host will block if run out
+	 * This controls SSL support via SSLSocketFactory. This defaults to {@literal false}.
+	 */
+	private boolean ssl;
+
+	/**
+	 * Specifies the {@link SSLSocketFactory} to use. This defaults to {@link SSLSocketFactory#getDefault()}
+	 */
+	private SSLSocketFactory sslSocketFactory;
+
+	/**
+	 * The maximum number of connections allowed per host until we will block.
+	 * 
+	 * @param connectionsPerHost
 	 */
 	public void setConnectionsPerHost(int connectionsPerHost) {
 		this.connectionsPerHost = connectionsPerHost;
 	}
 
 	/**
-	 * multiplier for connectionsPerHost for # of threads that can block if connectionsPerHost is 10, and
-	 * threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an exception will
-	 * be throw
+	 * A multiplier for connectionsPerHost for # of threads that can block a connection.
+	 * 
+	 * @see #threadsAllowedToBlockForConnectionMultiplier
+	 * @param threadsAllowedToBlockForConnectionMultiplier
 	 */
 	public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
 		this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
 	}
 
 	/**
-	 * max wait time of a blocking thread for a connection
+	 * Max wait time of a blocking thread for a connection.
+	 * 
+	 * @param maxWaitTime
 	 */
 	public void setMaxWaitTime(int maxWaitTime) {
 		this.maxWaitTime = maxWaitTime;
 	}
 
 	/**
-	 * connect timeout in milliseconds. 0 is default and infinite
+	 * The connect timeout in milliseconds. {@literal 0} is default and infinite
+	 * 
+	 * @param connectTimeout
 	 */
 	public void setConnectTimeout(int connectTimeout) {
 		this.connectTimeout = connectTimeout;
 	}
 
 	/**
-	 * socket timeout. 0 is default and infinite
+	 * The socket timeout. {@literal 0} is default and infinite.
+	 * 
+	 * @param socketTimeout
 	 */
 	public void setSocketTimeout(int socketTimeout) {
 		this.socketTimeout = socketTimeout;
 	}
 
 	/**
-	 * This controls whether or not to have socket keep alive
+	 * This controls whether or not to have socket keep alive.
 	 * 
 	 * @param socketKeepAlive
 	 */
@@ -147,12 +164,12 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 
 	/**
 	 * This specifies the number of servers to wait for on the write operation, and exception raising behavior. The 'w'
-	 * option to the getlasterror command. Defaults to 0.
+	 * option to the getlasterror command. Defaults to {@literal 0}.
 	 * <ul>
-	 * <li>-1 = don't even report network errors</li>
-	 * <li>0 = default, don't call getLastError by default</li>
-	 * <li>1 = basic, call getLastError, but don't wait for slaves</li>
-	 * <li>2+= wait for slaves</li>
+	 * <li>{@literal -1} = don't even report network errors</li>
+	 * <li>{@literal 0} = default, don't call getLastError by default</li>
+	 * <li>{@literal 1} = basic, call getLastError, but don't wait for slaves</li>
+	 * <li>{@literal 2} += wait for slaves</li>
 	 * </ul>
 	 * 
 	 * @param writeNumber the number of servers to wait for on the write operation, and exception raising behavior.
@@ -164,31 +181,33 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 	/**
 	 * This controls timeout for write operations in milliseconds. The 'wtimeout' option to the getlasterror command.
 	 * 
-	 * @param writeTimeout Defaults to 0 (indefinite). Greater than zero is number of milliseconds to wait.
+	 * @param writeTimeout Defaults to {@literal 0} (indefinite). Greater than zero is number of milliseconds to wait.
 	 */
 	public void setWriteTimeout(int writeTimeout) {
 		this.writeTimeout = writeTimeout;
 	}
 
 	/**
-	 * This controls whether or not to fsync. The 'fsync' option to the getlasterror command. Defaults to false.
+	 * This controls whether or not to fsync. The 'fsync' option to the getlasterror command. Defaults to {@literal false}
 	 * 
-	 * @param writeFsync to fsync on write (true), otherwise false.
+	 * @param writeFsync to fsync on <code>write (true)<code>, otherwise {@literal false}.
 	 */
 	public void setWriteFsync(boolean writeFsync) {
 		this.writeFsync = writeFsync;
 	}
 
 	/**
-	 * this controls whether or not on a connect, the system retries automatically
+	 * Controls whether or not the system retries automatically, on a failed connect.
+	 * 
+	 * @param autoConnectRetry
 	 */
 	public void setAutoConnectRetry(boolean autoConnectRetry) {
 		this.autoConnectRetry = autoConnectRetry;
 	}
 
 	/**
-	 * The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0,
-	 * which means to use the default 15s if autoConnectRetry is on.
+	 * The maximum amount of time in millisecons to spend retrying to open connection to the same server. This defaults to
+	 * {@literal 0}, which means to use the default {@literal 15s} if {@link #autoConnectRetry} is on.
 	 * 
 	 * @param maxAutoConnectRetryTime the maxAutoConnectRetryTime to set
 	 */
@@ -197,7 +216,7 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 	}
 
 	/**
-	 * Specifies if the driver is allowed to read from secondaries or slaves. Defaults to false.
+	 * Specifies if the driver is allowed to read from secondaries or slaves. This defaults to {@literal false}.
 	 * 
 	 * @param slaveOk true if the driver should read from secondaries or slaves.
 	 */
@@ -205,8 +224,29 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 		this.slaveOk = slaveOk;
 	}
 
+	/**
+	 * Specifies if the driver should use an SSL connection to Mongo. This defaults to {@literal false}.
+	 * 
+	 * @param ssl true if the driver should use an SSL connection.
+	 */
+	public void setSsl(boolean ssl) {
+		this.ssl = ssl;
+	}
+
+	/**
+	 * Specifies the SSLSocketFactory to use for creating SSL connections to Mongo.
+	 * 
+	 * @param sslSocketFactory the sslSocketFactory to use.
+	 */
+	public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+
+		setSsl(sslSocketFactory != null);
+		this.sslSocketFactory = sslSocketFactory;
+	}
+
 	@SuppressWarnings("deprecation")
 	public void afterPropertiesSet() {
+
 		MONGO_OPTIONS.connectionsPerHost = connectionsPerHost;
 		MONGO_OPTIONS.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
 		MONGO_OPTIONS.maxWaitTime = maxWaitTime;
@@ -219,6 +259,9 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 		MONGO_OPTIONS.w = writeNumber;
 		MONGO_OPTIONS.wtimeout = writeTimeout;
 		MONGO_OPTIONS.fsync = writeFsync;
+		if (ssl) {
+			MONGO_OPTIONS.setSocketFactory(sslSocketFactory != null ? sslSocketFactory : SSLSocketFactory.getDefault());
+		}
 	}
 
 	public MongoOptions getObject() {
@@ -232,5 +275,4 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 	public boolean isSingleton() {
 		return true;
 	}
-
 }

--- a/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd=org/sprin
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.1.xsd=org/springframework/data/mongodb/config/spring-mongo-1.1.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.2.xsd=org/springframework/data/mongodb/config/spring-mongo-1.2.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.3.xsd=org/springframework/data/mongodb/config/spring-mongo-1.3.xsd
-http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.3.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo-1.4.xsd=org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.4.xsd

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
@@ -1,0 +1,626 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="http://www.springframework.org/schema/data/mongo"
+						xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+						xmlns:beans="http://www.springframework.org/schema/beans"
+						xmlns:tool="http://www.springframework.org/schema/tool"
+						xmlns:context="http://www.springframework.org/schema/context"
+						xmlns:repository="http://www.springframework.org/schema/data/repository"
+						targetNamespace="http://www.springframework.org/schema/data/mongo"
+						elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/context" />
+	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
+				schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+
+	<xsd:element name="mongo" type="mongoType">
+		<xsd:annotation>
+			<xsd:documentation source="org.springframework.data.mongodb.core.core.MongoFactoryBean"><![CDATA[
+Defines a Mongo instance used for accessing MongoDB'.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.mongodb.Mongo"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="db-factory">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongo instance. If not configured a default com.mongodb.Mongo instance will be created.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="dbname" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the database to connect to. Default is 'db'.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The port to connect to MongoDB server.  Default is 27017
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The username to use when connecting to a MongoDB server.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The password to use when connecting to a MongoDB server.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="uri" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The Mongo URI string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="mongo-repository-attributes">
+		<xsd:attribute name="mongo-template-ref" type="mongoTemplateRef" default="mongoTemplate">
+			<xsd:annotation>
+				<xsd:documentation>
+					The reference to a MongoTemplate. Will default to 'mongoTemplate'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="create-query-indexes" type="xsd:boolean" default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Enables creation of indexes for queries that get derived from the method name
+					and thus reference domain class properties. Defaults to false.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:element name="repositories">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="repository:repositories">
+					<xsd:attributeGroup ref="mongo-repository-attributes"/>
+					<xsd:attributeGroup ref="repository:repository-attributes"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mapping-converter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[Defines a MongoConverter for getting rich mapping functionality.]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:exports type="org.springframework.data.mongodb.core.convert.MappingMongoConverter" />
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="custom-converters" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+        Top-level element that contains one or more custom converters to be used for mapping
+        domain objects to and from Mongo's DBObject]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="converter" type="customConverterType" minOccurs="0" maxOccurs="unbounded"/>
+						</xsd:sequence>
+						<xsd:attribute name="base-package" type="xsd:string" />
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MappingMongoConverter instance (by default "mappingConverter").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="base-package" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The base package in which to scan for entities annotated with @Document
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="type-mapper-ref" type="typeMapperRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a MongoTypeMapper to be used by this MappingMongoConverter.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mapping.model.MappingContext">
+						The reference to a MappingContext. Will default to 'mappingContext'.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="disable-validation" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener">
+						Disables JSR-303 validation on MongoDB documents before they are saved. By default it is set to false.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="abbreviate-field-names" use="optional" default="false">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.CamelCaseAbbreviatingFieldNamingStrategy">
+						Enables abbreviating the field names for domain class properties to the
+						first character of their camel case names, e.g. fooBar -> fb.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="jmx">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a JMX Model MBeans for monitoring a MongoDB server'.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the Mongo object that determines what server to monitor. (by default "mongo").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="auditing">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.data.mongodb.core.mapping.event.AuditingEventListener" />
+					<tool:exports type="org.springframework.data.auditing.IsNewAwareAuditingHandler" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="repository:auditing-attributes" />
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="typeMapperRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoTypeMapper"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mappingContextRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mapping.model.MappingContext"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoTemplateRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.core.MongoTemplate"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.core.MongoFactoryBean"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="sslSocketFactoryRef">
+	<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="javax.net.ssl.SSLSocketFactory"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="writeConcernEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="NONE" />
+			<xsd:enumeration value="NORMAL" />
+			<xsd:enumeration value="SAFE" />
+			<xsd:enumeration value="FSYNC_SAFE" />
+			<xsd:enumeration value="REPLICAS_SAFE" />
+			<xsd:enumeration value="JOURNAL_SAFE" />
+			<xsd:enumeration value="MAJORITY" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--  MLP
+	<xsd:attributeGroup name="writeConcern">
+		<xsd:attribute name="write-concern">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="NONE" />
+					<xsd:enumeration value="NORMAL" />
+					<xsd:enumeration value="SAFE" />
+					<xsd:enumeration value="FSYNC_SAFE" />
+					<xsd:enumeration value="REPLICA_SAFE" />
+					<xsd:enumeration value="JOURNAL_SAFE" />
+					<xsd:enumeration value="MAJORITY" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	-->
+	<xsd:complexType name="mongoType">
+		<xsd:sequence minOccurs="0" maxOccurs="1">
+			<xsd:element name="options" type="optionsType">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The Mongo driver options
+							]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation>
+							<tool:exports type="com.mongodb.MongoOptions"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>		
+		<!-- MLP 
+		<xsd:attributeGroup ref="writeConcern" />
+		-->
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongo").]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="port" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The port to connect to MongoDB server.  Default is 27017
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="host" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replica-set" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of host:port entries to use for replica set/pairs.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>				
+	</xsd:complexType>
+
+	<xsd:complexType name="optionsType">
+		<xsd:attribute name="connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="threads-allowed-to-block-for-connection-multiplier" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
+then 50 threads can block more than that and an exception will be thrown.			
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-wait-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout in milliseconds. 0 is default and infinite.	
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout.  0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-keep-alive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>		
+		<xsd:attribute name="auto-connect-retry" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls whether or not on a connect, the system retries automatically.  Default is false. 
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-number" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This specifies the number of servers to wait for on the write operation, and exception raising behavior.  The 'w' option to the getlasterror command.  Defaults to 0.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls timeout for write operations in milliseconds.  The 'wtimeout' option to the getlasterror command.  Defaults to 0 (indefinite).  Greater than zero is number of milliseconds to wait.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-fsync" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>						
+		<xsd:attribute name="slave-ok" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>				
+		<xsd:attribute name="ssl" type="xsd:boolean">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver should us an SSL connection.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:group name="beanElementGroup">
+		<xsd:choice>
+			<xsd:element ref="beans:bean"/>
+			<xsd:element ref="beans:ref"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:complexType name="customConverterType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+  Element defining a custom converterr.
+      ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="beanElementGroup" minOccurs="0" maxOccurs="1"/>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					A reference to a custom converter.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref"/>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:simpleType name="converterRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongoconverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string"
+				use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="gridFsTemplate">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongoconverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBeanUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBeanUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,20 @@
  */
 package org.springframework.data.mongodb.core;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import javax.net.ssl.SSLSocketFactory;
+
 import org.junit.Test;
 
 import com.mongodb.MongoOptions;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link MongoOptionsFactoryBean}.
  * 
  * @author Oliver Gierke
+ * @author Mike Saavedra
  */
 public class MongoOptionsFactoryBeanUnitTests {
 
@@ -40,5 +44,20 @@ public class MongoOptionsFactoryBeanUnitTests {
 
 		MongoOptions options = bean.getObject();
 		assertThat(options.maxAutoConnectRetryTime, is(27L));
+	}
+
+	/**
+	 * @see DATAMONGO-764
+	 */
+	@Test
+	public void testSslConnection() {
+
+		MongoOptionsFactoryBean bean = new MongoOptionsFactoryBean();
+		bean.setSsl(true);
+		bean.afterPropertiesSet();
+
+		MongoOptions options = bean.getObject();
+		assertNotNull(options.getSocketFactory());
+		assertTrue(options.getSocketFactory() instanceof SSLSocketFactory);
 	}
 }

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-			 xmlns:context="http://www.springframework.org/schema/context"
-			 xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
-			 http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-			 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder
 			location="classpath:/org/springframework/data/mongodb/config/mongo.properties"/>
 
-	<mongo:mongo host="${mongo.host}" port="${mongo.port}">
+	<mongo:mongo id="mongo" host="${mongo.host}" port="${mongo.port}">
 			<mongo:options
 					connections-per-host="${mongo.connectionsPerHost}"
 					threads-allowed-to-block-for-connection-multiplier="${mongo.threadsAllowedToBlockForConnectionMultiplier}"
@@ -37,6 +39,17 @@
 					  password="secret"/>
 
 	<mongo:mongo id="defaultMongo" host="localhost" port="27017"/>
+	
+	<mongo:mongo id="mongoSsl" host="localhost" port="27017">
+		<mongo:options ssl="true"/>
+	</mongo:mongo>
+	
+	<mongo:mongo id="mongoSslWithCustomSslFactory" host="localhost" port="27017">
+		<!-- setting a non-null ssl-socket-factory implicitly sets ssl=true -->
+		<mongo:options ssl-socket-factory-ref="customSslSocketFactory"/>
+	</mongo:mongo>
+
+	<bean id="customSslSocketFactory" class="javax.net.ssl.SSLSocketFactory" factory-method="getDefault" scope="singleton"/>
 
 	<mongo:mongo id="noAttrMongo"/>
 

--- a/spring-data-mongodb/template.mf
+++ b/spring-data-mongodb/template.mf
@@ -13,6 +13,7 @@ Import-Template:
  javax.annotation.processing.*;version="0",
  javax.enterprise.*;version="${cdi:[=.=.=,+1.0.0)}";resolution:=optional,
  javax.tools.*;version="0",
+ javax.net.*;version="0",
  javax.validation.*;version="${validation:[=.=.=.=,+1.0.0)}";resolution:=optional,
  org.aopalliance.*;version="[1.0.0, 2.0.0)";resolution:=optional,
  org.bson.*;version="0",


### PR DESCRIPTION
Added support for allowing Mongo clients to use secure SSL connections by introducing the "ssl" property in MongoOptionsFactoryBean that will enable the use of the configured SSLSocketFactory to create SSLSockets. If no custom SSLSocketFactory is configured SSLSocketFactory#getDefault() will be used. We introduce this configuration in a new version of spring-mongo-1.4.xsd.

Applied Mike Saavedra's patch with the above mentioned extensions.

Original Pull Request #75.
