### PR TITLE
DATAMONGO-780 - Add support for nested repositories.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/config/EnableMongoRepositories.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/config/EnableMongoRepositories.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
  * {@link #basePackages()} or {@link #basePackageClasses()} it will trigger scanning of the package of annotated class.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -119,4 +120,10 @@ public @interface EnableMongoRepositories {
 	 * @return
 	 */
 	boolean createIndexesForQueryMethods() default false;
+
+	/**
+	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the
+	 * repositories infrastructure.
+	 */
+	boolean considerNestedRepositories() default false;
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ClassWithNestedRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ClassWithNestedRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository;
+
+/**
+ * @see DATAMONGO-780
+ * @author Thomas Darimont
+ */
+public class ClassWithNestedRepository {
+
+	public static interface NestedUserRepository extends MongoRepository<User, Integer> {}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/config/AllowNestedMongoRepositoriesRepositoryConfigTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/config/AllowNestedMongoRepositoriesRepositoryConfigTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.repository.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for repository namespace configuration with nested repositories.
+ * 
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "AllowNestedMongoRepositoriesRepositoryConfigTests-context.xml")
+public class AllowNestedMongoRepositoriesRepositoryConfigTests {
+
+	@Autowired NestedUserRepository fooRepository;
+
+	/**
+	 * @see DATAMONGO-780
+	 */
+	@Test
+	public void shouldFindNestedRepository() {
+		assertThat(fooRepository, is(notNullValue()));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/config/NestedMongoRepositoriesJavaConfigTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/config/NestedMongoRepositoriesJavaConfigTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.mongodb.repository.ClassWithNestedRepository.NestedUserRepository;
+import org.springframework.data.mongodb.repository.PersonRepository;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for the combination of JavaConfig and an {@link Repositories} wrapper.
+ * 
+ * @author Thomas Darimont
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class NestedMongoRepositoriesJavaConfigTests {
+
+	@Configuration
+	@EnableMongoRepositories(basePackageClasses = PersonRepository.class, considerNestedRepositories = true)
+	@ImportResource("classpath:infrastructure.xml")
+	static class Config {}
+
+	@Autowired NestedUserRepository nestedUserRepository;
+
+	/**
+	 * @see DATAMONGO-780
+	 */
+	@Test
+	public void shouldSupportNestedRepositories() {
+		assertThat(nestedUserRepository, is(notNullValue()));
+	}
+}

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/config/AllowNestedMongoRepositoriesRepositoryConfigTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/config/AllowNestedMongoRepositoriesRepositoryConfigTests-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:repository="http://www.springframework.org/schema/data/repository"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	
+	<import resource="classpath:infrastructure.xml"/>
+	
+	<mongo:repositories base-package="org.springframework.data.mongodb.repository" consider-nested-repositories="true"/>
+</beans>


### PR DESCRIPTION
Support for considering nested repository interfaces can now be configured on the EnableMongoRepositories annotation via the considerNestedRepositories property. Previously nested repository definitions were ignored by the repositories infrastructure.

This depends on DATACMNS-90.
