### PR TITLE
DATAMONGO-789 - Support login via different (e.g. admin) authentication ...

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoConfiguration.java
@@ -49,6 +49,7 @@ import com.mongodb.Mongo;
  * 
  * @author Mark Pollack
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @Configuration
 public abstract class AbstractMongoConfiguration {
@@ -59,6 +60,15 @@ public abstract class AbstractMongoConfiguration {
 	 * @return must not be {@literal null}.
 	 */
 	protected abstract String getDatabaseName();
+
+	/**
+	 * Return the name of the authentication database to use.
+	 * 
+	 * @return must not be {@literal null}.
+	 */
+	protected String getAuthenticationDatabaseName() {
+		return getDatabaseName();
+	}
 
 	/**
 	 * Return the {@link Mongo} instance to connect to. Annotate with {@link Bean} in case you want to expose a
@@ -97,7 +107,7 @@ public abstract class AbstractMongoConfiguration {
 		if (credentials == null) {
 			return new SimpleMongoDbFactory(mongo(), getDatabaseName());
 		} else {
-			return new SimpleMongoDbFactory(mongo(), getDatabaseName(), credentials);
+			return new SimpleMongoDbFactory(mongo(), getDatabaseName(), credentials, getAuthenticationDatabaseName());
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 by the original author(s).
+ * Copyright 2011-2013 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import com.mongodb.MongoURI;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 
@@ -70,6 +71,8 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 		String uri = element.getAttribute("uri");
 		String mongoRef = element.getAttribute("mongo-ref");
 		String dbname = element.getAttribute("dbname");
+		String authDbname = element.getAttribute("authentication-dbname");
+
 		BeanDefinition userCredentials = getUserCredentialsBeanDefinition(element, parserContext);
 
 		// Common setup
@@ -95,9 +98,9 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 		dbname = StringUtils.hasText(dbname) ? dbname : "db";
 		dbFactoryBuilder.addConstructorArgValue(dbname);
 
-		if (userCredentials != null) {
-			dbFactoryBuilder.addConstructorArgValue(userCredentials);
-		}
+		dbFactoryBuilder.addConstructorArgValue(userCredentials != null ? userCredentials : UserCredentials.NO_CREDENTIALS);
+
+		dbFactoryBuilder.addConstructorArgValue(StringUtils.hasText(authDbname) ? authDbname : dbname);
 
 		BeanDefinitionBuilder writeConcernPropertyEditorBuilder = getWriteConcernPropertyEditorBuilder();
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoAdmin.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.mongodb.Mongo;
  * Mongo server administration exposed via JMX annotations
  * 
  * @author Mark Pollack
+ * @author Thomas Darimont
  */
 @ManagedResource(description = "Mongo Admin Operations")
 public class MongoAdmin implements MongoAdminOperations {
@@ -34,6 +35,7 @@ public class MongoAdmin implements MongoAdminOperations {
 	private final Mongo mongo;
 	private String username;
 	private String password;
+	private String authenticationDatabaseName;
 
 	public MongoAdmin(Mongo mongo) {
 		Assert.notNull(mongo);
@@ -82,7 +84,16 @@ public class MongoAdmin implements MongoAdminOperations {
 		this.password = password;
 	}
 
+	/**
+	 * Sets the authenticationDatabaseName to use to authenticate with the Mongo database.
+	 * 
+	 * @param authenticationDatabaseName The authenticationDatabaseName to use.
+	 */
+	public void setAuthenticationDatabaseName(String authenticationDatabaseName) {
+		this.authenticationDatabaseName = authenticationDatabaseName;
+	}
+
 	DB getDB(String databaseName) {
-		return MongoDbUtils.getDB(mongo, databaseName, new UserCredentials(username, password));
+		return MongoDbUtils.getDB(mongo, databaseName, new UserCredentials(username, password), authenticationDatabaseName);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
@@ -33,6 +33,7 @@ import com.mongodb.Mongo;
  * @author Graeme Rocher
  * @author Oliver Gierke
  * @author Randy Watler
+ * @author Thomas Darimont
  * @since 1.0
  */
 public abstract class MongoDbUtils {
@@ -54,7 +55,7 @@ public abstract class MongoDbUtils {
 	 * @return the {@link DB} connection
 	 */
 	public static DB getDB(Mongo mongo, String databaseName) {
-		return doGetDB(mongo, databaseName, UserCredentials.NO_CREDENTIALS, true);
+		return doGetDB(mongo, databaseName, UserCredentials.NO_CREDENTIALS, true, databaseName);
 	}
 
 	/**
@@ -71,10 +72,24 @@ public abstract class MongoDbUtils {
 		Assert.hasText(databaseName, "Database name must be given!");
 		Assert.notNull(credentials, "Credentials must not be null, use UserCredentials.NO_CREDENTIALS!");
 
-		return doGetDB(mongo, databaseName, credentials, true);
+		return getDB(mongo, databaseName, credentials, databaseName);
 	}
 
-	private static DB doGetDB(Mongo mongo, String databaseName, UserCredentials credentials, boolean allowCreate) {
+	/**
+	 * @param mongo
+	 * @param databaseName
+	 * @param credentials
+	 * @param authenticationDatabaseName
+	 * @return
+	 */
+	public static DB getDB(Mongo mongo, String databaseName, UserCredentials credentials,
+			String authenticationDatabaseName) {
+		return doGetDB(mongo, databaseName, credentials, true, authenticationDatabaseName == null ? databaseName
+				: authenticationDatabaseName);
+	}
+
+	private static DB doGetDB(Mongo mongo, String databaseName, UserCredentials credentials, boolean allowCreate,
+			String authenticationDatabaseName) {
 
 		DbHolder dbHolder = (DbHolder) TransactionSynchronizationManager.getResource(mongo);
 
@@ -103,14 +118,16 @@ public abstract class MongoDbUtils {
 		DB db = mongo.getDB(databaseName);
 		boolean credentialsGiven = credentials.hasUsername() && credentials.hasPassword();
 
-		synchronized (db) {
+		DB authDb = databaseName.equals(authenticationDatabaseName) ? db : mongo.getDB(authenticationDatabaseName);
 
-			if (credentialsGiven && !db.isAuthenticated()) {
+		synchronized (authDb) {
+
+			if (credentialsGiven && !authDb.isAuthenticated()) {
 
 				String username = credentials.getUsername();
 				String password = credentials.hasPassword() ? credentials.getPassword() : null;
 
-				if (!db.authenticate(username, password == null ? null : password.toCharArray())) {
+				if (!authDb.authenticate(username, password == null ? null : password.toCharArray())) {
 					throw new CannotGetMongoDbConnectionException("Failed to authenticate to database [" + databaseName + "], "
 							+ credentials.toString(), databaseName, credentials);
 				}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/ServerInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/ServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2012-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
@@ -56,6 +56,13 @@ The name of the database to connect to. Default is 'db'.
 							]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="authentication-dbname" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the authentication database to connect to. Default is 'db'.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="port" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
@@ -115,6 +115,21 @@ public class MongoNamespaceTests {
 	}
 
 	/**
+	 * @see DATAMONGO-789
+	 */
+	@Test
+	public void testThirdMongoDbFactory() {
+		assertTrue(ctx.containsBean("thirdMongoDbFactory"));
+		MongoDbFactory dbf = (MongoDbFactory) ctx.getBean("thirdMongoDbFactory");
+		Mongo mongo = (Mongo) getField(dbf, "mongo");
+		assertEquals("localhost", mongo.getAddress().getHost());
+		assertEquals(27017, mongo.getAddress().getPort());
+		assertEquals(new UserCredentials("joe", "secret"), getField(dbf, "credentials"));
+		assertEquals("database", getField(dbf, "databaseName"));
+		assertEquals("admin", getField(dbf, "authenticationDatabaseName"));
+	}
+
+	/**
 	 * @see DATAMONGO-140
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
@@ -37,6 +37,14 @@
 					  dbname="database"
 					  username="joe"
 					  password="secret"/>
+					  
+		<mongo:db-factory id="thirdMongoDbFactory"
+					  host="localhost"
+					  port="27017"
+					  dbname="database"
+					  username="joe"
+					  password="secret"
+					  authentication-dbname="admin"/>
 
 	<mongo:mongo id="defaultMongo" host="localhost" port="27017"/>
 


### PR DESCRIPTION
...database.

MongoDbUtils now supports to perform the authentication against a dedicated authenticationDatabase - if no authenticationDatabase is given explicitly then the given regular database will be used. The authentication database can be configured via the "authentication-dbname" attribute of the db-factory element in xml config or by overriding the getAuthenticationDatabaseName() method of AbstractMongoConfiguration.
