### PR TITLE
DATAMONGO-653 - Support for index operations in GridFsOperations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.4.0.BUILD-SNAPSHOT</version>
+	<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.4.0.BUILD-SNAPSHOT</version>
+			<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<version>1.4.0.DATAMONGO-653-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/DefaultGridFsIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/DefaultGridFsIndexOperations.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.CollectionCallback;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.util.Assert;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+
+/**
+ * Default implementation of {@link GridFsIndexOperations}.
+ * 
+ * @author Aparna Chaudhary
+ */
+public class DefaultGridFsIndexOperations implements GridFsIndexOperations {
+
+	private final GridFsOperations gridFsOperations;
+
+	/**
+	 * Creates a new {@link DefaultGridFsIndexOperations}.
+	 * 
+	 * @param gridFsOperations must not be {@literal null}.
+	 */
+	public DefaultGridFsIndexOperations(GridFsOperations gridFsOperations) {
+		Assert.notNull(gridFsOperations, "GridFsOperations must not be null!");
+		this.gridFsOperations = gridFsOperations;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsIndexOperations#ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition)
+	 */
+	@Override
+	public void ensureIndex(final IndexDefinition indexDefinition) {
+
+		gridFsOperations.execute(new CollectionCallback<Object>() {
+			@Override
+			public Object doInCollection(DBCollection collection) throws MongoException, DataAccessException {
+
+				DBObject indexOptions = indexDefinition.getIndexOptions();
+				if (indexOptions != null) {
+					collection.ensureIndex(indexDefinition.getIndexKeys(), indexOptions);
+				} else {
+					collection.ensureIndex(indexDefinition.getIndexKeys());
+				}
+				return null;
+			}
+		});
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsIndexOperations#dropIndex(java.lang.String)
+	 */
+	@Override
+	public void dropIndex(final String name) {
+
+		gridFsOperations.execute(new CollectionCallback<Void>() {
+			@Override
+			public Void doInCollection(DBCollection collection) throws MongoException, DataAccessException {
+
+				collection.dropIndex(name);
+				return null;
+			}
+		});
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsIndexOperations.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+
+/**
+ * Index operations for GridFs files collection.
+ * 
+ * @author Aparna Chaudhary
+ */
+public interface GridFsIndexOperations {
+
+	/**
+	 * Ensure that an index for the provided {@link IndexDefinition} exists for the files collection. If not it will be
+	 * created.
+	 * 
+	 * @param indexDefinition must not be {@literal null}.
+	 */
+	void ensureIndex(IndexDefinition indexDefinition);
+
+	/**
+	 * Drops an index from the files collection.
+	 * 
+	 * @param name name of index to drop
+	 */
+	void dropIndex(String name);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,11 @@ import java.util.List;
 
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.CollectionCallback;
+import org.springframework.data.mongodb.core.DbCallback;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSFile;
@@ -31,6 +34,7 @@ import com.mongodb.gridfs.GridFSFile;
  * 
  * @author Oliver Gierke
  * @author Philipp Schneider
+ * @author Aparna Chaudhary
  */
 public interface GridFsOperations extends ResourcePatternResolver {
 
@@ -98,6 +102,22 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	GridFSFile store(InputStream content, String filename, String contentType, DBObject metadata);
 
 	/**
+	 * Returns the operations that can be performed on indexes
+	 */
+	GridFsIndexOperations indexOps();
+
+	/**
+	 * Executes the given {@link DbCallback} on the GridFs files collection.
+	 * <p/>
+	 * Allows for returning a result object, that is a domain object or a collection of domain objects.
+	 * 
+	 * @param <T> return type
+	 * @param action callback that specified the GridFs actions to perform on the DB instance
+	 * @return a result object returned by the action or <tt>null</tt>
+	 */
+	<T> T execute(CollectionCallback<T> callback);
+
+	/**
 	 * Returns all files matching the given query. Note, that currently {@link Sort} criterias defined at the
 	 * {@link Query} will not be regarded as MongoDB does not support ordering for GridFS file access.
 	 * 
@@ -123,12 +143,20 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	void delete(Query query);
 
 	/**
+	 * Gets the {@link DBCollection} in which the file’s metadata is stored.
+	 * 
+	 * @return files collection
+	 */
+	DBCollection getFilesCollection();
+
+	/**
 	 * Returns all {@link GridFsResource} with the given file name.
 	 * 
 	 * @param filename
 	 * @return
 	 * @see ResourcePatternResolver#getResource(String)
 	 */
+	@Override
 	GridFsResource getResource(String filename);
 
 	/**
@@ -138,5 +166,6 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	 * @return
 	 * @see ResourcePatternResolver#getResources(String)
 	 */
+	@Override
 	GridFsResource[] getResources(String filenamePattern);
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.CollectionCallback;
+import org.springframework.data.mongodb.core.MongoExceptionTranslator;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.query.Query;
@@ -32,6 +35,7 @@ import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
+import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.gridfs.GridFS;
 import com.mongodb.gridfs.GridFSDBFile;
@@ -43,6 +47,7 @@ import com.mongodb.gridfs.GridFSInputFile;
  * 
  * @author Oliver Gierke
  * @author Philipp Schneider
+ * @author Aparna Chaudhary
  */
 public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver {
 
@@ -50,6 +55,7 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 	private final String bucket;
 	private final MongoConverter converter;
 	private final QueryMapper queryMapper;
+	private final MongoExceptionTranslator exceptionTranslator = new MongoExceptionTranslator();
 
 	/**
 	 * Creates a new {@link GridFsTemplate} using the given {@link MongoDbFactory} and {@link MongoConverter}.
@@ -153,6 +159,27 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 		return file;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#execute(org.springframework.data.mongodb.core.CollectionCallback)
+	 */
+	public <T> T execute(CollectionCallback<T> callback) {
+
+		Assert.notNull(callback);
+		try {
+			DBCollection collection = getFilesCollection();
+			return callback.doInCollection(collection);
+		} catch (RuntimeException e) {
+			throw potentiallyConvertRuntimeException(e);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#indexOps()
+	 */
+	public GridFsIndexOperations indexOps() {
+		return new DefaultGridFsIndexOperations(this);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#find(com.mongodb.DBObject)
@@ -183,6 +210,21 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 	 */
 	public void delete(Query query) {
 		getGridFs().remove(getMappedQuery(query));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#getFilesCollection()
+	 */
+	public DBCollection getFilesCollection() {
+
+		try {
+			DB db = getGridFs().getDB();
+			String fsCollection = bucket == null ? "fs.files" : bucket.concat(".files");
+			DBCollection collection = db.getCollectionFromString(fsCollection);
+			return collection;
+		} catch (RuntimeException e) {
+			throw potentiallyConvertRuntimeException(e);
+		}
 	}
 
 	/*
@@ -239,5 +281,18 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 	private GridFS getGridFs() {
 		DB db = dbFactory.getDb();
 		return bucket == null ? new GridFS(db) : new GridFS(db, bucket);
+	}
+
+	/**
+	 * Tries to convert the given {@link RuntimeException} into a {@link DataAccessException} but returns the original
+	 * exception if the conversation failed. Thus allows safe rethrowing of the return value.
+	 * 
+	 * @param ex exception to translate
+	 * @return translated {@link DataAccessException} or {@link RuntimeException} if translation fails
+	 */
+	private RuntimeException potentiallyConvertRuntimeException(RuntimeException ex) {
+
+		RuntimeException resolved = this.exceptionTranslator.translateExceptionIfPossible(ex);
+		return resolved == null ? ex : resolved;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsIndexOperationsTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+
+/**
+ * Integration tests for {@link GridFsIndexOperations}.
+ * 
+ * @author Aparna Chaudhary
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:gridfs/customgridfs.xml")
+public class GridFsIndexOperationsTests {
+
+	private static final String BUCKET = "custom";
+
+	Resource resource = new ClassPathResource("gridfs/customgridfs.xml");
+
+	@Autowired MongoDbFactory factory;
+	@Autowired MongoConverter converter;
+
+	GridFsOperations operations;
+
+	@Before
+	public void setUp() {
+
+		MongoTemplate mongoTemplate = new MongoTemplate(factory);
+		mongoTemplate.dropCollection(BUCKET.concat(".files"));
+		mongoTemplate.dropCollection(BUCKET.concat(".chunks"));
+
+		operations = new GridFsTemplate(factory, converter, BUCKET);
+	}
+
+	/**
+	 * @see DATAMONGO-653
+	 */
+	@Test
+	public void testEnsureIndex() throws IOException {
+
+		operations.indexOps().ensureIndex(new Index().on("md5", Direction.ASC).unique());
+
+		DBCollection coll = operations.getFilesCollection();
+		List<DBObject> indexInfo = coll.getIndexInfo();
+
+		assertThat(indexInfo.size(), is(3));
+		String indexKey = null;
+		boolean unique = false;
+		for (DBObject ix : indexInfo) {
+			if ("md5_1".equals(ix.get("name"))) {
+				indexKey = ix.get("key").toString();
+				unique = (Boolean) ix.get("unique");
+			}
+		}
+
+		assertThat(indexKey, is("{ \"md5\" : 1}"));
+		assertThat(unique, is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-653
+	 */
+	@Test
+	public void testEnsureIndexOnMetadata() throws IOException {
+
+		operations.indexOps().ensureIndex(new Index().on("metadata.key", Direction.ASC));
+
+		DBCollection coll = operations.getFilesCollection();
+		List<DBObject> indexInfo = coll.getIndexInfo();
+
+		assertThat(indexInfo.size(), is(3));
+		String indexKey = null;
+		for (DBObject ix : indexInfo) {
+			if ("metadata.key_1".equals(ix.get("name"))) {
+				indexKey = ix.get("key").toString();
+			}
+		}
+
+		assertThat(indexKey, is("{ \"metadata.key\" : 1}"));
+	}
+
+	/**
+	 * @see DATAMONGO-653
+	 */
+	@Test
+	public void testDropIndex() throws IOException {
+
+		operations.indexOps().ensureIndex(new Index().on("md5", Direction.ASC).unique());
+
+		DBCollection coll = operations.getFilesCollection();
+		List<DBObject> indexInfo = coll.getIndexInfo();
+		assertThat(indexInfo.size(), is(3));
+
+		operations.indexOps().dropIndex("md5_1");
+
+		indexInfo = coll.getIndexInfo();
+		assertThat(indexInfo.size(), is(2));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIIntegrationTests.java
@@ -31,11 +31,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSFile;
@@ -45,6 +47,7 @@ import com.mongodb.gridfs.GridFSFile;
  * 
  * @author Oliver Gierke
  * @author Philipp Schneider
+ * @author Aparna Chaudhary
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:gridfs/gridfs.xml")
@@ -160,6 +163,51 @@ public class GridFsTemplateIIntegrationTests {
 
 		assertThat(result, hasSize(1));
 		assertSame(result.get(0), reference);
+	}
+
+	/**
+	 * Tests index creation with default bucket
+	 * 
+	 * @see DATAMONGO-653
+	 */
+	@Test
+	public void testEnsureIndex() {
+
+		operations.indexOps().ensureIndex(new Index().on("md5", Direction.ASC).unique());
+
+		DBCollection coll = operations.getFilesCollection();
+		List<DBObject> indexInfo = coll.getIndexInfo();
+		assertThat(indexInfo.size(), is(3));
+		String indexKey = null;
+		boolean unique = false;
+		for (DBObject ix : indexInfo) {
+			if ("md5_1".equals(ix.get("name"))) {
+				indexKey = ix.get("key").toString();
+				unique = (Boolean) ix.get("unique");
+			}
+		}
+		assertThat(indexKey, is("{ \"md5\" : 1}"));
+		assertThat(unique, is(true));
+	}
+
+	/**
+	 * Tests index deletion with default bucket
+	 * 
+	 * @see DATAMONGO-653
+	 */
+	@Test
+	public void testDropIndex() {
+
+		operations.indexOps().ensureIndex(new Index().on("md5", Direction.ASC).unique());
+
+		DBCollection coll = operations.getFilesCollection();
+		List<DBObject> indexInfo = coll.getIndexInfo();
+		assertThat(indexInfo.size(), is(3));
+
+		operations.indexOps().dropIndex("md5_1");
+
+		indexInfo = coll.getIndexInfo();
+		assertThat(indexInfo.size(), is(2));
 	}
 
 	private static void assertSame(GridFSFile left, GridFSFile right) {

--- a/spring-data-mongodb/src/test/resources/gridfs/customgridfs.xml
+++ b/spring-data-mongodb/src/test/resources/gridfs/customgridfs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory id="mongoDbFactory" dbname="database" />
+	<mongo:mapping-converter id="converter" />
+
+</beans>


### PR DESCRIPTION
Introduced GridFsIndexOperations for creating and deleting GridFS indices which can be accessed via GridFsOperations#indexOps().

Original pull request #65.
