### PR TITLE
DATAMONGO-884 - Crash on calling override method of Object class when the class is an DBRef(lazy=true)

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -199,7 +199,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 		 */
 		@Override
 		public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
-			return ReflectionUtils.isObjectMethod(method) ? method.invoke(obj, args) : method.invoke(ensureResolved(), args);
+			return ReflectionUtils.isObjectMethod(method) && method.getDeclaringClass()==Object.class ? method.invoke(obj, args) : method.invoke(ensureResolved(), args);
 		}
 
 		private Object ensureResolved() {


### PR DESCRIPTION
The parameter "method" can be  either from Object's method or an override of original Object method.
ReflectionUtils.isObjectMethod(method) only check if the same method exists in Object.
So in order to check if the method is an original method from Object class, it needs to explicitly check method.getDeclaringClass() with Object.class.

For example below, 

public class B
{
   @Id
   private String id;
   private String value;

   @Override
   public String toString(){
      return String.format("B[id='%s', value='%s']",id,value);  
   }
}
public class A
{
   @DBRef(lazy=true)
   public B b;

   @Override
   public String toString()
   {
      return String.format("A[b='%s']",b);
   }
}

if class A is loaded with current DefaultDbRefResolver, when class B.toString() is called, it will result NullPointerException since the toString method is not actually from Object.
If we also check "method.getDeclaringClass()==Object.class," it will resolve the issue
