### PR TITLE
DATAMONGO-884 - Avoid NPE for lazy-loaded DBRefs

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -155,7 +155,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 	 * 
 	 * @author Thomas Darimont
 	 */
-	static class LazyLoadingInterceptor implements MethodInterceptor, org.springframework.cglib.proxy.MethodInterceptor,
+	public static class LazyLoadingInterceptor implements MethodInterceptor, org.springframework.cglib.proxy.MethodInterceptor,
 			Serializable {
 
 		private final DbRefResolverCallback callback;
@@ -207,7 +207,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 			return method.invoke(ensureResolved(), args);
 		}
 
-		private Object ensureResolved() {
+		public Object ensureResolved() {
 
 			if (!resolved) {
 				this.result = resolve();


### PR DESCRIPTION
It seems when intercept function is called the parameter "Object obj" is always "null" (in my case), which results NPE when Object method is called.

If the parameter Object obj is actually always null, it  either should remove all the checks and just always invoke by "method.invoke(ensureResolved(), args);"

If there is case that parameter Object obj is NOT null, then it should add another check to handle the case, which the parameter Object obj is null.

See my last comment in jira: https://jira.spring.io/browse/DATAMONGO-884?focusedCommentId=100657&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-100657
