### PR TITLE
Use Long value when comparing version field

### DIFF
--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -235,7 +235,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 				org.mockito.Matchers.isNull(DBObject.class), org.mockito.Matchers.isNull(DBObject.class), eq(false),
 				captor.capture(), eq(false), eq(false));
 
-		Assert.assertThat(captor.getValue().get("$inc"), Is.<Object> is(new BasicDBObject("version", 1)));
+		Assert.assertThat(captor.getValue().get("$inc"), Is.<Object> is(new BasicDBObject("version", 1L)));
 	}
 
 	/**


### PR DESCRIPTION
When comparing the value of the version field, compare against a Long rather than an Integer, since the version field generated is a Long.

This allows the test to pass against the upcoming 2.12.0 release of the Java driver, which has a stricter implementation of BasisDBObject.equals (it treats Integer and Long as un-equal, as MongoDB does).
