### PR TITLE
Relaxing error message comparison so that test passes against MongoDB 2.6

### DIFF
--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -316,7 +316,7 @@ public class MongoTemplateTests {
 			assertThat(
 					e.getMessage(),
 					CoreMatchers
-							.startsWith("Insert list failed: E11000 duplicate key error index: database.person.$_id_  dup key: { : ObjectId"));
+							.containsString("E11000 duplicate key error index: database.person.$_id_  dup key: { : ObjectId"));
 		}
 	}
 


### PR DESCRIPTION
MongoDB 2.6 is returning an error message starting with:

"Insert list failed: insertDocument :: caused by :: "

which was making this test fail.

Note also that to test against MongoDB 2.6.0-rc2 I had to in the setup method first strip the "-rc2" from the version before passing it to Spring's Version class, which doesn't handle anything but integer versions.
