### PR TITLE
DATAMONGO-1043

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -129,7 +129,7 @@ public class MongoQueryMethod extends QueryMethod {
 					: managedEntity;
 
 			this.metadata = new SimpleMongoEntityMetadata<Object>((Class<Object>) returnedEntity.getType(),
-					collectionEntity.getCollection());
+					(MongoPersistentEntity<Object>) collectionEntity); /*collectionEntity.getCollection());*/
 		}
 
 		return this.metadata;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/SimpleMongoEntityMetadata.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/SimpleMongoEntityMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.util.Assert;
 
 /**
@@ -26,6 +27,7 @@ class SimpleMongoEntityMetadata<T> implements MongoEntityMetadata<T> {
 
 	private final Class<T> type;
 	private final String collectionName;
+	private final MongoPersistentEntity<T> persistentEntityRef;
 
 	/**
 	 * Creates a new {@link SimpleMongoEntityMetadata} using the given type and collection name.
@@ -40,6 +42,16 @@ class SimpleMongoEntityMetadata<T> implements MongoEntityMetadata<T> {
 
 		this.type = type;
 		this.collectionName = collectionName;
+		this.persistentEntityRef = null;
+	}
+	
+	public SimpleMongoEntityMetadata(Class<T> type, MongoPersistentEntity<T> persistentEntityRef) {
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(persistentEntityRef, "PersistentEntityRef must not be null!");
+
+		this.type = type;
+		this.collectionName = null;
+		this.persistentEntityRef = persistentEntityRef;
 	}
 
 	/* 
@@ -55,6 +67,6 @@ class SimpleMongoEntityMetadata<T> implements MongoEntityMetadata<T> {
 	 * @see org.springframework.data.mongodb.repository.query.MongoEntityMetadata#getCollectionName()
 	 */
 	public String getCollectionName() {
-		return collectionName;
+		return this.persistentEntityRef != null ? this.persistentEntityRef.getCollection() : collectionName;
 	}
 }


### PR DESCRIPTION
already applied formatting from https://github.com/spring-projects/spring-data-build/blob/master/etc/ide/eclipse-formatting.xml, but still too many changes

To summarize :
- MongoQueryMethod.getEntityInformation when creating SimpleMongoEntityMetadata uses the MongoPersistentEntity itself, instead of MongoPersistentEntity.getCollection()
- new constructor added : SimpleMongoEntityMetadata(Class<T> type, MongoPersistentEntity<T> persistentEntityRef) 
- SimpleMongoEntityMetadata.getCollectionName checks the presence of persistentEntityRef and uses it whenever possible
