### PR TITLE
DATAMONGO-941 - Add support for Update $min.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.7.0.BUILD-SNAPSHOT</version>
+			<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-941-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -20,6 +20,7 @@ import static org.springframework.util.ObjectUtils.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -305,6 +306,38 @@ public class Update {
 	public Update currentTimestamp(String key) {
 
 		addMultiFieldOperation("$currentDate", key, new BasicDBObject("$type", "timestamp"));
+		return this;
+	}
+
+	/**
+	 * Update given key to value if the given value is less than the current value of the field.
+	 * 
+	 * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 * @since 1.7
+	 */
+	public Update min(String key, Number value) {
+
+		Assert.notNull(value, "Value for min operation must not be 'null'.");
+		addMultiFieldOperation("$min", key, value);
+		return this;
+	}
+
+	/**
+	 * Update given key to value if the given date is before than the current date value of the field.
+	 * 
+	 * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 * @since 1.7
+	 */
+	public Update min(String key, Date value) {
+
+		Assert.notNull(value, "Value for min operation must not be 'null'.");
+		addMultiFieldOperation("$min", key, value);
 		return this;
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 
 import org.joda.time.DateTime;
@@ -419,5 +420,46 @@ public class UpdateTests {
 
 		Update update = new Update().addToSet("key", new DateTime());
 		assertThat(update.toString(), is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAMONGO-941
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void minWithNumberShouldThrowExceptionWhenGivenNullValue() {
+		new Update().min("key", (Number) null);
+	}
+
+	/**
+	 * @see DATAMONGO-941
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void minWithDateShouldThrowExceptionWhenGivenNullValue() {
+		new Update().min("key", (Date) null);
+	}
+
+	/**
+	 * @see DATAMONGO-941
+	 */
+	@Test
+	public void minShouldBeAppliedCorrectly() {
+
+		Update update = new Update().min("key", 10);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$min", new BasicDBObject("key", 10))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-941
+	 */
+	@Test
+	public void minShouldBeAppliedToMultipleFieldsCorrectly() {
+
+		Update update = new Update().min("foo", 10).min("bar", 20);
+
+		assertThat(update.getUpdateObject(),
+				equalTo(new BasicDBObjectBuilder().add("$min", new BasicDBObjectBuilder().add("foo", 10).add("bar", 20).get())
+						.get()));
 	}
 }


### PR DESCRIPTION
We now offer dedicated methods for _min_ (`Number`/`Date`) on `Update`.
As `BigInteger` and `BigDecimal` values are converted to `String` before storing in `MongoDB` it is not possible to use for the _min_ operation. Therefore we type check both the given value and the property it should be applied to and raise an error if  it fails.

This PR ist a first draft for discussion and should not be directly merged.