### PR TITLE
DATAMONGO-479 - Add support for calling functions. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.7.0.BUILD-SNAPSHOT</version>
+			<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-479-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static java.util.UUID.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.script.CallableMongoScript;
+import org.springframework.data.mongodb.core.script.MongoScript;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+import com.mongodb.DB;
+import com.mongodb.MongoException;
+
+/**
+ * Default implementation of {@link ScriptOperations} capable of saving and executing simple {@link MongoScript}.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class DefaultScriptOperations implements ScriptOperations {
+
+	private static final String SCRIPT_COLLECTION_NAME = "system.js";
+	private static final String SCRIPT_NAME_PREFIX = "func_";
+	private final MongoOperations mongoOperations;
+
+	/**
+	 * Creates new {@link DefaultScriptOperations} using given {@link MongoOperations}.
+	 * 
+	 * @param mongoOperations must not be {@literal null}.
+	 */
+	public DefaultScriptOperations(MongoOperations mongoOperations) {
+
+		Assert.notNull(mongoOperations, "MongoOperations must not be null!");
+		this.mongoOperations = mongoOperations;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.ScriptOperations#save(org.springframework.data.mongodb.core.script.MongoScript)
+	 */
+	@Override
+	public CallableMongoScript save(MongoScript script) {
+
+		Assert.notNull(script, "Script must not be null!");
+		CallableMongoScript callableScript = null;
+
+		if (script instanceof CallableMongoScript) {
+			callableScript = (CallableMongoScript) script;
+		} else {
+			callableScript = new CallableMongoScript(generateScriptName(), script);
+		}
+
+		mongoOperations.save(callableScript, SCRIPT_COLLECTION_NAME);
+		return callableScript;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.ScriptOperations#execute(org.springframework.data.mongodb.core.script.MongoScript, java.lang.Object[])
+	 */
+	@Override
+	public Object execute(final MongoScript script, final Object... args) {
+
+		Assert.notNull(script, "Script must not be null!");
+		return mongoOperations.execute(new DbCallback<Object>() {
+
+			@Override
+			public Object doInDB(DB db) throws MongoException, DataAccessException {
+
+				if (script instanceof CallableMongoScript) {
+
+					String evalString = ((CallableMongoScript) script).getName() + "(" + convertAndJoinScriptArgs(args) + ")";
+					return db.eval(evalString);
+				}
+
+				Assert.notNull(script.getCode(), "Script.code must not be null!");
+				return db.eval(script.getCode().toString(), convertScriptArgs(args));
+			}
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.ScriptOperations#load(java.io.Serializable)
+	 */
+	@Override
+	public CallableMongoScript load(Serializable name) {
+
+		Assert.notNull(name, "Name must not be null!");
+		return mongoOperations.findOne(query(where("name").is(name)), CallableMongoScript.class, SCRIPT_COLLECTION_NAME);
+	}
+
+	/**
+	 * Generate a valid name for the script. MongoDB requires a script id of type String. Calling scripts having ObjectId
+	 * as id fails. Therefore we create a random UUID without {@code -} (as this won't work) an prefix the result with
+	 * {@link #SCRIPT_NAME_PREFIX}.
+	 * 
+	 * @return
+	 */
+	private String generateScriptName() {
+		return SCRIPT_NAME_PREFIX + randomUUID().toString().replaceAll("-", "");
+	}
+
+	private Object[] convertScriptArgs(Object... args) {
+
+		if (ObjectUtils.isEmpty(args)) {
+			return args;
+		}
+
+		List<Object> convertedValues = new ArrayList<Object>(args.length);
+		for (Object arg : args) {
+			if (arg instanceof String) {
+				convertedValues.add("'" + arg + "'");
+			} else {
+				convertedValues.add(this.mongoOperations.getConverter().convertToMongoType(arg));
+			}
+		}
+		return convertedValues.toArray();
+	}
+
+	private String convertAndJoinScriptArgs(Object... args) {
+
+		if (ObjectUtils.isEmpty(args)) {
+			return "";
+		}
+
+		return StringUtils.arrayToCommaDelimitedString(convertScriptArgs(args));
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -269,6 +269,14 @@ public interface MongoOperations {
 	IndexOperations indexOps(Class<?> entityClass);
 
 	/**
+	 * Returns the {@link ScriptOperations} that can be performed on {@link com.mongodb.DB} level.
+	 * 
+	 * @return
+	 * @since 1.7
+	 */
+	ScriptOperations scriptOps();
+
+	/**
 	 * Query for a list of objects of type T from the collection used by the entity class.
 	 * <p/>
 	 * The object is converted from the MongoDB native representation using an instance of {@see MongoConverter}. Unless
@@ -978,4 +986,5 @@ public interface MongoOperations {
 	 * @return
 	 */
 	MongoConverter getConverter();
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -513,6 +513,15 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		return new DefaultIndexOperations(this, determineCollectionName(entityClass));
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.MongoOperations#scriptOps()
+	 */
+	@Override
+	public ScriptOperations scriptOps() {
+		return new DefaultScriptOperations(this);
+	}
+
 	// Find methods that take a Query to express the query and that return a single object.
 
 	public <T> T findOne(Query query, Class<T> entityClass) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.data.mongodb.core;
 
-import java.io.Serializable;
+import java.util.Set;
 
 import org.springframework.data.mongodb.core.script.CallableMongoScript;
-import org.springframework.data.mongodb.core.script.MongoScript;
+import org.springframework.data.mongodb.core.script.ServerSideJavaScript;
+
+import com.mongodb.DB;
 
 /**
- * Script operations on {@link com.mongodb.DB} level.
+ * Script operations on {@link com.mongodb.DB} level. Allows interaction with server side {@literal JavaScript}
+ * functions.
  * 
  * @author Christoph Strobl
  * @since 1.7
@@ -29,29 +32,45 @@ import org.springframework.data.mongodb.core.script.MongoScript;
 public interface ScriptOperations {
 
 	/**
-	 * Saves given {@literal script} to currently used {@link com.mongodb.DB}.
+	 * Store given {@literal script} to {@link com.mongodb.DB} so it can be called via its name.
 	 * 
 	 * @param script must not be {@literal null}.
-	 * @return
+	 * @return {@link CallableMongoScript} with name under which the {@literal JavaScript} function can be called.
 	 */
-	CallableMongoScript save(MongoScript script);
+	CallableMongoScript register(ServerSideJavaScript script);
 
 	/**
-	 * Executes the {@literal script} by either calling it via its {@literal _id} or directly sending it.
+	 * Executes the {@literal script} by either calling it via its {@literal name} or directly sending it.
 	 * 
 	 * @param script must not be {@literal null}.
 	 * @param args arguments to pass on for script execution.
 	 * @return the script evaluation result.
 	 * @throws org.springframework.dao.DataAccessException
 	 */
-	Object execute(MongoScript script, Object... args);
+	Object execute(ServerSideJavaScript script, Object... args);
 
 	/**
-	 * Retrieves the {@link CallableMongoScript} by its {@literal id}.
+	 * Call the {@literal JavaScript} by its name.
 	 * 
-	 * @param name
-	 * @return {@literal null} if not found.
+	 * @param scriptName must not be {@literal null} or empty.
+	 * @param args
+	 * @return
 	 */
-	CallableMongoScript load(Serializable name);
+	Object call(String scriptName, Object... args);
+
+	/**
+	 * Checks {@link DB} for existence of {@link ServerSideJavaScript} with given name.
+	 * 
+	 * @param scriptName must not be {@literal null} or empty.
+	 * @return false if no {@link ServerSideJavaScript} with given name exists.
+	 */
+	Boolean exists(String scriptName);
+
+	/**
+	 * Returns names of {@literal JavaScript} functions that can be called.
+	 * 
+	 * @return empty {@link Set} if no scripts found.
+	 */
+	Set<String> scriptNames();
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import java.io.Serializable;
+
+import org.springframework.data.mongodb.core.script.CallableMongoScript;
+import org.springframework.data.mongodb.core.script.MongoScript;
+
+/**
+ * Script operations on {@link com.mongodb.DB} level.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public interface ScriptOperations {
+
+	/**
+	 * Saves given {@literal script} to currently used {@link com.mongodb.DB}.
+	 * 
+	 * @param script must not be {@literal null}.
+	 * @return
+	 */
+	CallableMongoScript save(MongoScript script);
+
+	/**
+	 * Executes the {@literal script} by either calling it via its {@literal _id} or directly sending it.
+	 * 
+	 * @param script must not be {@literal null}.
+	 * @param args arguments to pass on for script execution.
+	 * @return the script evaluation result.
+	 * @throws org.springframework.dao.DataAccessException
+	 */
+	Object execute(MongoScript script, Object... args);
+
+	/**
+	 * Retrieves the {@link CallableMongoScript} by its {@literal id}.
+	 * 
+	 * @param name
+	 * @return {@literal null} if not found.
+	 */
+	CallableMongoScript load(Serializable name);
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
@@ -44,6 +44,8 @@ import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.mongodb.core.convert.MongoConverters.BigDecimalToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.BigIntegerToStringConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.CallableMongoScriptToDBObjectConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToCallableMongoScriptCoverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigIntegerConverter;
@@ -118,6 +120,8 @@ public class CustomConversions {
 		toRegister.add(StringToURLConverter.INSTANCE);
 		toRegister.add(DBObjectToStringConverter.INSTANCE);
 		toRegister.add(TermToStringConverter.INSTANCE);
+		toRegister.add(CallableMongoScriptToDBObjectConverter.INSTANCE);
+		toRegister.add(DBObjectToCallableMongoScriptCoverter.INSTANCE);
 
 		toRegister.addAll(JodaTimeConverters.getConvertersToRegister());
 		toRegister.addAll(GeoConverters.getConvertersToRegister());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -202,7 +202,7 @@ abstract class MongoConverters {
 			String id = source.get("_id").toString();
 			Object rawValue = source.get("value");
 
-			return new CallableMongoScript(id, rawValue.toString());
+			return new CallableMongoScript(id, ((Code) rawValue).getCode());
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.bson.types.Code;
 import org.bson.types.ObjectId;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.TypeDescriptor;
@@ -201,11 +202,7 @@ abstract class MongoConverters {
 			String id = source.get("_id").toString();
 			Object rawValue = source.get("value");
 
-			if (rawValue != null) {
-				return new CallableMongoScript(id, rawValue.toString());
-			}
-
-			return new CallableMongoScript(id);
+			return new CallableMongoScript(id, rawValue.toString());
 		}
 	}
 
@@ -229,7 +226,7 @@ abstract class MongoConverters {
 
 			builder.append("_id", source.getName());
 			if (source.getCode() != null) {
-				builder.append("value", source.getCode());
+				builder.append("value", new Code(source.getCode()));
 			}
 
 			return builder.get();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/CallableMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/CallableMongoScript.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.script;
+
+import org.bson.types.Code;
+import org.springframework.data.annotation.Id;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MongoScript} implementation that allows calling the function by its {@literal id} once it has been saved to
+ * the {@link com.mongodb.DB} instance.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class CallableMongoScript implements MongoScript {
+
+	private final @Id String name;
+	private final MongoScript script;
+
+	/**
+	 * Creates new {@link CallableMongoScript} that uses the given {@literal id} to call the function on the server.
+	 * 
+	 * @param name must not be {@literal null} or {@literal empty}.
+	 */
+	public CallableMongoScript(String name) {
+		this(name, (MongoScript) null);
+	}
+
+	/**
+	 * Creates new {@link CallableMongoScript} that can be saved to the {@link com.mongodb.DB} instance.
+	 * 
+	 * @param name must not be {@literal null} or {@literal empty}.
+	 * @param rawScript the {@link String} representation of the javascript function. Must not be {@literal null} or
+	 *          {@literal empty}.
+	 */
+	public CallableMongoScript(String name, String rawScript) {
+		this(name, new ExecutableMongoScript(rawScript));
+	}
+
+	/**
+	 * Creates new {@link CallableMongoScript}.
+	 * 
+	 * @param name must not be {@literal null} or {@literal empty}.
+	 * @param script can be {@literal null}.
+	 */
+	public CallableMongoScript(String name, MongoScript script) {
+
+		Assert.hasText(name, "Name must not be null or empty!");
+		this.name = name;
+		this.script = script;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.script.MongoScript#getCode()
+	 */
+	@Override
+	public Code getCode() {
+
+		if (script == null) {
+			return null;
+		}
+
+		return script.getCode();
+	}
+
+	/**
+	 * Get the id of the callable script.
+	 * 
+	 * @return
+	 */
+	public String getName() {
+		return name;
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/CallableMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/CallableMongoScript.java
@@ -15,37 +15,27 @@
  */
 package org.springframework.data.mongodb.core.script;
 
-import org.bson.types.Code;
 import org.springframework.data.annotation.Id;
 import org.springframework.util.Assert;
 
 /**
- * A {@link MongoScript} implementation that allows calling the function by its {@literal id} once it has been saved to
- * the {@link com.mongodb.DB} instance.
+ * A {@link ServerSideJavaScript} implementation that allows calling the function by its {@literal name} once it has
+ * been saved to the {@link com.mongodb.DB} instance.
  * 
  * @author Christoph Strobl
  * @since 1.7
  */
-public class CallableMongoScript implements MongoScript {
+public class CallableMongoScript implements ServerSideJavaScript {
 
 	private final @Id String name;
-	private final MongoScript script;
-
-	/**
-	 * Creates new {@link CallableMongoScript} that uses the given {@literal id} to call the function on the server.
-	 * 
-	 * @param name must not be {@literal null} or {@literal empty}.
-	 */
-	public CallableMongoScript(String name) {
-		this(name, (MongoScript) null);
-	}
+	private final ServerSideJavaScript script;
 
 	/**
 	 * Creates new {@link CallableMongoScript} that can be saved to the {@link com.mongodb.DB} instance.
 	 * 
 	 * @param name must not be {@literal null} or {@literal empty}.
-	 * @param rawScript the {@link String} representation of the javascript function. Must not be {@literal null} or
-	 *          {@literal empty}.
+	 * @param rawScript the {@link String} representation of the {@literal JavaScript} function. Must not be
+	 *          {@literal null} or {@literal empty}.
 	 */
 	public CallableMongoScript(String name, String rawScript) {
 		this(name, new ExecutableMongoScript(rawScript));
@@ -57,7 +47,7 @@ public class CallableMongoScript implements MongoScript {
 	 * @param name must not be {@literal null} or {@literal empty}.
 	 * @param script can be {@literal null}.
 	 */
-	public CallableMongoScript(String name, MongoScript script) {
+	public CallableMongoScript(String name, ServerSideJavaScript script) {
 
 		Assert.hasText(name, "Name must not be null or empty!");
 		this.name = name;
@@ -69,7 +59,7 @@ public class CallableMongoScript implements MongoScript {
 	 * @see org.springframework.data.mongodb.core.script.MongoScript#getCode()
 	 */
 	@Override
-	public Code getCode() {
+	public String getCode() {
 
 		if (script == null) {
 			return null;
@@ -79,7 +69,7 @@ public class CallableMongoScript implements MongoScript {
 	}
 
 	/**
-	 * Get the id of the callable script.
+	 * Get the name of the {@link CallableMongoScript} script.
 	 * 
 	 * @return
 	 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.script;
+
+import org.bson.types.Code;
+import org.springframework.util.Assert;
+
+/**
+ * {@link MongoScript} implementation that can be saved or directly executed.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class ExecutableMongoScript implements MongoScript {
+
+	private final String rawScript;
+
+	/**
+	 * Creates new {@link ExecutableMongoScript}.
+	 * 
+	 * @param rawScript must not be {@literal null} or {@literal empty}.
+	 */
+	public ExecutableMongoScript(String rawScript) {
+
+		Assert.hasText(rawScript, "RawScript must not be null or empty!");
+		this.rawScript = rawScript;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.script.MongoScript#getCode()
+	 */
+	@Override
+	public Code getCode() {
+		return new Code(this.rawScript);
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
@@ -15,28 +15,27 @@
  */
 package org.springframework.data.mongodb.core.script;
 
-import org.bson.types.Code;
 import org.springframework.util.Assert;
 
 /**
- * {@link MongoScript} implementation that can be saved or directly executed.
+ * {@link ServerSideJavaScript} implementation that can be saved or directly executed.
  * 
  * @author Christoph Strobl
  * @since 1.7
  */
-public class ExecutableMongoScript implements MongoScript {
+public class ExecutableMongoScript implements ServerSideJavaScript {
 
-	private final String rawScript;
+	private final String code;
 
 	/**
 	 * Creates new {@link ExecutableMongoScript}.
 	 * 
-	 * @param rawScript must not be {@literal null} or {@literal empty}.
+	 * @param code must not be {@literal null} or {@literal empty}.
 	 */
-	public ExecutableMongoScript(String rawScript) {
+	public ExecutableMongoScript(String code) {
 
-		Assert.hasText(rawScript, "RawScript must not be null or empty!");
-		this.rawScript = rawScript;
+		Assert.hasText(code, "Code must not be null or empty!");
+		this.code = code;
 	}
 
 	/*
@@ -44,8 +43,8 @@ public class ExecutableMongoScript implements MongoScript {
 	 * @see org.springframework.data.mongodb.core.script.MongoScript#getCode()
 	 */
 	@Override
-	public Code getCode() {
-		return new Code(this.rawScript);
+	public String getCode() {
+		return this.code;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/MongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/MongoScript.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.script;
+
+import org.bson.types.Code;
+
+/**
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public interface MongoScript {
+
+	/**
+	 * Get the {@link Code} representation.
+	 * 
+	 * @return {@literal null} when no code available.
+	 */
+	Code getCode();
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ServerSideJavaScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ServerSideJavaScript.java
@@ -15,18 +15,16 @@
  */
 package org.springframework.data.mongodb.core.script;
 
-import org.bson.types.Code;
-
 /**
  * @author Christoph Strobl
  * @since 1.7
  */
-public interface MongoScript {
+public interface ServerSideJavaScript {
 
 	/**
-	 * Get the {@link Code} representation.
+	 * Get the {@link String} representation of the JavaScript code.
 	 * 
 	 * @return {@literal null} when no code available.
 	 */
-	Code getCode();
+	String getCode();
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
@@ -26,9 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataAccessException;
-import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.script.CallableMongoScript;
 import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
@@ -47,16 +47,18 @@ import com.mongodb.MongoClient;
 public class DefaultScriptOperationsTests {
 
 	@Configuration
-	static class Config extends AbstractMongoConfiguration {
+	static class Config {
 
-		@Override
-		protected String getDatabaseName() {
-			return "script-tests";
-		}
+		private static final String DB_NAME = "script-tests";
 
-		@Override
+		@Bean
 		public Mongo mongo() throws Exception {
 			return new MongoClient();
+		}
+
+		@Bean
+		public MongoTemplate template() throws Exception {
+			return new MongoTemplate(mongo(), DB_NAME);
 		}
 
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.script.CallableMongoScript;
+import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class DefaultScriptOperationsTests {
+
+	@Configuration
+	static class Config extends AbstractMongoConfiguration {
+
+		@Override
+		protected String getDatabaseName() {
+			return "script-tests";
+		}
+
+		@Override
+		public Mongo mongo() throws Exception {
+			return new MongoClient();
+		}
+
+	}
+
+	static final String SCRIPT_NAME = "echo";
+	static final String JS_FUNCTION = "function(x) { return x; }";
+	static final ExecutableMongoScript EXECUTABLE_SCRIPT = new ExecutableMongoScript(JS_FUNCTION);
+	static final CallableMongoScript CALLABLE_SCRIPT = new CallableMongoScript(SCRIPT_NAME, JS_FUNCTION);
+
+	@Autowired MongoTemplate template;
+	DefaultScriptOperations scriptOps;
+
+	@Before
+	public void setUp() {
+
+		template.getCollection("system.js").remove(new BasicDBObject());
+		this.scriptOps = new DefaultScriptOperations(template);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void executeShouldDirectlyRunExecutableMongoScript() {
+
+		Object result = scriptOps.execute(EXECUTABLE_SCRIPT, 10);
+
+		assertThat(result, Is.<Object> is(10D));
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = DataAccessException.class)
+	public void executeThowsDataAccessExceptionWhenRunningCallableScriptThatHasNotBeenSavedBefore() {
+		scriptOps.execute(CALLABLE_SCRIPT, 10);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void saveShouldStoreCallableScriptCorrectly() {
+
+		Query query = query(where("_id").is(SCRIPT_NAME));
+		assumeThat(template.exists(query, "system.js"), is(false));
+
+		scriptOps.save(CALLABLE_SCRIPT);
+
+		assumeThat(template.exists(query, "system.js"), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void saveShouldStoreExecutableScriptCorrectly() {
+
+		CallableMongoScript script = scriptOps.save(EXECUTABLE_SCRIPT);
+
+		Query query = query(where("_id").is(script.getName()));
+		assumeThat(template.exists(query, "system.js"), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void executeShouldRunCallableScriptThatHasBeenSavedBefore() {
+
+		scriptOps.save(CALLABLE_SCRIPT);
+
+		Query query = query(where("_id").is(SCRIPT_NAME));
+		assumeThat(template.exists(query, "system.js"), is(true));
+
+		Object result = scriptOps.execute(CALLABLE_SCRIPT, 10);
+
+		assertThat(result, Is.<Object> is(10D));
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void loadShouldFindScriptByItsName() {
+
+		scriptOps.save(CALLABLE_SCRIPT);
+
+		CallableMongoScript loaded = scriptOps.load(SCRIPT_NAME);
+
+		assertThat(loaded.getName(), is(CALLABLE_SCRIPT.getName()));
+		assertThat(loaded.getCode(), is(CALLABLE_SCRIPT.getCode()));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsUnitTests.java
@@ -49,7 +49,7 @@ public class DefaultScriptOperationsUnitTests {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void saveShouldThrowExceptionWhenCalledWithNullValue() {
-		scriptOps.save(null);
+		scriptOps.register(null);
 	}
 
 	/**
@@ -58,7 +58,7 @@ public class DefaultScriptOperationsUnitTests {
 	@Test
 	public void saveShouldUseCorrectCollectionName() {
 
-		scriptOps.save(new CallableMongoScript("foo", "function..."));
+		scriptOps.register(new CallableMongoScript("foo", "function..."));
 
 		verify(mongoOperationsMock, times(1)).save(any(CallableMongoScript.class), eq("system.js"));
 	}
@@ -69,7 +69,7 @@ public class DefaultScriptOperationsUnitTests {
 	@Test
 	public void saveShouldGenerateScriptNameForExecutableMongoScripts() {
 
-		scriptOps.save(new ExecutableMongoScript("function..."));
+		scriptOps.register(new ExecutableMongoScript("function..."));
 
 		ArgumentCaptor<CallableMongoScript> captor = ArgumentCaptor.forClass(CallableMongoScript.class);
 
@@ -83,6 +83,38 @@ public class DefaultScriptOperationsUnitTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void executeShouldThrowExceptionWhenScriptIsNull() {
 		scriptOps.execute(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void existsShouldThrowExceptionWhenScriptNameIsNull() {
+		scriptOps.exists(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void existsShouldThrowExceptionWhenScriptNameIsEmpty() {
+		scriptOps.exists("");
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void callShouldThrowExceptionWhenScriptNameIsNull() {
+		scriptOps.call(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void callShouldThrowExceptionWhenScriptNameIsEmpty() {
+		scriptOps.call("");
 	}
 
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsUnitTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.hamcrest.core.IsNull.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mongodb.core.script.CallableMongoScript;
+import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
+
+/**
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultScriptOperationsUnitTests {
+
+	DefaultScriptOperations scriptOps;
+	@Mock MongoOperations mongoOperationsMock;
+
+	@Before
+	public void setUp() {
+		this.scriptOps = new DefaultScriptOperations(mongoOperationsMock);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void saveShouldThrowExceptionWhenCalledWithNullValue() {
+		scriptOps.save(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void saveShouldUseCorrectCollectionName() {
+
+		scriptOps.save(new CallableMongoScript("foo", "function..."));
+
+		verify(mongoOperationsMock, times(1)).save(any(CallableMongoScript.class), eq("system.js"));
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void saveShouldGenerateScriptNameForExecutableMongoScripts() {
+
+		scriptOps.save(new ExecutableMongoScript("function..."));
+
+		ArgumentCaptor<CallableMongoScript> captor = ArgumentCaptor.forClass(CallableMongoScript.class);
+
+		verify(mongoOperationsMock, times(1)).save(captor.capture(), eq("system.js"));
+		Assert.assertThat(captor.getValue().getName(), notNullValue());
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void executeShouldThrowExceptionWhenScriptIsNull() {
+		scriptOps.execute(null);
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.springframework.data.mongodb.core.convert.CallableMongoScriptConvertsUnitTests.CallableMongoScriptToDboConverterUnitTests;
+import org.springframework.data.mongodb.core.convert.CallableMongoScriptConvertsUnitTests.DboToCallableMongoScriptConverterUnitTests;
 import org.springframework.data.mongodb.core.convert.MongoConverters.CallableMongoScriptToDBObjectConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToCallableMongoScriptCoverter;
 import org.springframework.data.mongodb.core.script.CallableMongoScript;
@@ -39,7 +40,7 @@ import com.mongodb.DBObject;
  * @author Christoph Strobl
  */
 @RunWith(Suite.class)
-@SuiteClasses({ CallableMongoScriptToDboConverterUnitTests.class })
+@SuiteClasses({ CallableMongoScriptToDboConverterUnitTests.class, DboToCallableMongoScriptConverterUnitTests.class })
 public class CallableMongoScriptConvertsUnitTests {
 
 	static final String FUNCTION_NAME = "echo";
@@ -86,7 +87,7 @@ public class CallableMongoScriptConvertsUnitTests {
 
 			Object code = dbo.get("value");
 			assertThat(code, instanceOf(Code.class));
-			assertThat(code.toString(), equalTo(JS_FUNCTION));
+			assertThat(code, equalTo((Object) new Code(JS_FUNCTION)));
 		}
 	}
 
@@ -125,7 +126,7 @@ public class CallableMongoScriptConvertsUnitTests {
 			CallableMongoScript script = converter.convert(FUNCTION);
 
 			assertThat(script.getCode(), notNullValue());
-			assertThat(script.getCode().toString(), equalTo(JS_FUNCTION));
+			assertThat(script.getCode(), equalTo(JS_FUNCTION));
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsInstanceOf.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import org.bson.types.Code;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import org.springframework.data.mongodb.core.convert.CallableMongoScriptConvertsUnitTests.CallableMongoScriptToDboConverterUnitTests;
+import org.springframework.data.mongodb.core.convert.MongoConverters.CallableMongoScriptToDBObjectConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToCallableMongoScriptCoverter;
+import org.springframework.data.mongodb.core.script.CallableMongoScript;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CallableMongoScriptToDboConverterUnitTests.class })
+public class CallableMongoScriptConvertsUnitTests {
+
+	static final String FUNCTION_NAME = "echo";
+	static final String JS_FUNCTION = "function(x) { return x; }";
+	static final CallableMongoScript ECHO_SCRIPT = new CallableMongoScript(FUNCTION_NAME, JS_FUNCTION);
+	static final DBObject FUNCTION = new BasicDBObjectBuilder().add("_id", FUNCTION_NAME)
+			.add("value", new Code(JS_FUNCTION)).get();
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	public static class CallableMongoScriptToDboConverterUnitTests {
+
+		CallableMongoScriptToDBObjectConverter converter = CallableMongoScriptToDBObjectConverter.INSTANCE;
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldReturnEmptyDboWhenScriptIsNull() {
+			assertThat(converter.convert(null), IsEqual.<DBObject> equalTo(new BasicDBObject()));
+		}
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldConvertScriptNameCorreclty() {
+
+			DBObject dbo = converter.convert(ECHO_SCRIPT);
+
+			Object id = dbo.get("_id");
+			assertThat(id, instanceOf(String.class));
+			assertThat(id, IsEqual.<Object> equalTo(FUNCTION_NAME));
+		}
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldConvertScriptCodeCorreclty() {
+
+			DBObject dbo = converter.convert(ECHO_SCRIPT);
+
+			Object code = dbo.get("value");
+			assertThat(code, instanceOf(Code.class));
+			assertThat(code.toString(), equalTo(JS_FUNCTION));
+		}
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldNotAddValueWhenCodeIsNull() {
+
+			DBObject dbo = converter.convert(new CallableMongoScript("named"));
+
+			assertThat(dbo.containsField("value"), is(false));
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	public static class DboToCallableMongoScriptConverterUnitTests {
+
+		DBObjectToCallableMongoScriptCoverter converter = DBObjectToCallableMongoScriptCoverter.INSTANCE;
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldReturnNullIfSourceIsNull() {
+			assertThat(converter.convert(null), nullValue());
+		}
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldConvertIdCorreclty() {
+
+			CallableMongoScript script = converter.convert(FUNCTION);
+
+			assertThat(script.getName(), equalTo(FUNCTION_NAME));
+		}
+
+		/**
+		 * @see DATAMONGO-479
+		 */
+		@Test
+		public void convertShouldConvertScriptValueCorreclty() {
+
+			CallableMongoScript script = converter.convert(FUNCTION);
+
+			assertThat(script.getCode(), notNullValue());
+			assertThat(script.getCode().toString(), equalTo(JS_FUNCTION));
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/CallableMongoScriptConvertsUnitTests.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.mongodb.core.convert;
 
-import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.hamcrest.core.IsNull.*;
@@ -88,17 +87,6 @@ public class CallableMongoScriptConvertsUnitTests {
 			Object code = dbo.get("value");
 			assertThat(code, instanceOf(Code.class));
 			assertThat(code.toString(), equalTo(JS_FUNCTION));
-		}
-
-		/**
-		 * @see DATAMONGO-479
-		 */
-		@Test
-		public void convertShouldNotAddValueWhenCodeIsNull() {
-
-			DBObject dbo = converter.convert(new CallableMongoScript("named"));
-
-			assertThat(dbo.containsField("value"), is(false));
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/CallableMongoScriptUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/CallableMongoScriptUnitTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.mongodb.core.script;
 
 import static org.hamcrest.core.IsEqual.*;
-import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
@@ -31,7 +30,7 @@ public class CallableMongoScriptUnitTests {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenScriptNameIsNull() {
-		new CallableMongoScript(null);
+		new CallableMongoScript(null, "return 1;");
 	}
 
 	/**
@@ -39,7 +38,7 @@ public class CallableMongoScriptUnitTests {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenScriptNameIsEmptyString() {
-		new CallableMongoScript("");
+		new CallableMongoScript("", "return 1");
 	}
 
 	/**
@@ -60,8 +59,7 @@ public class CallableMongoScriptUnitTests {
 
 		CallableMongoScript script = new CallableMongoScript("echo", jsFunction);
 
-		assertThat(script.getCode(), notNullValue());
-		assertThat(script.getCode().toString(), equalTo(jsFunction));
+		assertThat(script.getCode(), equalTo(jsFunction));
 	}
 
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/CallableMongoScriptUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/CallableMongoScriptUnitTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.script;
+
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Christoph Strobl
+ */
+public class CallableMongoScriptUnitTests {
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenScriptNameIsNull() {
+		new CallableMongoScript(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenScriptNameIsEmptyString() {
+		new CallableMongoScript("");
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenRawScriptIsEmptyString() {
+		new CallableMongoScript("foo", "");
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void getCodeShouldReturnCodeRepresentationOfRawScript() {
+
+		String jsFunction = "function(x) { return x; }";
+
+		CallableMongoScript script = new CallableMongoScript("echo", jsFunction);
+
+		assertThat(script.getCode(), notNullValue());
+		assertThat(script.getCode().toString(), equalTo(jsFunction));
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/ExecutableMongoScriptUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/script/ExecutableMongoScriptUnitTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.script;
+
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * @author Christoph Strobl
+ */
+public class ExecutableMongoScriptUnitTests {
+
+	public @Rule ExpectedException expectedException = ExpectedException.none();
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void constructorShouldThrowExceptionWhenRawScriptIsNull() {
+
+		expectException(IllegalArgumentException.class, "must not be", "null");
+
+		new ExecutableMongoScript(null);
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void constructorShouldThrowExceptionWhenRawScriptIsEmpty() {
+
+		expectException(IllegalArgumentException.class, "must not be", "empty");
+
+		new ExecutableMongoScript("");
+	}
+
+	/**
+	 * @see DATAMONGO-479
+	 */
+	@Test
+	public void getCodeShouldReturnCodeRepresentationOfRawScript() {
+
+		String jsFunction = "function(x) { return x; }";
+
+		ExecutableMongoScript script = new ExecutableMongoScript(jsFunction);
+
+		assertThat(script.getCode(), notNullValue());
+		assertThat(script.getCode().toString(), equalTo(jsFunction));
+	}
+
+	private void expectException(Class<?> type, String... messageFragments) {
+
+		expectedException.expect(IllegalArgumentException.class);
+
+		if (!ObjectUtils.isEmpty(messageFragments)) {
+			for (String fragment : messageFragments) {
+				expectedException.expectMessage(fragment);
+			}
+		}
+	}
+
+}

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1325,6 +1325,25 @@ MapReduceResults<ValueObject> results = mongoOperations.mapReduce(query, "jmr1",
 
 Note that you can specify additional limit and sort values as well on the query but not skip values.
 
+[[mongo.server-side-scripts]]
+== Script Operations
+
+MongoDB allows to execute JavaScript functions on the server by either directly sending the script or calling a stored one. `ScriptOperations` can be accessed via `MongoTemplate` and provides basic abstraction for `JavaScript` usage.
+
+=== Example Usage
+
+[source,java]
+----
+ScriptOperations scriptOps = template.scriptOps();
+
+ServerSideJavaScript echoScript = new ExecutableMongoScript("function(x) { return x; }");
+scriptOps.execute(echoScript, "directly execute script");
+
+scriptOps.register(new CallableMongoScript("echo", echoScript));
+scriptOps.call("echo", "execute script via name");
+----
+
+
 [[mongo.group]]
 == Group Operations
 


### PR DESCRIPTION
We added `ScriptOperations` to `MongoTemplate`. Those allow storage and execution of javascript function directly on the MongoDB server instance. Having `ScriptOperations` in place builds the foundation for annotation driver support in repository layer.