### PR TITLE
fix wrong parentheses

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
@@ -97,8 +97,8 @@ public class PartTreeMongoQuery extends AbstractMongoQuery {
 			return result;
 
 		} catch (JSONParseException o_O) {
-			throw new IllegalStateException(String.format("Invalid query or field specification in %s!", getQueryMethod(),
-					o_O));
+			throw new IllegalStateException(String.format("Invalid query or field specification in %s!", getQueryMethod()),
+					o_O);
 		}
 	}
 


### PR DESCRIPTION
fix JSONParseException passed not as a second argument to IllegalStateException, but into String.format()