### PR TITLE
DATAMONGO-1118 - MappingMongoConverter uses Converter when reading but not writing Maps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.7.0.BUILD-SNAPSHOT</version>
+			<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1118-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
@@ -245,9 +245,9 @@ public class CustomConversions {
 	}
 
 	/**
-	 * Returns the target type we can write an onject of the given source type to. The returned type might be a subclass
-	 * oth the given expected type though. If {@code expectedTargetType} is {@literal null} we will simply return the
-	 * first target type matching or {@literal null} if no conversion can be found.
+	 * Returns the target type we can write an inject of the given source type to. The returned type might be a subclass
+	 * of the given expected type though. If {@code expectedTargetType} is {@literal null} we will simply return the first
+	 * target type matching or {@literal null} if no conversion can be found.
 	 * 
 	 * @param sourceType must not be {@literal null}
 	 * @param requestedTargetType

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -647,7 +647,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			Object val = entry.getValue();
 			if (conversions.isSimpleType(key.getClass())) {
 
-				String simpleKey = potentiallyConvertMapKey(key);
+				String simpleKey = potentiallyEscapeMapKey(potentiallyConvertMapKey(key));
 				if (val == null || conversions.isSimpleType(val.getClass())) {
 					writeSimpleInternal(val, dbo, simpleKey);
 				} else if (val instanceof Collection || val.getClass().isArray()) {
@@ -670,16 +670,15 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 	private String potentiallyConvertMapKey(Object key) {
 
-		String stringKey = null;
-		if (key instanceof String
-				|| !(conversions.hasCustomWriteTarget(key.getClass()) && conversions.getCustomWriteTarget(key.getClass())
-						.equals(String.class))) {
-			stringKey = key.toString();
-		} else {
-			stringKey = (String) getPotentiallyConvertedSimpleWrite(key);
+		if (key instanceof String) {
+			return (String) key;
 		}
 
-		return potentiallyEscapeMapKey(stringKey);
+		if (conversions.hasCustomWriteTarget(key.getClass(), String.class)) {
+			return (String) getPotentiallyConvertedSimpleWrite(key);
+		}
+
+		return key.toString();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -646,9 +646,8 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			Object key = entry.getKey();
 			Object val = entry.getValue();
 			if (conversions.isSimpleType(key.getClass())) {
-				// Don't use conversion service here as removal of ObjectToString converter results in some primitive types not
-				// being convertable
-				String simpleKey = potentiallyEscapeMapKey(key.toString());
+
+				String simpleKey = potentiallyConvertMapKey(key);
 				if (val == null || conversions.isSimpleType(val.getClass())) {
 					writeSimpleInternal(val, dbo, simpleKey);
 				} else if (val instanceof Collection || val.getClass().isArray()) {
@@ -667,6 +666,20 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		}
 
 		return dbo;
+	}
+
+	private String potentiallyConvertMapKey(Object key) {
+
+		String stringKey = null;
+		if (key instanceof String
+				|| !(conversions.hasCustomWriteTarget(key.getClass()) && conversions.getCustomWriteTarget(key.getClass())
+						.equals(String.class))) {
+			stringKey = key.toString();
+		} else {
+			stringKey = (String) getPotentiallyConvertedSimpleWrite(key);
+		}
+
+		return potentiallyEscapeMapKey(stringKey);
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -54,12 +54,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
@@ -1962,6 +1965,68 @@ public class MappingMongoConverterUnitTests {
 		assertThat(converter.read(TypeWithLocalDateTime.class, result).date, is(reference));
 	}
 
+	/**
+	 * @see DATAMONGO-1118
+	 */
+	@Test
+	public void convertsMapKeyUsingCustomConverterForAndBackwards() {
+
+		MappingMongoConverter converter = new MappingMongoConverter(resolver, mappingContext);
+		converter.setCustomConversions(new CustomConversions(Arrays.asList(new FooBarEnumToStringConverter(),
+				new StringToFooNumConverter())));
+		converter.afterPropertiesSet();
+
+		ClassWithMapUsingEnumAsKey source = new ClassWithMapUsingEnumAsKey();
+		source.map = new HashMap<MappingMongoConverterUnitTests.FooBarEnum, String>();
+		source.map.put(FooBarEnum.FOO, "wohoo");
+
+		DBObject target = new BasicDBObject();
+		converter.write(source, target);
+
+		assertThat(converter.read(ClassWithMapUsingEnumAsKey.class, target).map, equalTo(source.map));
+	}
+
+	/**
+	 * @see DATAMONGO-1118
+	 */
+	@Test
+	public void writesMapKeyUsingCustomConverter() {
+
+		MappingMongoConverter converter = new MappingMongoConverter(resolver, mappingContext);
+		converter.setCustomConversions(new CustomConversions(Arrays.asList(new FooBarEnumToStringConverter())));
+		converter.afterPropertiesSet();
+
+		ClassWithMapUsingEnumAsKey source = new ClassWithMapUsingEnumAsKey();
+		source.map = new HashMap<MappingMongoConverterUnitTests.FooBarEnum, String>();
+		source.map.put(FooBarEnum.FOO, "spring");
+		source.map.put(FooBarEnum.BAR, "data");
+
+		DBObject target = new BasicDBObject();
+		converter.write(source, target);
+
+		DBObject map = DBObjectTestUtils.getAsDBObject(target, "map");
+
+		assertThat(map.containsField("foo-enum-value"), is(true));
+		assertThat(map.containsField("bar-enum-value"), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1118
+	 */
+	@Test
+	public void readsMapKeyUsingCustomConverter() {
+
+		MappingMongoConverter converter = new MappingMongoConverter(resolver, mappingContext);
+		converter.setCustomConversions(new CustomConversions(Arrays.asList(new StringToFooNumConverter())));
+		converter.afterPropertiesSet();
+
+		DBObject source = new BasicDBObject("map", new BasicDBObject("foo-enum-value", "spring"));
+
+		ClassWithMapUsingEnumAsKey target = converter.read(ClassWithMapUsingEnumAsKey.class, source);
+
+		assertThat(target.map.get(FooBarEnum.FOO), is("spring"));
+	}
+
 	static class GenericType<T> {
 		T content;
 	}
@@ -2258,4 +2323,49 @@ public class MappingMongoConverterUnitTests {
 			this.date = LocalDateTime.now();
 		}
 	}
+
+	static enum FooBarEnum {
+		FOO, BAR;
+	}
+
+	static class ClassWithMapUsingEnumAsKey {
+		Map<FooBarEnum, String> map;
+	}
+
+	@WritingConverter
+	static class FooBarEnumToStringConverter implements Converter<FooBarEnum, String> {
+
+		@Override
+		public String convert(FooBarEnum source) {
+			if (source == null) {
+				return null;
+			}
+
+			return FooBarEnum.FOO.equals(source) ? "foo-enum-value" : "bar-enum-value";
+		}
+
+	}
+
+	@ReadingConverter
+	static class StringToFooNumConverter implements Converter<String, FooBarEnum> {
+
+		@Override
+		public FooBarEnum convert(String source) {
+
+			if (source == null) {
+				return null;
+			}
+
+			if (source.equals("foo-enum-value")) {
+				return FooBarEnum.FOO;
+			}
+			if (source.equals("bar-enum-value")) {
+				return FooBarEnum.BAR;
+			}
+
+			throw new ConversionNotSupportedException(source, String.class, null);
+		}
+
+	}
+
 }


### PR DESCRIPTION
We now allow conversions of map keys using `CustomConverter` implementation as long as the conversion target type is a `String`.