### PR TITLE
DATAMONGO-1135 - Convert GeoJson to $geometry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.7.0.BUILD-SNAPSHOT</version>
+			<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1135-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
@@ -469,12 +469,12 @@ abstract class GeoConverters {
 
 			Object geometry = source.getGeometry();
 
-			DBObject $geometry = new BasicDBObject();
+			DBObject geometryDbo = new BasicDBObject();
 
 			if (geometry instanceof Point) {
 
-				$geometry.put("type", "Point");
-				$geometry.put("coordinates", toList((Point) geometry));
+				geometryDbo.put("type", "Point");
+				geometryDbo.put("coordinates", toList((Point) geometry));
 			}
 
 			else if (geometry instanceof double[]) {
@@ -484,13 +484,13 @@ abstract class GeoConverters {
 					throw new IllegalArgumentException("Point coordinates need to have x and y value.");
 				}
 
-				$geometry.put("type", "Point");
-				$geometry.put("coordinates", toList(new Point(values[0], values[1])));
+				geometryDbo.put("type", "Point");
+				geometryDbo.put("coordinates", toList(new Point(values[0], values[1])));
 			}
 
 			else if (geometry instanceof Box) {
 
-				$geometry.put("type", "Polygon");
+				geometryDbo.put("type", "Polygon");
 
 				Point p1 = ((Box) geometry).getFirst();
 				Point p3 = ((Box) geometry).getSecond();
@@ -500,12 +500,12 @@ abstract class GeoConverters {
 
 				Point p5 = ((Box) geometry).getFirst();
 
-				$geometry.put("coordinates", toCoordinates(p1, p2, p3, p4, p5));
+				geometryDbo.put("coordinates", toCoordinates(p1, p2, p3, p4, p5));
 			}
 
 			else if (geometry instanceof Polygon) {
 
-				$geometry.put("type", "Polygon");
+				geometryDbo.put("type", "Polygon");
 
 				List<Point> points = new ArrayList<Point>(((Polygon) geometry).getPoints());
 
@@ -516,7 +516,7 @@ abstract class GeoConverters {
 					points.add(first);
 				}
 
-				$geometry.put("coordinates", toCoordinates(points));
+				geometryDbo.put("coordinates", toCoordinates(points));
 			}
 
 			else if (geometry instanceof Circle) {
@@ -543,7 +543,7 @@ abstract class GeoConverters {
 				throw new InvalidDataAccessApiUsageException(String.format("Unknown GeoJson type %s!", geometry.getClass()));
 			}
 
-			return new BasicDBObject("$geometry", $geometry);
+			return geometryDbo;
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.bson.BSONObject;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.geo.Box;
@@ -29,7 +31,7 @@ import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
-import org.springframework.data.geo.Shape;
+import org.springframework.data.mongodb.core.geo.GeoJson;
 import org.springframework.data.mongodb.core.geo.Sphere;
 import org.springframework.data.mongodb.core.query.GeoCommand;
 import org.springframework.util.Assert;
@@ -43,6 +45,7 @@ import com.mongodb.DBObject;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 1.5
  */
 abstract class GeoConverters {
@@ -69,7 +72,8 @@ abstract class GeoConverters {
 				, DbObjectToSphereConverter.INSTANCE //
 				, DbObjectToPointConverter.INSTANCE //
 				, PointToDbObjectConverter.INSTANCE //
-				, GeoCommandToDbObjectConverter.INSTANCE);
+				, GeoCommandToDbObjectConverter.INSTANCE //
+				, GeoJsonToDbObjectConverter.INSTANCE);
 	}
 
 	/**
@@ -409,7 +413,7 @@ abstract class GeoConverters {
 
 			BasicDBList argument = new BasicDBList();
 
-			Shape shape = source.getShape();
+			Object shape = source.getShape();
 
 			if (shape instanceof Box) {
 
@@ -442,7 +446,125 @@ abstract class GeoConverters {
 		}
 	}
 
+	/**
+	 * Converts a {@link GeoJson} into a {@link DBObject}.
+	 * 
+	 * @author Christoph Strobl
+	 * @since 1.7
+	 */
+	public static enum GeoJsonToDbObjectConverter implements Converter<GeoJson<?>, DBObject> {
+
+		INSTANCE;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+		 */
+		@Override
+		public DBObject convert(GeoJson<?> source) {
+
+			if (source == null) {
+				return null;
+			}
+
+			Object geometry = source.getGeometry();
+
+			DBObject $geometry = new BasicDBObject();
+
+			if (geometry instanceof Point) {
+
+				$geometry.put("type", "Point");
+				$geometry.put("coordinates", toList((Point) geometry));
+			}
+
+			else if (geometry instanceof double[]) {
+
+				double[] values = (double[]) geometry;
+				if (values.length != 2) {
+					throw new IllegalArgumentException("Point coordinates need to have x and y value.");
+				}
+
+				$geometry.put("type", "Point");
+				$geometry.put("coordinates", toList(new Point(values[0], values[1])));
+			}
+
+			else if (geometry instanceof Box) {
+
+				$geometry.put("type", "Polygon");
+
+				Point p1 = ((Box) geometry).getFirst();
+				Point p3 = ((Box) geometry).getSecond();
+
+				Point p2 = new Point(p1.getX(), p3.getY());
+				Point p4 = new Point(p3.getX(), p1.getY());
+
+				Point p5 = ((Box) geometry).getFirst();
+
+				$geometry.put("coordinates", toCoordinates(p1, p2, p3, p4, p5));
+			}
+
+			else if (geometry instanceof Polygon) {
+
+				$geometry.put("type", "Polygon");
+
+				List<Point> points = new ArrayList<Point>(((Polygon) geometry).getPoints());
+
+				Point first = points.get(0);
+				Point last = points.get(points.size() - 1);
+
+				if (!first.equals(last)) {
+					points.add(first);
+				}
+
+				$geometry.put("coordinates", toCoordinates(points));
+			}
+
+			else if (geometry instanceof Circle) {
+
+				Circle circle = (Circle) geometry;
+
+				BasicDBList argument = new BasicDBList();
+				argument.add(toList(circle.getCenter()));
+				argument.add(circle.getRadius().getNormalizedValue());
+
+				return new BasicDBObject("$center", argument);
+			}
+
+			else if (geometry instanceof Sphere) {
+
+				Sphere sphere = (Sphere) geometry;
+
+				BasicDBList argument = new BasicDBList();
+				argument.add(toList(sphere.getCenter()));
+				argument.add(sphere.getRadius().getNormalizedValue());
+
+				return new BasicDBObject("$centerSphere", argument);
+			} else {
+				throw new InvalidDataAccessApiUsageException(String.format("Unknown GeoJson type %s!", geometry.getClass()));
+			}
+
+			return new BasicDBObject("$geometry", $geometry);
+		}
+	}
+
 	static List<Double> toList(Point point) {
 		return Arrays.asList(point.getX(), point.getY());
+	}
+
+	static BSONObject toCoordinates(Point... points) {
+		return toCoordinates(Arrays.asList(points));
+	}
+
+	static BSONObject toCoordinates(List<Point> points) {
+
+		BasicDBList pointList = new BasicDBList();
+		for (Point point : points) {
+			pointList.add(toList(point));
+		}
+
+		BasicDBList coordinates = new BasicDBList();
+		coordinates.add(pointList);
+
+		return coordinates;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -64,9 +64,9 @@ public class UpdateMapper extends QueryMapper {
 	 *      org.springframework.data.mongodb.core.mapping.MongoPersistentEntity)
 	 */
 	@Override
-	protected Object delegateConvertToMongoType(Object source, MongoPersistentEntity<?> entity) {
-		return entity == null ? super.delegateConvertToMongoType(source, null) : converter.convertToMongoType(source,
-				entity.getTypeInformation());
+	protected Object delegateConvertToMongoType(Object source, MongoPersistentEntity<?> entity, Field documentField) {
+		return entity == null ? super.delegateConvertToMongoType(source, null, documentField) : converter
+				.convertToMongoType(source, entity.getTypeInformation());
 	}
 
 	/*
@@ -77,7 +77,7 @@ public class UpdateMapper extends QueryMapper {
 	protected Entry<String, Object> getMappedObjectForField(Field field, Object rawValue) {
 
 		if (isDBObject(rawValue)) {
-			return createMapEntry(field, convertSimpleOrDBObject(rawValue, field.getPropertyEntity()));
+			return createMapEntry(field, convertSimpleOrDBObject(rawValue, field.getPropertyEntity(), field));
 		}
 
 		if (isQuery(rawValue)) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJson.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJson.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * {@link GeoJson} provides a wrapper around geometric structures like {@link Point},...
+ * 
+ * @author Christoph Strobl
+ * @param <T>
+ * @since 1.7
+ */
+public class GeoJson<T> {
+
+	private final T geometry;
+
+	/**
+	 * Creates new {@link GeoJson}.
+	 * 
+	 * @param geometry
+	 */
+	public GeoJson(T geometry) {
+
+		Assert.notNull(geometry, "Geometry to construct GeoJson must not be null!");
+		this.geometry = geometry;
+	}
+
+	/**
+	 * Get the underlying geometry object.
+	 * 
+	 * @return
+	 */
+	public T getGeometry() {
+		return geometry;
+	}
+
+	/**
+	 * Creates {@link GeoJson} for {@link Point}.
+	 * 
+	 * @param point must not be {@literal null}.
+	 * @return
+	 */
+	public static GeoJson<Point> point(Point point) {
+		return new GeoJson<Point>(point);
+	}
+
+	/**
+	 * Creates {@link GeoJson} for {@link Point} with given {@code x,y} coordinates.
+	 * 
+	 * @param x
+	 * @param y
+	 * @return
+	 */
+	public static GeoJson<Point> point(double x, double y) {
+		return new GeoJson<Point>(new Point(x, y));
+	}
+
+	/**
+	 * Creates {@link GeoJson} for given {@link Box}.
+	 * 
+	 * @param box must not be {@literal null}.
+	 * @return
+	 */
+	public static GeoJson<Polygon> polygon(Box box) {
+
+		Point p0 = box.getFirst();
+		Point p2 = box.getSecond();
+
+		Point p1 = new Point(p0.getX(), p2.getY());
+		Point p3 = new Point(p2.getX(), p0.getY());
+
+		return polygon(p0, p1, p2, p3, p0);
+	}
+
+	/**
+	 * Creates {@link GeoJson} for given {@link Polygon}.
+	 * 
+	 * @param polygon must not be {@literal null}.
+	 * @return
+	 */
+	public static GeoJson<Polygon> polygon(Polygon polygon) {
+		return new GeoJson<Polygon>(polygon);
+	}
+
+	/**
+	 * Creates {@link GeoJson} for {@link Polygon} defined by given {@link Point}s.
+	 * 
+	 * @param p0 must not be {@literal null}.
+	 * @param p1 must not be {@literal null}.
+	 * @param p2 must not be {@literal null}.
+	 * @param p3 must not be {@literal null}.
+	 * @param others
+	 * @return
+	 */
+	public static GeoJson<Polygon> polygon(Point p0, Point p1, Point p2, Point p3, Point... others) {
+
+		List<Point> points = new ArrayList<Point>(Arrays.asList(p0, p1, p2, p3));
+		if (!ObjectUtils.isEmpty(others)) {
+			points.addAll(Arrays.asList(others));
+		}
+		return new GeoJson<Polygon>(new Polygon(points));
+	}
+
+	/**
+	 * Creates {@link GeoJson} for {@link Polygon} defined by given {@link Point}s.
+	 * 
+	 * @param p0 must not be {@literal null}.
+	 * @param p1 must not be {@literal null}.
+	 * @param p2 must not be {@literal null}.
+	 * @return
+	 */
+	public static GeoJson<Polygon> triangle(Point p0, Point p1, Point p2) {
+		return polygon(p0, p1, p2, p0);
+	}
+
+	/**
+	 * Creates {@link GeoJson} for {@link Polygon} defined by given {@link Point}s.
+	 * 
+	 * @param p0 must not be {@literal null}.
+	 * @param p1 must not be {@literal null}.
+	 * @param p2 must not be {@literal null}.
+	 * @param p3 must not be {@literal null}.
+	 * @param others
+	 * @return
+	 */
+	public static GeoJson<Polygon> rectangle(Point p0, Point p1, Point p2, Point p3) {
+		return polygon(p0, p1, p2, p3, p0);
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
@@ -25,12 +25,16 @@ import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Shape;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.mongodb.core.geo.GeoJson;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.DBObject;
@@ -53,6 +57,8 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 	private static final Set<Class<?>> SUPPORTED_ID_TYPES = new HashSet<Class<?>>();
 	private static final Set<String> SUPPORTED_ID_PROPERTY_NAMES = new HashSet<String>();
 
+	private static final Set<Class<?>> GEO_TYPES = new HashSet<Class<?>>();
+
 	static {
 
 		SUPPORTED_ID_TYPES.add(ObjectId.class);
@@ -61,6 +67,10 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 
 		SUPPORTED_ID_PROPERTY_NAMES.add("id");
 		SUPPORTED_ID_PROPERTY_NAMES.add("_id");
+
+		GEO_TYPES.add(Point.class);
+		GEO_TYPES.add(Shape.class);
+		GEO_TYPES.add(GeoJson.class);
 	}
 
 	private final FieldNamingStrategy fieldNamingStrategy;
@@ -228,5 +238,19 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 	@Override
 	public boolean isTextScoreProperty() {
 		return isAnnotationPresent(TextScore.class);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.mapping.MongoPersistentProperty#isGeometry()
+	 */
+	@Override
+	public boolean isGeometry() {
+
+		if (isAnnotationPresent(GeoSpatialIndexed.class)) {
+			return true;
+		}
+
+		return GEO_TYPES.contains(rawType);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,4 +119,14 @@ public interface MongoPersistentProperty extends PersistentProperty<MongoPersist
 	 * @return
 	 */
 	boolean usePropertyAccess();
+
+	/**
+	 * Returns whether the property refers to a geometry structure such as {@link org.springframework.data.geo.Shape} or
+	 * is {@link org.springframework.data.mongodb.core.index.GeoSpatialIndexed}.
+	 * 
+	 * @return
+	 * @since 1.7
+	 */
+	boolean isGeometry();
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearCommand.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearCommand.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query;
+
+import static org.springframework.util.Assert.*;
+import static org.springframework.util.ObjectUtils.*;
+
+import org.springframework.data.geo.Point;
+
+/**
+ * {@link NearCommand} used to define geo spatial criterion parameter for constructing {@literal $near} and
+ * {@literal $nearSphere} commands.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class NearCommand {
+
+	private final Point coordinates;
+	private double minDistance;
+	private double maxDistance;
+
+	/**
+	 * Creates new {@link NearCommand}.
+	 * 
+	 * @param point must not be {@literal null}.
+	 */
+	public NearCommand(Point point) {
+
+		notNull(point, "Point for NearCommand must not be null!");
+		this.coordinates = point;
+	}
+
+	/**
+	 * Creates new {@link NearCommand}.
+	 * 
+	 * @param must not be {@literal null}.
+	 * @param maxDistance
+	 */
+	public NearCommand(Point o, double maxDistance) {
+
+		this(o);
+		this.maxDistance = maxDistance;
+	}
+
+	/**
+	 * Get center coordinates
+	 * 
+	 * @return
+	 */
+	public Point getCoordinates() {
+		return coordinates;
+	}
+
+	/**
+	 * Get maxDistance
+	 * 
+	 * @return
+	 */
+	public double getMaxDistance() {
+		return maxDistance;
+	}
+
+	/**
+	 * @param maxDistance
+	 */
+	public void setMaxDistance(double maxDistance) {
+		this.maxDistance = maxDistance;
+	}
+
+	/**
+	 * @param minDistance
+	 */
+	public void setMinDistance(double minDistance) {
+		this.minDistance = minDistance;
+	}
+
+	@Override
+	public int hashCode() {
+
+		int result = nullSafeHashCode(coordinates);
+		result += nullSafeHashCode(maxDistance);
+		result += nullSafeHashCode(minDistance);
+		return result;
+
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof NearCommand)) {
+			return false;
+		}
+		NearCommand that = (NearCommand) obj;
+		return nullSafeEquals(this.coordinates, that.coordinates) && nullSafeEquals(this.maxDistance, that.maxDistance)
+				&& nullSafeEquals(this.minDistance, that.minDistance);
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,11 +213,10 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 					return criteria.near(point);
 				} else {
 					if (!Metrics.NEUTRAL.equals(distance.getMetric())) {
-						criteria.nearSphere(point);
+						criteria.nearSphere(point, distance.getNormalizedValue());
 					} else {
-						criteria.near(point);
+						criteria.near(point, distance.getNormalizedValue());
 					}
-					criteria.maxDistance(distance.getNormalizedValue());
 				}
 				return criteria;
 			case WITHIN:

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/Venue.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/Venue.java
@@ -24,8 +24,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "newyork")
 public class Venue {
 
-	@Id
-	private String id;
+	@Id private String id;
 	private String name;
 	private double[] location;
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoJsonToDbObjectConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoJsonToDbObjectConverterUnitTests.java
@@ -67,8 +67,7 @@ public class GeoJsonToDbObjectConverterUnitTests {
 		BasicDBList values = new BasicDBList();
 		values.add(new double[] { SINGLE_POINT.getX(), SINGLE_POINT.getY() });
 
-		assertThat(point,
-				isBsonObject().containing("$geometry.coordinates", Arrays.asList(SINGLE_POINT.getX(), SINGLE_POINT.getY())));
+		assertThat(point, isBsonObject().containing("coordinates", Arrays.asList(SINGLE_POINT.getX(), SINGLE_POINT.getY())));
 	}
 
 	/**
@@ -107,10 +106,9 @@ public class GeoJsonToDbObjectConverterUnitTests {
 	@SuppressWarnings("unchecked")
 	void validatePolygon(DBObject dbo, Point... expectedCoordinates) {
 
-		DBObject $geometry = DBObjectTestUtils.getAsDBObject(dbo, "$geometry");
-		assertThat(DBObjectTestUtils.getTypedValue($geometry, "type", String.class), equalTo("Polygon"));
+		assertThat(DBObjectTestUtils.getTypedValue(dbo, "type", String.class), equalTo("Polygon"));
 
-		BasicDBList coordinates = DBObjectTestUtils.getAsDBList($geometry, "coordinates");
+		BasicDBList coordinates = DBObjectTestUtils.getAsDBList(dbo, "coordinates");
 		BasicDBList values = (BasicDBList) coordinates.get(0);
 
 		for (int i = 0; i < values.size(); i++) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoJsonToDbObjectConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoJsonToDbObjectConverterUnitTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.hamcrest.core.IsCollectionContaining.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.core.geo.GeoJson.*;
+import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Point;
+import org.springframework.data.mongodb.core.DBObjectTestUtils;
+import org.springframework.data.mongodb.core.convert.GeoConverters.GeoJsonToDbObjectConverter;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.DBObject;
+
+/**
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class GeoJsonToDbObjectConverterUnitTests {
+
+	GeoJsonToDbObjectConverter converter = GeoJsonToDbObjectConverter.INSTANCE;
+
+	static final Point SINGLE_POINT = new Point(100, 50);
+
+	static final Point POLYGON_0 = new Point(0, 0);
+	static final Point POLYGON_1 = new Point(100, 0);
+	static final Point POLYGON_2 = new Point(100, 100);
+	static final Point POLYGON_3 = new Point(0, 100);
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	public void convertShouldReturnNullWhenGivenNull() {
+		assertThat(converter.convert(null), nullValue());
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConvertGeoJsonPointCorrectly() {
+
+		DBObject point = converter.convert(point(SINGLE_POINT));
+
+		BasicDBList values = new BasicDBList();
+		values.add(new double[] { SINGLE_POINT.getX(), SINGLE_POINT.getY() });
+
+		assertThat(point,
+				isBsonObject().containing("$geometry.coordinates", Arrays.asList(SINGLE_POINT.getX(), SINGLE_POINT.getY())));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConvertGeoJsonBoxCorrectly() {
+
+		DBObject dbo = converter.convert(polygon(new Box(POLYGON_0, POLYGON_2)));
+
+		validatePolygon(dbo, POLYGON_0, POLYGON_1, POLYGON_2, POLYGON_3, POLYGON_0);
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConvertGeoJsonPolygonCorrectly() {
+
+		DBObject dbo = converter.convert(polygon(POLYGON_0, POLYGON_1, POLYGON_2, POLYGON_3, POLYGON_0));
+
+		validatePolygon(dbo, POLYGON_0, POLYGON_1, POLYGON_2, POLYGON_3, POLYGON_0);
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldAddMissingClosingPointWhenConvertGeoJsonPolygon() {
+
+		DBObject dbo = converter.convert(polygon(POLYGON_0, POLYGON_1, POLYGON_2, POLYGON_3));
+
+		validatePolygon(dbo, POLYGON_0, POLYGON_1, POLYGON_2, POLYGON_3, POLYGON_0);
+	}
+
+	@SuppressWarnings("unchecked")
+	void validatePolygon(DBObject dbo, Point... expectedCoordinates) {
+
+		DBObject $geometry = DBObjectTestUtils.getAsDBObject(dbo, "$geometry");
+		assertThat(DBObjectTestUtils.getTypedValue($geometry, "type", String.class), equalTo("Polygon"));
+
+		BasicDBList coordinates = DBObjectTestUtils.getAsDBList($geometry, "coordinates");
+		BasicDBList values = (BasicDBList) coordinates.get(0);
+
+		for (int i = 0; i < values.size(); i++) {
+			assertThat((List<Double>) values.get(i), hasItems(expectedCoordinates[i].getX(), expectedCoordinates[i].getY()));
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.geo;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metric;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
+import org.springframework.data.mongodb.core.index.GeospatialIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.NearQuery;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class GeoJsonTests {
+
+	@Configuration
+	static class TestConfig extends AbstractMongoConfiguration {
+
+		@Override
+		protected String getDatabaseName() {
+			return "database";
+		}
+
+		@Override
+		public Mongo mongo() throws Exception {
+			return new MongoClient();
+		}
+	}
+
+	@Autowired MongoTemplate template;
+
+	@Before
+	public void setUp() {
+
+		template.setWriteConcern(WriteConcern.FSYNC_SAFE);
+
+		createIndex();
+		addVenues();
+	}
+
+	@After
+	public void tearDown() {
+
+		dropIndex();
+		removeVenues();
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void geoNear() {
+
+		NearQuery geoNear = NearQuery.near(-73, 40, Metrics.KILOMETERS).num(10).maxDistance(150);
+
+		GeoResults<Venue2DSphere> result = template.geoNear(geoNear, Venue2DSphere.class);
+
+		assertThat(result.getContent().size(), is(not(0)));
+		assertThat(result.getAverageDistance().getMetric(), is((Metric) Metrics.KILOMETERS));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void withinCenter() {
+
+		Circle circle = new Circle(-73.99171, 40.738868, 0.01);
+		List<Venue2DSphere> venues = template.find(query(where("location").within(circle)), Venue2DSphere.class);
+		assertThat(venues.size(), is(7));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void withinCenterSphere() {
+
+		Circle circle = new Circle(-73.99171, 40.738868, 0.003712240453784);
+		List<Venue2DSphere> venues = template.find(query(where("location").withinSphere(circle)), Venue2DSphere.class);
+		assertThat(venues.size(), is(11));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void withinBox() {
+
+		Box box = new Box(new Point(-73.99756, 40.73083), new Point(-73.988135, 40.741404));
+		List<Venue2DSphere> venues = template.find(query(where("location").within(box)), Venue2DSphere.class);
+		assertThat(venues.size(), is(4));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void withinPolygon() {
+
+		Point first = new Point(-73.99756, 40.73083);
+		Point second = new Point(-73.99756, 40.741404);
+		Point third = new Point(-73.988135, 40.741404);
+		Point fourth = new Point(-73.988135, 40.73083);
+
+		Polygon polygon = new Polygon(first, second, third, fourth);
+
+		List<Venue2DSphere> venues = template.find(query(where("location").within(polygon)), Venue2DSphere.class);
+		assertThat(venues.size(), is(4));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void nearPoint() {
+
+		Point point = new Point(-73.99171, 40.738868);
+
+		List<Venue2DSphere> venues = template.find(query(where("location").near(point).maxDistance(0.01)),
+				Venue2DSphere.class);
+		assertThat(venues.size(), is(1));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void nearSphere() {
+
+		Point point = new Point(-73.99171, 40.738868);
+		Query query = query(where("location").nearSphere(point).maxDistance(0.003712240453784));
+		List<Venue2DSphere> venues = template.find(query, Venue2DSphere.class);
+		assertThat(venues.size(), is(1));
+	}
+
+	private void addVenues() {
+
+		template.insert(new Venue2DSphere("Penn Station", -73.99408, 40.75057));
+		template.insert(new Venue2DSphere("10gen Office", -73.99171, 40.738868));
+		template.insert(new Venue2DSphere("Flatiron Building", -73.988135, 40.741404));
+		template.insert(new Venue2DSphere("Players Club", -73.997812, 40.739128));
+		template.insert(new Venue2DSphere("City Bakery ", -73.992491, 40.738673));
+		template.insert(new Venue2DSphere("Splash Bar", -73.992491, 40.738673));
+		template.insert(new Venue2DSphere("Momofuku Milk Bar", -73.985839, 40.731698));
+		template.insert(new Venue2DSphere("Shake Shack", -73.98820, 40.74164));
+		template.insert(new Venue2DSphere("Penn Station", -73.99408, 40.75057));
+		template.insert(new Venue2DSphere("Empire State Building", -73.98602, 40.74894));
+		template.insert(new Venue2DSphere("Ulaanbaatar, Mongolia", 106.9154, 47.9245));
+		template.insert(new Venue2DSphere("Maplewood, NJ", -74.2713, 40.73137));
+	}
+
+	protected void createIndex() {
+		dropIndex();
+		template.indexOps(Venue2DSphere.class).ensureIndex(
+				new GeospatialIndex("location").typed(GeoSpatialIndexType.GEO_2DSPHERE));
+	}
+
+	protected void dropIndex() {
+		try {
+			template.indexOps(Venue2DSphere.class).dropIndex("location");
+		} catch (Exception e) {
+
+		}
+	}
+
+	protected void removeVenues() {
+		template.dropCollection(Venue2DSphere.class);
+	}
+
+	@Document(collection = "venue2dsphere")
+	static class Venue2DSphere {
+
+		@Id private String id;
+		private String name;
+		private @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE) double[] location;
+
+		@PersistenceConstructor
+		public Venue2DSphere(String name, double[] location) {
+			this.name = name;
+			this.location = location;
+		}
+
+		public Venue2DSphere(String name, double x, double y) {
+			this.name = name;
+			this.location = new double[] { x, y };
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public double[] getLocation() {
+			return location;
+		}
+
+		@Override
+		public String toString() {
+			return "Venue2DSphere [id=" + id + ", name=" + name + ", location=" + Arrays.toString(location) + "]";
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 by the original author(s).
+ * Copyright 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Shape;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.mongodb.core.geo.GeoJson;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.util.ReflectionUtils;
 
@@ -185,6 +189,61 @@ public class BasicMongoPersistentPropertyUnitTests {
 		assertThat(property.isIdProperty(), is(true));
 	}
 
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConsiderPointAsGeoProperty() {
+
+		MongoPersistentProperty property = getPropertyFor(DocumentWithGeoStructures.class, "point");
+
+		assertThat(property.isGeometry(), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConsiderShapeAsGeoProperty() {
+
+		MongoPersistentProperty property = getPropertyFor(DocumentWithGeoStructures.class, "shape");
+
+		assertThat(property.isGeometry(), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConsiderGeoJsonAsGeoProperty() {
+
+		MongoPersistentProperty property = getPropertyFor(DocumentWithGeoStructures.class, "geoJson");
+
+		assertThat(property.isGeometry(), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldConsiderGeoSpatialIndexedPropertyAsGeoProperty() {
+
+		MongoPersistentProperty property = getPropertyFor(DocumentWithGeoStructures.class, "geoIndexed");
+
+		assertThat(property.isGeometry(), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void shouldNotConsiderArbitraryPropertyAsGeoType() {
+
+		MongoPersistentProperty property = getPropertyFor(DocumentWithGeoStructures.class, "justAnArray");
+
+		assertThat(property.isGeometry(), is(false));
+	}
+
 	private MongoPersistentProperty getPropertyFor(Field field) {
 		return getPropertyFor(entity, field);
 	}
@@ -252,5 +311,16 @@ public class BasicMongoPersistentPropertyUnitTests {
 	static class DocumentWithExplicitlyRenamedIdPropertyHavingIdAnnotation {
 
 		@Id @org.springframework.data.mongodb.core.mapping.Field("id") String id;
+	}
+
+	static class DocumentWithGeoStructures {
+
+		double[] justAnArray;
+
+		Point point;
+		Shape shape;
+		GeoJson<double[]> geoJson;
+
+		@GeoSpatialIndexed double[] geoIndexed;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
@@ -95,6 +95,7 @@ public class MapReduceTests {
 		template.dropCollection("jmr2_out");
 		template.dropCollection("jmr1_out");
 		template.dropCollection("jmr1");
+		template.dropCollection("jmrWithGeo");
 	}
 
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package org.springframework.data.mongodb.core.query;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 
 import org.junit.Test;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.InvalidMongoDbApiUsageException;
 
 import com.mongodb.BasicDBObject;
@@ -163,5 +165,29 @@ public class CriteriaTests {
 		DBObject dbo = new Criteria().lt("foo").not().getCriteriaObject();
 
 		assertThat(dbo, equalTo(new BasicDBObjectBuilder().add("$not", new BasicDBObject("$lt", "foo")).get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	@SuppressWarnings("deprecation")
+	public void nearShouldUseSpecialTypeWhenMaxDistanceIsPresent() {
+
+		DBObject dbo = Criteria.where("foo").near(new Point(100, 100)).maxDistance(10).getCriteriaObject();
+
+		assertThat(dbo, isBsonObject().containing("foo.$near", new NearCommand(new Point(100, 100), 10)));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	@SuppressWarnings("deprecation")
+	public void nearSphereShouldUseSpecialTypeWhenMaxDistanceIsPresent() {
+
+		DBObject dbo = Criteria.where("foo").nearSphere(new Point(100, 100)).maxDistance(10).getCriteriaObject();
+
+		assertThat(dbo, isBsonObject().containing("foo.$nearSphere", new NearCommand(new Point(100, 100), 10)));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
@@ -56,8 +56,11 @@ public class IsBsonObject<T extends BSONObject> extends TypeSafeMatcher<T> {
 
 			if (expectation.not) {
 				description.appendText(String.format("Path %s should not be present.", expectation.path));
+			} else if (expectation.value == null) {
+				description.appendText(String.format("Expected to find path %s.", expectation.path));
+			} else {
+				description.appendText(String.format("Expected to find %s for path %s.", expectation.value, expectation.path));
 			}
-			description.appendText(String.format("Expected to find %s for path %s.", expectation.value, expectation.path));
 		}
 
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.test.util;
+
+import static org.springframework.data.mongodb.core.DBObjectTestUtils.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.bson.BSONObject;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsEqual;
+import org.springframework.data.mongodb.core.query.SerializationUtils;
+import org.springframework.util.ClassUtils;
+
+import com.mongodb.BasicDBList;
+
+/**
+ * @author Christoph Strobl
+ * @param <T>
+ */
+public class IsBsonObject<T extends BSONObject> extends TypeSafeMatcher<T> {
+
+	private List<ExpectedBsonContent> expectations = new ArrayList<ExpectedBsonContent>();;
+
+	public static <T extends BSONObject> IsBsonObject<T> isBsonObject() {
+		return new IsBsonObject<T>();
+	}
+
+	@Override
+	protected void describeMismatchSafely(T item, Description mismatchDescription) {
+		mismatchDescription.appendText("was ").appendValue(SerializationUtils.serializeToJsonSafely(item));
+	}
+
+	@Override
+	public void describeTo(Description description) {
+
+		for (ExpectedBsonContent expectation : expectations) {
+
+			if (expectation.not) {
+				description.appendText(String.format("Path %s should not be present.", expectation.path));
+			}
+			description.appendText(String.format("Expected to find %s for path %s.", expectation.value, expectation.path));
+		}
+
+	}
+
+	@Override
+	protected boolean matchesSafely(T item) {
+
+		if (expectations.isEmpty()) {
+			return true;
+		}
+
+		for (ExpectedBsonContent expectation : expectations) {
+
+			Object o = getValue(item, expectation.path);
+
+			if ((o == null && expectation.not) || o == null) {
+				return false;
+			}
+
+			if (expectation.type != null && !o.getClass().equals(expectation.type)) {
+				return false;
+			}
+
+			if (expectation.value != null && !new IsEqual<Object>(expectation.value).matches(o)) {
+				return false;
+			}
+
+		}
+		return true;
+	}
+
+	public IsBsonObject<T> containing(String key) {
+
+		ExpectedBsonContent expected = new ExpectedBsonContent();
+		expected.path = key;
+
+		this.expectations.add(expected);
+		return this;
+	}
+
+	public IsBsonObject<T> containing(String key, Class<?> type) {
+
+		ExpectedBsonContent expected = new ExpectedBsonContent();
+		expected.path = key;
+		expected.type = type;
+
+		this.expectations.add(expected);
+		return this;
+	}
+
+	public IsBsonObject<T> containing(String key, Object value) {
+
+		if (value == null) {
+			return notContaining(key);
+		}
+
+		ExpectedBsonContent expected = new ExpectedBsonContent();
+		expected.path = key;
+		expected.type = ClassUtils.getUserClass(value);
+		expected.value = value;
+
+		this.expectations.add(expected);
+		return this;
+	}
+
+	private IsBsonObject<T> notContaining(String key) {
+
+		ExpectedBsonContent expected = new ExpectedBsonContent();
+		expected.path = key;
+		expected.not = true;
+
+		this.expectations.add(expected);
+		return this;
+	}
+
+	static class ExpectedBsonContent {
+		String path;
+		Class<?> type;
+		Object value;
+		boolean not = false;
+	}
+
+	Object getValue(BSONObject source, String path) {
+
+		String[] fragments = path.split("\\.");
+		if (fragments.length == 1) {
+			return source.get(path);
+		}
+
+		Iterator<String> it = Arrays.asList(fragments).iterator();
+
+		BSONObject dbo = source;
+		while (it.hasNext()) {
+
+			String key = it.next();
+
+			if (key.startsWith("[")) {
+				String indexNumber = key.substring(1, key.indexOf("]"));
+				dbo = getAsDBObject((BasicDBList) dbo, Integer.parseInt(indexNumber));
+			} else {
+
+				if (!it.hasNext()) {
+					return dbo.get(key);
+				}
+
+				Object value = dbo.get(key);
+				if (value instanceof BSONObject) {
+					dbo = (BSONObject) value;
+				} else {
+					return value;
+				}
+			}
+		}
+
+		throw new NoSuchElementException(String.format("Unable to find '%s' in %s.", path, source));
+	}
+
+}


### PR DESCRIPTION
We now support [GeoJson](http://www.geojson.org) structures for queries. Depending on the `GeoSpatialIndexType` we use the legacy format for _2D_ and _GeoJson_ for _2D_Sphere_ indexes. Therfore we inspect the query for specific geo spatial keywords and convert the query parameter according to the information we read from the Entities meta model.