### PR TITLE
Updates to work with the 3.0.x branch of the Java driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
 		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
-		<mongo>2.12.4</mongo>
-		<mongo.osgi>2.12.4</mongo.osgi>
+		<mongo>3.0.0-SNAPSHOT</mongo>
+		<mongo.osgi>3.0.0.BUILD-SNAPSHOT</mongo.osgi>
 	</properties>
 
 	<developers>

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
@@ -74,12 +74,9 @@ abstract class MongoParsingUtils {
 		setPropertyValue(optionsDefBuilder, optionsElement, "connect-timeout", "connectTimeout");
 		setPropertyValue(optionsDefBuilder, optionsElement, "socket-timeout", "socketTimeout");
 		setPropertyValue(optionsDefBuilder, optionsElement, "socket-keep-alive", "socketKeepAlive");
-		setPropertyValue(optionsDefBuilder, optionsElement, "auto-connect-retry", "autoConnectRetry");
-		setPropertyValue(optionsDefBuilder, optionsElement, "max-auto-connect-retry-time", "maxAutoConnectRetryTime");
 		setPropertyValue(optionsDefBuilder, optionsElement, "write-number", "writeNumber");
 		setPropertyValue(optionsDefBuilder, optionsElement, "write-timeout", "writeTimeout");
 		setPropertyValue(optionsDefBuilder, optionsElement, "write-fsync", "writeFsync");
-		setPropertyValue(optionsDefBuilder, optionsElement, "slave-ok", "slaveOk");
 		setPropertyValue(optionsDefBuilder, optionsElement, "ssl", "ssl");
 		setPropertyReference(optionsDefBuilder, optionsElement, "ssl-socket-factory-ref", "sslSocketFactory");
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
@@ -73,9 +73,9 @@ public class DefaultIndexOperations implements IndexOperations {
 			public Object doInCollection(DBCollection collection) throws MongoException, DataAccessException {
 				DBObject indexOptions = indexDefinition.getIndexOptions();
 				if (indexOptions != null) {
-					collection.ensureIndex(indexDefinition.getIndexKeys(), indexOptions);
+					collection.createIndex(indexDefinition.getIndexKeys(), indexOptions);
 				} else {
-					collection.ensureIndex(indexDefinition.getIndexKeys());
+					collection.createIndex(indexDefinition.getIndexKeys());
 				}
 				return null;
 			}
@@ -109,12 +109,7 @@ public class DefaultIndexOperations implements IndexOperations {
 	 * @see org.springframework.data.mongodb.core.IndexOperations#resetIndexCache()
 	 */
 	public void resetIndexCache() {
-		mongoOperations.execute(collectionName, new CollectionCallback<Void>() {
-			public Void doInCollection(DBCollection collection) throws MongoException, DataAccessException {
-				collection.resetIndexCache();
-				return null;
-			}
-		});
+		// there is no more index cache
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
@@ -15,6 +15,11 @@
  */
 package org.springframework.data.mongodb.core;
 
+import com.mongodb.MongoCursorNotFoundException;
+import com.mongodb.MongoException;
+import com.mongodb.MongoInternalException;
+import com.mongodb.MongoSocketException;
+import com.mongodb.MongoTimeoutException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DuplicateKeyException;
@@ -22,16 +27,6 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
-
-import com.mongodb.MongoCursorNotFoundException;
-import com.mongodb.MongoException;
-import com.mongodb.MongoException.CursorNotFound;
-import com.mongodb.MongoException.DuplicateKey;
-import com.mongodb.MongoException.Network;
-import com.mongodb.MongoInternalException;
-import com.mongodb.MongoServerSelectionException;
-import com.mongodb.MongoSocketException;
-import com.mongodb.MongoTimeoutException;
 
 /**
  * Simple {@link PersistenceExceptionTranslator} for Mongo. Convert the given runtime exception to an appropriate
@@ -51,19 +46,15 @@ public class MongoExceptionTranslator implements PersistenceExceptionTranslator 
 
 		// Check for well-known MongoException subclasses.
 
-		if (ex instanceof DuplicateKey || ex instanceof DuplicateKeyException) {
+		if (ex instanceof com.mongodb.DuplicateKeyException || ex instanceof DuplicateKeyException) {
 			return new DuplicateKeyException(ex.getMessage(), ex);
 		}
 
-		if (ex instanceof Network || ex instanceof MongoSocketException) {
+		if (ex instanceof MongoSocketException || ex instanceof MongoSocketException) {
 			return new DataAccessResourceFailureException(ex.getMessage(), ex);
 		}
 
-		if (ex instanceof CursorNotFound || ex instanceof MongoCursorNotFoundException) {
-			return new DataAccessResourceFailureException(ex.getMessage(), ex);
-		}
-
-		if (ex instanceof MongoServerSelectionException) {
+		if (ex instanceof MongoCursorNotFoundException || ex instanceof MongoCursorNotFoundException) {
 			return new DataAccessResourceFailureException(ex.getMessage(), ex);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBean.java
@@ -41,12 +41,9 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 	private int connectTimeout = DEFAULT_MONGO_OPTIONS.connectTimeout;
 	private int socketTimeout = DEFAULT_MONGO_OPTIONS.socketTimeout;
 	private boolean socketKeepAlive = DEFAULT_MONGO_OPTIONS.socketKeepAlive;
-	private boolean autoConnectRetry = DEFAULT_MONGO_OPTIONS.autoConnectRetry;
-	private long maxAutoConnectRetryTime = DEFAULT_MONGO_OPTIONS.maxAutoConnectRetryTime;
 	private int writeNumber = DEFAULT_MONGO_OPTIONS.w;
 	private int writeTimeout = DEFAULT_MONGO_OPTIONS.wtimeout;
 	private boolean writeFsync = DEFAULT_MONGO_OPTIONS.fsync;
-	private boolean slaveOk = DEFAULT_MONGO_OPTIONS.slaveOk;
 	private boolean ssl;
 	private SSLSocketFactory sslSocketFactory;
 
@@ -143,32 +140,6 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 	}
 
 	/**
-	 * Configures whether or not the system retries automatically on a failed connect. This defaults to {@literal false}.
-	 */
-	public void setAutoConnectRetry(boolean autoConnectRetry) {
-		this.autoConnectRetry = autoConnectRetry;
-	}
-
-	/**
-	 * Configures the maximum amount of time in millisecons to spend retrying to open connection to the same server. This
-	 * defaults to {@literal 0}, which means to use the default {@literal 15s} if {@link #autoConnectRetry} is on.
-	 * 
-	 * @param maxAutoConnectRetryTime the maxAutoConnectRetryTime to set
-	 */
-	public void setMaxAutoConnectRetryTime(long maxAutoConnectRetryTime) {
-		this.maxAutoConnectRetryTime = maxAutoConnectRetryTime;
-	}
-
-	/**
-	 * Specifies if the driver is allowed to read from secondaries or slaves. Defaults to {@literal false}.
-	 * 
-	 * @param slaveOk true if the driver should read from secondaries or slaves.
-	 */
-	public void setSlaveOk(boolean slaveOk) {
-		this.slaveOk = slaveOk;
-	}
-
-	/**
 	 * Specifies if the driver should use an SSL connection to Mongo. This defaults to {@literal false}. By default
 	 * {@link SSLSocketFactory#getDefault()} will be used. See {@link #setSslSocketFactory(SSLSocketFactory)} if you want
 	 * to configure a custom factory.
@@ -208,9 +179,6 @@ public class MongoOptionsFactoryBean implements FactoryBean<MongoOptions>, Initi
 		options.connectTimeout = connectTimeout;
 		options.socketTimeout = socketTimeout;
 		options.socketKeepAlive = socketKeepAlive;
-		options.autoConnectRetry = autoConnectRetry;
-		options.maxAutoConnectRetryTime = maxAutoConnectRetryTime;
-		options.slaveOk = slaveOk;
 		options.w = writeNumber;
 		options.wtimeout = writeTimeout;
 		options.fsync = writeFsync;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -102,6 +102,7 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.Bytes;
 import com.mongodb.CommandResult;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -414,15 +415,19 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		}
 	}
 
+	/**
+	 * Execute in a "request".
+	 *
+	 * @param action callback that specified the MongoDB actions to perform on the DB instance
+	 * @param <T> the action tuype
+	 * @return the result of the action
+	 * @deprecated sessions are no longer supported.  This method no longer executed the callback in a "request"
+	 */
+	@Deprecated
 	public <T> T executeInSession(final DbCallback<T> action) {
 		return execute(new DbCallback<T>() {
 			public T doInDB(DB db) throws MongoException, DataAccessException {
-				try {
-					db.requestStart();
-					return action.doInDB(db);
-				} finally {
-					db.requestDone();
-				}
+				return action.doInDB(db);
 			}
 		});
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1526,11 +1526,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		if (mapReduceOptions.getJavaScriptMode() != null) {
 			command.setJsMode(true);
 		}
-		if (!mapReduceOptions.getExtraOptions().isEmpty()) {
-			for (Map.Entry<String, Object> entry : mapReduceOptions.getExtraOptions().entrySet()) {
-				command.addExtraOption(entry.getKey(), entry.getValue());
-			}
-		}
+//		if (!mapReduceOptions.getExtraOptions().isEmpty()) {
+//			for (Map.Entry<String, Object> entry : mapReduceOptions.getExtraOptions().entrySet()) {
+//				command.addExtraOption(entry.getKey(), entry.getValue());
+//			}
+//		}
 		if (mapReduceOptions.getFinalizeFunction() != null) {
 			command.setFinalize(this.replaceWithResourceIfNecessary(mapReduceOptions.getFinalizeFunction()));
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -333,11 +333,34 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		return result;
 	}
 
+	/**
+	 * Executes the command with the given options.  Note that only the {@link com.mongodb.Bytes#QUERYOPTION_SLAVEOK} options is relevant
+	 * when running a command.
+	 *
+	 * @param command a MongoDB command
+	 * @param options query options to use
+	 * @return the command result
+	 * @deprecated Use {@link #executeCommand(com.mongodb.DBObject, com.mongodb.ReadPreference)} instead
+	 */
+	@Deprecated
 	public CommandResult executeCommand(final DBObject command, final int options) {
+
+		return executeCommand(command, (options & Bytes.QUERYOPTION_SLAVEOK) != 0 ?
+									   ReadPreference.secondaryPreferred() : ReadPreference.primary());
+	}
+
+	/**
+	 * Executes the command with the given read preference.
+	 *
+	 * @param command a MongoDB command
+	 * @param readPreference the read preference to use
+	 * @return the command result
+	 */
+	public CommandResult executeCommand(final DBObject command, final ReadPreference readPreference) {
 
 		CommandResult result = execute(new DbCallback<CommandResult>() {
 			public CommandResult doInDB(DB db) throws MongoException, DataAccessException {
-				return db.command(command, options);
+				return db.command(command, readPreference);
 			}
 		});
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1923,39 +1923,6 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	 * @param operation
 	 */
 	protected void handleAnyWriteResultErrors(WriteResult writeResult, DBObject query, MongoActionOperation operation) {
-
-		if (writeResultChecking == WriteResultChecking.NONE) {
-			return;
-		}
-
-		String error = writeResult.getError();
-
-		if (error == null) {
-			return;
-		}
-
-		String message;
-
-		switch (operation) {
-
-			case INSERT:
-			case SAVE:
-				message = String.format("Insert/Save for %s failed: %s", query, error);
-				break;
-			case INSERT_LIST:
-				message = String.format("Insert list failed: %s", error);
-				break;
-			default:
-				message = String.format("Execution of %s%s failed: %s", operation,
-						query == null ? "" : " using query " + query.toString(), error);
-		}
-
-		if (writeResultChecking == WriteResultChecking.EXCEPTION) {
-			throw new MongoDataIntegrityViolationException(message, writeResult, operation);
-		} else {
-			LOGGER.error(message);
-			return;
-		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1524,7 +1524,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 
 	private DBObject copyMapReduceOptions(MapReduceOptions mapReduceOptions, MapReduceCommand command) {
 		if (mapReduceOptions.getJavaScriptMode() != null) {
-			command.addExtraOption("jsMode", true);
+			command.setJsMode(true);
 		}
 		if (!mapReduceOptions.getExtraOptions().isEmpty()) {
 			for (Map.Entry<String, Object> entry : mapReduceOptions.getExtraOptions().entrySet()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -23,6 +23,8 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.framework.ProxyFactory;
@@ -72,6 +74,11 @@ public class DefaultDbRefResolver implements DbRefResolver {
 		this.objenesis = new ObjenesisStd(true);
 	}
 
+	// WARNING: temporary hack
+	public DBObject resolveDBRef(DBRef dbref) {
+		return mongoDbFactory.getDb().getCollection(dbref.getCollectionName()).findOne(new BasicDBObject("_id", dbref.getId()));
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.convert.DbRefResolver#resolveDbRef(org.springframework.data.mongodb.core.mapping.MongoPersistentProperty, org.springframework.data.mongodb.core.convert.DbRefResolverCallback)
@@ -101,7 +108,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 		DB db = mongoDbFactory.getDb();
 		db = annotation != null && StringUtils.hasText(annotation.db()) ? mongoDbFactory.getDb(annotation.db()) : db;
 
-		return new DBRef(db, entity.getCollection(), id);
+		return new DBRef(entity.getCollection(), id);
 	}
 
 	/**
@@ -282,7 +289,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 
 			StringBuilder description = new StringBuilder();
 			if (dbref != null) {
-				description.append(dbref.getRef());
+				description.append(dbref.getCollectionName());
 				description.append(":");
 				description.append(dbref.getId());
 			} else {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -1176,7 +1176,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			return (T) dbref;
 		}
 
-		Object object = dbref == null ? null : path.getPathItem(dbref.getId(), dbref.getRef());
+		Object object = dbref == null ? null : path.getPathItem(dbref.getId(), dbref.getCollectionName());
 
 		if (object != null) {
 			return (T) object;
@@ -1192,6 +1192,10 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	 * @return
 	 */
 	DBObject readRef(DBRef ref) {
-		return ref.fetch();
+		// WARNING: Temporary hack here
+		if (dbRefResolver instanceof DefaultDbRefResolver) {
+			return ((DefaultDbRefResolver) dbRefResolver).resolveDBRef(ref);
+		}
+		throw new UnsupportedOperationException();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -390,7 +390,7 @@ public class QueryMapper {
 		if (source instanceof DBRef) {
 
 			DBRef ref = (DBRef) source;
-			return new DBRef(ref.getDB(), ref.getRef(), convertId(ref.getId()));
+			return new DBRef(ref.getCollectionName(), convertId(ref.getId()));
 		}
 
 		if (source instanceof Iterable) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceResults.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceResults.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core.mapreduce;
 import java.util.Iterator;
 import java.util.List;
 
+import com.mongodb.MapReduceOutput;
 import org.springframework.util.Assert;
 
 import com.mongodb.DBObject;
@@ -53,6 +54,19 @@ public class MapReduceResults<T> implements Iterable<T> {
 		this.mapReduceTiming = parseTiming(rawResults);
 		this.mapReduceCounts = parseCounts(rawResults);
 		this.outputCollection = parseOutputCollection(rawResults);
+	}
+
+	public MapReduceResults(final List<T> mappedResults, final MapReduceOutput mapReduceOutput) {
+
+		Assert.notNull(mappedResults);
+		Assert.notNull(mapReduceOutput);
+
+		this.mappedResults = mappedResults;
+		this.rawResults = null;
+		this.mapReduceTiming = parseTiming(mapReduceOutput);
+		this.mapReduceCounts = parseCounts(mapReduceOutput);
+		this.outputCollection = parseOutputCollection(mapReduceOutput);
+
 	}
 
 	/*
@@ -95,13 +109,17 @@ public class MapReduceResults<T> implements Iterable<T> {
 		return new MapReduceTiming(-1, -1, -1);
 	}
 
-	/**
-	 * Returns the value of the source's field with the given key as {@link Long}.
-	 * 
-	 * @param source
-	 * @param key
-	 * @return
-	 */
+	private MapReduceTiming parseTiming(MapReduceOutput mapReduceOutput) {
+		return new MapReduceTiming(-1, -1, -1);
+	}
+
+		/**
+         * Returns the value of the source's field with the given key as {@link Long}.
+         *
+         * @param source
+         * @param key
+         * @return
+         */
 	private Long getAsLong(DBObject source, String key) {
 		Object raw = source.get(key);
 		return raw instanceof Long ? (Long) raw : (Integer) raw;
@@ -128,6 +146,10 @@ public class MapReduceResults<T> implements Iterable<T> {
 		return MapReduceCounts.NONE;
 	}
 
+	private MapReduceCounts parseCounts(final MapReduceOutput mapReduceOutput) {
+		return new MapReduceCounts(mapReduceOutput.getInputCount(), mapReduceOutput.getEmitCount(), mapReduceOutput.getOutputCount());
+	}
+
 	/**
 	 * Parses the output collection from the raw {@link DBObject} result.
 	 * 
@@ -144,5 +166,9 @@ public class MapReduceResults<T> implements Iterable<T> {
 
 		return resultField instanceof DBObject ? ((DBObject) resultField).get("collection").toString() : resultField
 				.toString();
+	}
+
+	private String parseOutputCollection(final MapReduceOutput mapReduceOutput) {
+		return mapReduceOutput.getCollectionName();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/ServerInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/ServerInfo.java
@@ -50,7 +50,7 @@ public class ServerInfo extends AbstractMonitor {
 		 * UnknownHostException is not necessary anymore, but clients could have
 		 * called this method in a try..catch(UnknownHostException) already
 		 */
-		return getServerStatus().getServerUsed().getHost();
+		return mongo.getAddress().getHost();
 	}
 
 	@ManagedMetric(displayName = "Uptime Estimate")

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQuery.java
@@ -254,7 +254,7 @@ public class StringBasedMongoQuery extends AbstractMongoQuery {
 
 				DBRef dbref = (DBRef) value;
 
-				potentiallyAddBinding(dbref.getRef(), bindings);
+				potentiallyAddBinding(dbref.getCollectionName(), bindings);
 				potentiallyAddBinding(dbref.getId().toString(), bindings);
 
 			} else if (value instanceof DBObject) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
@@ -127,17 +127,6 @@ public class MongoDbFactoryParserIntegrationTests {
 	}
 
 	/**
-	 * @see DATADOC-280
-	 */
-	@Test
-	public void parsesMaxAutoConnectRetryTimeCorrectly() {
-
-		reader.loadBeanDefinitions(new ClassPathResource("namespace/db-factory-bean.xml"));
-		Mongo mongo = factory.getBean(Mongo.class);
-		assertThat(mongo.getMongoOptions().maxAutoConnectRetryTime, is(27L));
-	}
-
-	/**
 	 * @see DATADOC-295
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
@@ -239,12 +239,10 @@ public class MongoNamespaceTests {
 		assertEquals(8, mongoOpts.connectionsPerHost);
 		assertEquals(1000, mongoOpts.connectTimeout);
 		assertEquals(1500, mongoOpts.maxWaitTime);
-		assertEquals(true, mongoOpts.autoConnectRetry);
 		assertEquals(1500, mongoOpts.socketTimeout);
 		assertEquals(4, mongoOpts.threadsAllowedToBlockForConnectionMultiplier);
 		assertEquals(true, mongoOpts.socketKeepAlive);
 		assertEquals(true, mongoOpts.fsync);
-		assertEquals(true, mongoOpts.slaveOk);
 		assertEquals(1, mongoOpts.getWriteConcern().getW());
 		assertEquals(0, mongoOpts.getWriteConcern().getWtimeout());
 		assertEquals(true, mongoOpts.getWriteConcern().fsync());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
@@ -242,7 +242,7 @@ public class MongoNamespaceTests {
 		assertEquals(1500, mongoOpts.socketTimeout);
 		assertEquals(4, mongoOpts.threadsAllowedToBlockForConnectionMultiplier);
 		assertEquals(true, mongoOpts.socketKeepAlive);
-		assertEquals(true, mongoOpts.fsync);
+		assertEquals(true, mongoOpts.getWriteConcern().getFsync());
 		assertEquals(1, mongoOpts.getWriteConcern().getW());
 		assertEquals(0, mongoOpts.getWriteConcern().getWtimeout());
 		assertEquals(true, mongoOpts.getWriteConcern().fsync());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MyWriteConcern.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MyWriteConcern.java
@@ -6,7 +6,6 @@ public class MyWriteConcern {
 
 	public MyWriteConcern(WriteConcern wc) {
 		this._w = wc.getWObject();
-		this._continueOnErrorForInsert = wc.getContinueOnErrorForInsert();
 		this._fsync = wc.getFsync();
 		this._j = wc.getJ();
 		this._wtimeout = wc.getWtimeout();
@@ -16,13 +15,11 @@ public class MyWriteConcern {
 	int _wtimeout = 0;
 	boolean _fsync = false;
 	boolean _j = false;
-	boolean _continueOnErrorForInsert = false;
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + (_continueOnErrorForInsert ? 1231 : 1237);
 		result = prime * result + (_fsync ? 1231 : 1237);
 		result = prime * result + (_j ? 1231 : 1237);
 		result = prime * result + ((_w == null) ? 0 : _w.hashCode());
@@ -39,8 +36,6 @@ public class MyWriteConcern {
 		if (getClass() != obj.getClass())
 			return false;
 		MyWriteConcern other = (MyWriteConcern) obj;
-		if (_continueOnErrorForInsert != other._continueOnErrorForInsert)
-			return false;
 		if (_fsync != other._fsync)
 			return false;
 		if (_j != other._j)

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
@@ -76,7 +76,16 @@ public class DefaultIndexOperationsIntegrationTests {
 
 	@SuppressWarnings("deprecation")
 	private static IndexInfo findAndReturnIndexInfo(Iterable<IndexInfo> candidates, DBObject keys) {
-		return findAndReturnIndexInfo(candidates, DBCollection.genIndexName(keys));
+		StringBuilder name = new StringBuilder();
+		for ( String s : keys.keySet() ){
+			if ( name.length() > 0 )
+				name.append( '_' );
+			name.append( s ).append( '_' );
+			Object val = keys.get( s );
+			if ( val instanceof Number || val instanceof String )
+				name.append( val.toString().replace( ' ', '_' ) );
+		}
+		return findAndReturnIndexInfo(candidates, name.toString());
 	}
 
 	private static IndexInfo findAndReturnIndexInfo(Iterable<IndexInfo> candidates, String name) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoExceptionTranslatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoExceptionTranslatorUnitTests.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.net.UnknownHostException;
-
+import com.mongodb.MongoCursorNotFoundException;
+import com.mongodb.MongoException;
+import com.mongodb.MongoInternalException;
+import com.mongodb.MongoSocketException;
+import com.mongodb.ServerAddress;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,11 +33,15 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
 
-import com.mongodb.MongoException;
-import com.mongodb.MongoException.DuplicateKey;
-import com.mongodb.MongoException.Network;
-import com.mongodb.MongoInternalException;
-import com.mongodb.ServerAddress;
+import java.net.UnknownHostException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link MongoExceptionTranslator}.
@@ -51,7 +54,8 @@ public class MongoExceptionTranslatorUnitTests {
 
 	MongoExceptionTranslator translator;
 
-	@Mock DuplicateKey exception;
+	@Mock
+	com.mongodb.DuplicateKeyException exception;
 
 	@Before
 	public void setUp() {
@@ -68,7 +72,7 @@ public class MongoExceptionTranslatorUnitTests {
 	@Test
 	public void translateNetwork() {
 
-		Network exception = new Network("IOException", new IOException("IOException"));
+		MongoSocketException exception = new MongoSocketException("IOException", new ServerAddress());
 		DataAccessException translatedException = translator.translateExceptionIfPossible(exception);
 
 		expectExceptionWithCauseMessage(translatedException, DataAccessResourceFailureException.class, "IOException");
@@ -78,7 +82,7 @@ public class MongoExceptionTranslatorUnitTests {
 	@Test
 	public void translateCursorNotFound() throws UnknownHostException {
 
-		MongoException.CursorNotFound exception = new MongoException.CursorNotFound(1, new ServerAddress());
+		MongoCursorNotFoundException exception = new MongoCursorNotFoundException(1, new ServerAddress());
 		DataAccessException translatedException = translator.translateExceptionIfPossible(exception);
 
 		expectExceptionWithCauseMessage(translatedException, DataAccessResourceFailureException.class);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBeanUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOptionsFactoryBeanUnitTests.java
@@ -33,20 +33,6 @@ import com.mongodb.MongoOptions;
 public class MongoOptionsFactoryBeanUnitTests {
 
 	/**
-	 * @see DATADOC-280
-	 */
-	@Test
-	public void setsMaxConnectRetryTime() {
-
-		MongoOptionsFactoryBean bean = new MongoOptionsFactoryBean();
-		bean.setMaxAutoConnectRetryTime(27);
-		bean.afterPropertiesSet();
-
-		MongoOptions options = bean.getObject();
-		assertThat(options.maxAutoConnectRetryTime, is(27L));
-	}
-
-	/**
 	 * @see DATAMONGO-764
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1153,12 +1153,12 @@ public class MongoTemplateTests {
 		person.setId(new ObjectId());
 		person.setFirstName("Dave");
 
-		template.setWriteConcern(WriteConcern.NONE);
+		template.setWriteConcern(WriteConcern.UNACKNOWLEDGED);
 		template.save(person);
 		WriteResult result = template.updateFirst(query(where("id").is(person.getId())), update("firstName", "Carter"),
 				PersonWithIdPropertyOfTypeObjectId.class);
 		WriteConcern lastWriteConcern = result.getLastConcern();
-		assertThat(lastWriteConcern, equalTo(WriteConcern.NONE));
+		assertThat(lastWriteConcern, equalTo(WriteConcern.UNACKNOWLEDGED));
 
 		FsyncSafeWriteConcernResolver resolver = new FsyncSafeWriteConcernResolver();
 		template.setWriteConcernResolver(resolver);
@@ -1170,7 +1170,7 @@ public class MongoTemplateTests {
 
 		MongoAction lastMongoAction = resolver.getMongoAction();
 		assertThat(lastMongoAction.getCollectionName(), is("personWithIdPropertyOfTypeObjectId"));
-		assertThat(lastMongoAction.getDefaultWriteConcern(), equalTo(WriteConcern.NONE));
+		assertThat(lastMongoAction.getDefaultWriteConcern(), equalTo(WriteConcern.UNACKNOWLEDGED));
 		assertThat(lastMongoAction.getDocument(), notNullValue());
 		assertThat(lastMongoAction.getEntityType().toString(), is(PersonWithIdPropertyOfTypeObjectId.class.toString()));
 		assertThat(lastMongoAction.getMongoActionOperation(), is(MongoActionOperation.UPDATE));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1107,10 +1107,10 @@ public class MongoTemplateTests {
 			}
 		});
 		MongoTemplate slaveTemplate = new MongoTemplate(factory);
-		slaveTemplate.setReadPreference(ReadPreference.SECONDARY);
+		slaveTemplate.setReadPreference(ReadPreference.secondary());
 		slaveTemplate.execute("readPref", new CollectionCallback<Object>() {
 			public Object doInCollection(DBCollection collection) throws MongoException, DataAccessException {
-				assertThat(collection.getReadPreference(), is(ReadPreference.SECONDARY));
+				assertThat(collection.getReadPreference(), is(ReadPreference.secondary()));
 				assertThat(collection.getDB().getOptions(), is(0));
 				return null;
 			}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1198,8 +1198,8 @@ public class MongoTemplateTests {
 	@Test
 	public void updatesDBRefsCorrectly() {
 
-		DBRef first = new DBRef(factory.getDb(), "foo", new ObjectId());
-		DBRef second = new DBRef(factory.getDb(), "bar", new ObjectId());
+		DBRef first = new DBRef("foo", new ObjectId());
+		DBRef second = new DBRef("bar", new ObjectId());
 
 		template.updateFirst(null, update("dbRefs", Arrays.asList(first, second)), ClassWithDBRefs.class);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1157,16 +1157,12 @@ public class MongoTemplateTests {
 		template.save(person);
 		WriteResult result = template.updateFirst(query(where("id").is(person.getId())), update("firstName", "Carter"),
 				PersonWithIdPropertyOfTypeObjectId.class);
-		WriteConcern lastWriteConcern = result.getLastConcern();
-		assertThat(lastWriteConcern, equalTo(WriteConcern.UNACKNOWLEDGED));
 
 		FsyncSafeWriteConcernResolver resolver = new FsyncSafeWriteConcernResolver();
 		template.setWriteConcernResolver(resolver);
 		Query q = query(where("_id").is(person.getId()));
 		Update u = update("firstName", "Carter");
 		result = template.updateFirst(q, u, PersonWithIdPropertyOfTypeObjectId.class);
-		lastWriteConcern = result.getLastConcern();
-		assertThat(lastWriteConcern, equalTo(WriteConcern.FSYNC_SAFE));
 
 		MongoAction lastMongoAction = resolver.getMongoAction();
 		assertThat(lastMongoAction.getCollectionName(), is("personWithIdPropertyOfTypeObjectId"));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1712,29 +1712,6 @@ public class MongoTemplateTests {
 	}
 
 	/**
-	 * @see DATAMONGO-651
-	 */
-	@Test
-	public void throwsMongoSpecificExceptionForDataIntegrityViolations() {
-
-		WriteResult result = mock(WriteResult.class);
-		when(result.getError()).thenReturn("ERROR");
-
-		MongoActionOperation operation = MongoActionOperation.INSERT;
-
-		MongoTemplate mongoTemplate = new MongoTemplate(factory);
-		mongoTemplate.setWriteResultChecking(WriteResultChecking.EXCEPTION);
-
-		try {
-			mongoTemplate.handleAnyWriteResultErrors(result, null, operation);
-			fail("Expected MonogoDataIntegrityViolationException!");
-		} catch (MongoDataIntegrityViolationException o_O) {
-			assertThat(o_O.getActionOperation(), is(operation));
-			assertThat(o_O.getWriteResult(), is(result));
-		}
-	}
-
-	/**
 	 * @see DATAMONGO-679
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -202,7 +202,6 @@ public class AggregationTests {
 		AggregationResults<TagCount> results = mongoTemplate.aggregate(agg, INPUT_COLLECTION, TagCount.class);
 
 		assertThat(results, is(notNullValue()));
-		assertThat(results.getServerUsed(), endsWith("127.0.0.1:27017"));
 
 		List<TagCount> tagCount = results.getMappedResults();
 
@@ -230,7 +229,6 @@ public class AggregationTests {
 		AggregationResults<TagCount> results = mongoTemplate.aggregate(aggregation, INPUT_COLLECTION, TagCount.class);
 
 		assertThat(results, is(notNullValue()));
-		assertThat(results.getServerUsed(), endsWith("127.0.0.1:27017"));
 
 		List<TagCount> tagCount = results.getMappedResults();
 
@@ -254,7 +252,6 @@ public class AggregationTests {
 		AggregationResults<TagCount> results = mongoTemplate.aggregate(aggregation, INPUT_COLLECTION, TagCount.class);
 
 		assertThat(results, is(notNullValue()));
-		assertThat(results.getServerUsed(), endsWith("127.0.0.1:27017"));
 
 		List<TagCount> tagCount = results.getMappedResults();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
@@ -89,7 +89,7 @@ public class DbRefMappingMongoConverterUnitTests {
 
 		DBRef dbRef = converter.toDBRef(person, null);
 		assertThat(dbRef.getId(), is((Object) "foo"));
-		assertThat(dbRef.getRef(), is("person"));
+		assertThat(dbRef.getCollectionName(), is("person"));
 	}
 
 	/**
@@ -114,18 +114,6 @@ public class DbRefMappingMongoConverterUnitTests {
 		DBObject map = (DBObject) dbObject.get("map");
 
 		assertThat(map.get("test"), instanceOf(DBRef.class));
-
-		DBObject mapValDBObject = new BasicDBObject();
-		mapValDBObject.put("_id", BigInteger.ONE);
-
-		DBRef dbRef = mock(DBRef.class);
-		when(dbRef.fetch()).thenReturn(mapValDBObject);
-
-		((DBObject) dbObject.get("map")).put("test", dbRef);
-
-		MapDBRef read = converter.read(MapDBRef.class, dbObject);
-
-		assertThat(read.map.get("test").id, is(BigInteger.ONE));
 	}
 
 	/**
@@ -142,7 +130,7 @@ public class DbRefMappingMongoConverterUnitTests {
 
 		DBRef dbRef = converter.toDBRef(person, property);
 		assertThat(dbRef.getId(), is((Object) "foo"));
-		assertThat(dbRef.getRef(), is("person"));
+		assertThat(dbRef.getCollectionName(), is("person"));
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -1092,7 +1092,7 @@ public class MappingMongoConverterUnitTests {
 	@Test
 	public void readsPlainDBRefObject() {
 
-		DBRef dbRef = new DBRef(mock(DB.class), "foo", 2);
+		DBRef dbRef = new DBRef("foo", 2);
 		DBObject dbObject = new BasicDBObject("ref", dbRef);
 
 		DBRefWrapper result = converter.read(DBRefWrapper.class, dbObject);
@@ -1105,7 +1105,7 @@ public class MappingMongoConverterUnitTests {
 	@Test
 	public void readsCollectionOfDBRefs() {
 
-		DBRef dbRef = new DBRef(mock(DB.class), "foo", 2);
+		DBRef dbRef = new DBRef("foo", 2);
 		BasicDBList refs = new BasicDBList();
 		refs.add(dbRef);
 
@@ -1130,27 +1130,6 @@ public class MappingMongoConverterUnitTests {
 
 		assertThat(result.refMap.entrySet(), hasSize(1));
 		assertThat(result.refMap.values(), hasItem(dbRef));
-	}
-
-	/**
-	 * @see DATAMONGO-424
-	 */
-	@Test
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public void resolvesDBRefMapValue() {
-
-		DBRef dbRef = mock(DBRef.class);
-		when(dbRef.fetch()).thenReturn(new BasicDBObject());
-
-		BasicDBObject refMap = new BasicDBObject("foo", dbRef);
-		DBObject dbObject = new BasicDBObject("personMap", refMap);
-
-		DBRefWrapper result = converter.read(DBRefWrapper.class, dbObject);
-
-		Matcher isPerson = instanceOf(Person.class);
-
-		assertThat(result.personMap.entrySet(), hasSize(1));
-		assertThat(result.personMap.values(), hasItem(isPerson));
 	}
 
 	/**
@@ -1268,7 +1247,7 @@ public class MappingMongoConverterUnitTests {
 	public void eagerlyReturnsDBRefObjectIfTargetAlreadyIsOne() {
 
 		DB db = mock(DB.class);
-		DBRef dbRef = new DBRef(db, "collection", "id");
+		DBRef dbRef = new DBRef("collection", "id");
 
 		MongoPersistentProperty property = mock(MongoPersistentProperty.class);
 
@@ -1869,7 +1848,7 @@ public class MappingMongoConverterUnitTests {
 	public void readShouldRespectExplicitFieldNameForDbRef() {
 
 		BasicDBObject source = new BasicDBObject();
-		source.append("explict-name-for-db-ref", new DBRef(mock(DB.class), "foo", "1"));
+		source.append("explict-name-for-db-ref", new DBRef("foo", "1"));
 
 		converter.read(ClassWithExplicitlyNamedDBRefProperty.class, source);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -383,7 +383,7 @@ public class QueryMapperUnitTests {
 	public void handleMapWithDBRefCorrectly() {
 
 		DBObject mapDbObject = new BasicDBObject();
-		mapDbObject.put("test", new com.mongodb.DBRef(null, "test", "test"));
+		mapDbObject.put("test", new com.mongodb.DBRef("test", "test"));
 		DBObject dbObject = new BasicDBObject();
 		dbObject.put("mapWithDBRef", mapDbObject);
 
@@ -666,7 +666,7 @@ public class QueryMapperUnitTests {
 
 		ObjectId id = new ObjectId();
 
-		DBObject query = new BasicDBObject("reference.id", new com.mongodb.DBRef(null, "reference", id.toString()));
+		DBObject query = new BasicDBObject("reference.id", new com.mongodb.DBRef("reference", id.toString()));
 		DBObject result = mapper.getMappedObject(query, context.getPersistentEntity(WithDBRef.class));
 
 		assertThat(result.containsField("reference"), is(true));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -392,7 +392,7 @@ public class UpdateMapperUnitTests {
 				context.getPersistentEntity(DocumentWithDBRefCollection.class));
 
 		DBObject pullClause = getAsDBObject(mappedObject, "$pull");
-		assertThat(pullClause.get("dbRefAnnotatedList"), is((Object) new DBRef(null, "entity", "2")));
+		assertThat(pullClause.get("dbRefAnnotatedList"), is((Object) new DBRef("entity", "2")));
 	}
 
 	/**
@@ -409,7 +409,7 @@ public class UpdateMapperUnitTests {
 				context.getPersistentEntity(DocumentWithDBRefCollection.class));
 
 		DBObject pullClause = getAsDBObject(mappedObject, "$pull");
-		assertThat(pullClause.get("dbRefAnnotatedList"), is((Object) new DBRef(null, "entity", entity.id)));
+		assertThat(pullClause.get("dbRefAnnotatedList"), is((Object) new DBRef("entity", entity.id)));
 	}
 
 	/**
@@ -450,7 +450,7 @@ public class UpdateMapperUnitTests {
 				context.getPersistentEntity(DocumentWithDBRefCollection.class));
 
 		DBObject setClause = getAsDBObject(mappedObject, "$set");
-		assertThat(setClause.get("dbRefProperty"), is((Object) new DBRef(null, "entity", entity.id)));
+		assertThat(setClause.get("dbRefProperty"), is((Object) new DBRef("entity", entity.id)));
 	}
 
 	/**
@@ -541,7 +541,7 @@ public class UpdateMapperUnitTests {
 		DBObject $set = DBObjectTestUtils.getAsDBObject(mappedObject, "$set");
 		Object model = $set.get("referencedDocument");
 
-		DBRef expectedDBRef = new DBRef(factory.getDb(), "interfaceDocumentDefinitionImpl", "1");
+		DBRef expectedDBRef = new DBRef( "interfaceDocumentDefinitionImpl", "1");
 		assertThat(model, allOf(instanceOf(DBRef.class), IsEqual.<Object> equalTo(expectedDBRef)));
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/GroupByTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/GroupByTests.java
@@ -168,9 +168,6 @@ public class GroupByTests {
 
 		DBObject dboRawResults = results.getRawResults();
 
-		assertThat(dboRawResults.containsField("serverUsed"), is(true));
-		assertThat(dboRawResults.get("serverUsed").toString(), endsWith("127.0.0.1:27017"));
-
 		int numResults = 0;
 		for (XObject xObject : results) {
 			if (xObject.getX() == 1) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/performance/PerformanceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/performance/PerformanceTests.java
@@ -270,8 +270,8 @@ public class PerformanceTests {
 			DBCollection collection = db.getCollection(collectionName);
 			collection.drop();
 			collection.getDB().command(getCreateCollectionCommand(collectionName));
-			collection.ensureIndex(new BasicDBObject("firstname", -1));
-			collection.ensureIndex(new BasicDBObject("lastname", -1));
+			collection.createIndex(new BasicDBObject("firstname", -1));
+			collection.createIndex(new BasicDBObject("lastname", -1));
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessorUnitTests.java
@@ -105,7 +105,7 @@ public class ConvertingParameterAccessorUnitTests {
 
 		assertThat(result, is(instanceOf(com.mongodb.DBRef.class)));
 		com.mongodb.DBRef dbRef = (com.mongodb.DBRef) result;
-		assertThat(dbRef.getRef(), is("property"));
+		assertThat(dbRef.getCollectionName(), is("property"));
 		assertThat(dbRef.getId(), is((Object) 5L));
 	}
 
@@ -128,7 +128,7 @@ public class ConvertingParameterAccessorUnitTests {
 
 		assertThat(element, is(instanceOf(com.mongodb.DBRef.class)));
 		com.mongodb.DBRef dbRef = (com.mongodb.DBRef) element;
-		assertThat(dbRef.getRef(), is("property"));
+		assertThat(dbRef.getCollectionName(), is("property"));
 		assertThat(dbRef.getId(), is((Object) 5L));
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -238,7 +238,7 @@ public class MongoQueryCreatorUnitTests {
 	public void createsQueryReferencingADBRefCorrectly() {
 
 		User user = new User();
-		com.mongodb.DBRef dbref = new com.mongodb.DBRef(null, "user", "id");
+		com.mongodb.DBRef dbref = new com.mongodb.DBRef("user", "id");
 		when(converter.toDBRef(eq(user), Mockito.any(MongoPersistentProperty.class))).thenReturn(dbref);
 
 		PartTree tree = new PartTree("findByCreator", User.class);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
@@ -271,7 +271,7 @@ public class StringBasedMongoQueryUnitTests {
 
 		DBRef dbRef = DBObjectTestUtils.getTypedValue(query.getQueryObject(), "reference", DBRef.class);
 		assertThat(dbRef.getId(), is((Object) "myid"));
-		assertThat(dbRef.getRef(), is("reference"));
+		assertThat(dbRef.getCollectionName(), is("reference"));
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/resources/namespace/db-factory-bean-custom-write-concern.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/db-factory-bean-custom-write-concern.xml
@@ -8,7 +8,6 @@
 	<mongo:db-factory id="first" mongo-ref="mongo" write-concern="rack1" />
 
 	<mongo:mongo id="mongo">
-		<mongo:options max-auto-connect-retry-time="27" />
 	</mongo:mongo>
 	
 	<mongo:db-factory id="second" write-concern="REPLICAS_SAFE" />

--- a/spring-data-mongodb/src/test/resources/namespace/db-factory-bean.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/db-factory-bean.xml
@@ -8,7 +8,6 @@
 	<mongo:db-factory id="first" mongo-ref="mongo" write-concern="SAFE" />
 
 	<mongo:mongo id="mongo">
-		<mongo:options max-auto-connect-retry-time="27" />
 	</mongo:mongo>
 	
 	<!-- now part of the namespace

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
@@ -17,11 +17,9 @@
 					connections-per-host="${mongo.connectionsPerHost}"
 					threads-allowed-to-block-for-connection-multiplier="${mongo.threadsAllowedToBlockForConnectionMultiplier}"
 					connect-timeout="${mongo.connectTimeout}"
-					max-wait-time="${mongo.maxWaitTime}"					
-					auto-connect-retry="${mongo.autoConnectRetry}"
-					socket-keep-alive="${mongo.socketKeepAlive}"					
+					max-wait-time="${mongo.maxWaitTime}"
+					socket-keep-alive="${mongo.socketKeepAlive}"
 					socket-timeout="${mongo.socketTimeout}"
-					slave-ok="${mongo.slaveOk}"
 					write-number="1"
 					write-timeout="0"
 					write-fsync="true"/>

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/mongo.properties
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/mongo.properties
@@ -3,10 +3,8 @@ mongo.port=27017
 mongo.connectionsPerHost=8
 mongo.connectTimeout=1000
 mongo.maxWaitTime=1500
-mongo.autoConnectRetry=true
 mongo.socketTimeout=1500
 mongo.threadsAllowedToBlockForConnectionMultiplier=4
 mongo.socketKeepAlive=true
 mongo.fsync=true
-mongo.slaveOk=true
 


### PR DESCRIPTION
There are a few failing tests, but this is pretty close to working.  Please see individual commits for specific issues.  

The biggest remaining problem relates to checking the results of a write.  From what I can see MongoTemplate currently forces the acknowledgement of every write, regardless of the write concern in play.  This is due to the explicit call by MongoTemplate to WriteResult.getError() (which have been deprecated in 2.13 and removed in 3.0) after each write, and also by the call to WriteResult.getN() after each update.

Given that current behavior, one option is to instead force acknowledgment by using WriteConcern.ACKNOWLEDGED as the minimum write concern.  Doing this lets the driver apply the write concern at the same time as the write, which is the only option you have in 3.0 and more efficient in 2.x as well.

I realize now that I didn't fully follow the contributing guidelines.  I will fix that and rebase if this looks like something that you'll eventually accept.