### PR TITLE
DATAMONGO-1110 - Add support for $minDistance. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.7.0.BUILD-SNAPSHOT</version>
+			<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.7.0.BUILD-SNAPSHOT</version>
+		<version>1.7.0.DATAMONGO-1110-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -450,6 +450,19 @@ public class Criteria implements CriteriaDefinition {
 	}
 
 	/**
+	 * Creates a geospatial criterion using a {@literal $minDistance} operation, for use with {@literal $near} or
+	 * {@literal $nearSphere}.
+	 * 
+	 * @param minDistance
+	 * @return
+	 * @since 1.7
+	 */
+	public Criteria minDistance(double minDistance) {
+		criteria.put("$minDistance", minDistance);
+		return this;
+	}
+
+	/**
 	 * Creates a criterion using the {@literal $elemMatch} operator
 	 * 
 	 * @see http://docs.mongodb.org/manual/reference/operator/query/elemMatch/

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -441,7 +441,8 @@ public class Criteria implements CriteriaDefinition {
 	 */
 	public Criteria maxDistance(double maxDistance) {
 
-		if (createNearCriteriaForCommand("$near", maxDistance) || createNearCriteriaForCommand("$nearSphere", maxDistance)) {
+		if (createNearCriteriaForCommand("$near", "$maxDistance", maxDistance)
+				|| createNearCriteriaForCommand("$nearSphere", "$maxDistance", maxDistance)) {
 			return this;
 		}
 
@@ -458,6 +459,12 @@ public class Criteria implements CriteriaDefinition {
 	 * @since 1.7
 	 */
 	public Criteria minDistance(double minDistance) {
+
+		if (createNearCriteriaForCommand("$near", "$minDistance", minDistance)
+				|| createNearCriteriaForCommand("$nearSphere", "$minDistance", minDistance)) {
+			return this;
+		}
+
 		criteria.put("$minDistance", minDistance);
 		return this;
 	}
@@ -618,7 +625,7 @@ public class Criteria implements CriteriaDefinition {
 		}
 	}
 
-	private boolean createNearCriteriaForCommand(String command, double maxDistance) {
+	private boolean createNearCriteriaForCommand(String command, String operation, double maxDistance) {
 
 		if (!criteria.containsKey(command)) {
 			return false;
@@ -628,14 +635,13 @@ public class Criteria implements CriteriaDefinition {
 
 		if (existingNearOperationValue instanceof DBObject) {
 
-			((DBObject) existingNearOperationValue).put("$maxDistance", maxDistance);
+			((DBObject) existingNearOperationValue).put(operation, maxDistance);
 
 			return true;
 
 		} else if (existingNearOperationValue instanceof GeoJson) {
 
-			BasicDBObject dbo = new BasicDBObject("$geometry", existingNearOperationValue)
-					.append("$maxDistance", maxDistance);
+			BasicDBObject dbo = new BasicDBObject("$geometry", existingNearOperationValue).append(operation, maxDistance);
 			criteria.put(command, dbo);
 
 			return true;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public final class NearQuery {
 	private final Point point;
 	private Query query;
 	private Distance maxDistance;
+	private Distance minDistance;
 	private Metric metric;
 	private boolean spherical;
 	private Integer num;
@@ -212,12 +213,79 @@ public final class NearQuery {
 	}
 
 	/**
+	 * Sets the minimum distance results shall have from the configured origin. If a {@link Metric} was set before the
+	 * given value will be interpreted as being a value in that metric. E.g.
+	 * 
+	 * <pre>
+	 * NearQuery query = near(10.0, 20.0, Metrics.KILOMETERS).minDistance(150);
+	 * </pre>
+	 * 
+	 * Will set the minimum distance to 150 kilometers.
+	 * 
+	 * @param minDistance
+	 * @return
+	 * @since 1.7
+	 */
+	public NearQuery minDistance(double minDistance) {
+		return minDistance(new Distance(minDistance, getMetric()));
+	}
+
+	/**
+	 * Sets the minimum distance supplied in a given metric. Will normalize the distance but not reconfigure the query's
+	 * result {@link Metric} if one was configured before.
+	 * 
+	 * @param minDistance
+	 * @param metric must not be {@literal null}.
+	 * @return
+	 * @since 1.7
+	 */
+	public NearQuery minDistance(double minDistance, Metric metric) {
+
+		Assert.notNull(metric);
+		return minDistance(new Distance(minDistance, metric));
+	}
+
+	/**
+	 * Sets the minimum distance to the given {@link Distance}. Will set the returned {@link Metric} to be the one of the
+	 * given {@link Distance} if no {@link Metric} was set before.
+	 * 
+	 * @param distance must not be {@literal null}.
+	 * @return
+	 * @since 1.7
+	 */
+	public NearQuery minDistance(Distance distance) {
+
+		Assert.notNull(distance);
+
+		if (distance.getMetric() != Metrics.NEUTRAL) {
+			this.spherical(true);
+		}
+
+		if (this.metric == null) {
+			in(distance.getMetric());
+		}
+
+		this.minDistance = distance;
+		return this;
+	}
+
+	/**
 	 * Returns the maximum {@link Distance}.
 	 * 
 	 * @return
 	 */
 	public Distance getMaxDistance() {
 		return this.maxDistance;
+	}
+
+	/**
+	 * Returns the maximum {@link Distance}.
+	 * 
+	 * @return
+	 * @since 1.7
+	 */
+	public Distance getMinDistance() {
+		return this.minDistance;
 	}
 
 	/**
@@ -352,7 +420,11 @@ public final class NearQuery {
 		}
 
 		if (maxDistance != null) {
-			dbObject.put("maxDistance", this.maxDistance.getNormalizedValue());
+			dbObject.put("maxDistance", maxDistance.getNormalizedValue());
+		}
+
+		if (minDistance != null) {
+			dbObject.put("minDistance", minDistance.getNormalizedValue());
 		}
 
 		if (metric != null) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.geo.Distance;
@@ -361,12 +362,15 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 				nearQuery.query(query);
 			}
 
-			Distance maxDistance = accessor.getMaxDistance();
+			Range<Distance> distances = accessor.getDistanceRange();
+			Distance maxDistance = distances.getUpperBound();
+
 			if (maxDistance != null) {
 				nearQuery.maxDistance(maxDistance).in(maxDistance.getMetric());
 			}
 
-			Distance minDistance = accessor.getMinDistance();
+			Distance minDistance = distances.getLowerBound();
+
 			if (minDistance != null) {
 				nearQuery.minDistance(minDistance).in(minDistance.getMetric());
 			}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -366,6 +366,11 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 				nearQuery.maxDistance(maxDistance).in(maxDistance.getMetric());
 			}
 
+			Distance minDistance = accessor.getMinDistance();
+			if (minDistance != null) {
+				nearQuery.minDistance(minDistance).in(minDistance.getMetric());
+			}
+
 			Pageable pageable = accessor.getPageable();
 			if (pageable != null) {
 				nearQuery.with(pageable);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
@@ -96,21 +97,13 @@ public class ConvertingParameterAccessor implements MongoParameterAccessor {
 		return getConvertedValue(delegate.getBindableValue(index), null);
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.MongoParameterAccessor#getMaxDistance()
-	 */
-	public Distance getMaxDistance() {
-		return delegate.getMaxDistance();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getMinDistance()
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getDistanceRange()
 	 */
 	@Override
-	public Distance getMinDistance() {
-		return delegate.getMinDistance();
+	public Range<Distance> getDistanceRange() {
+		return delegate.getDistanceRange();
 	}
 
 	/* 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,15 @@ public class ConvertingParameterAccessor implements MongoParameterAccessor {
 	 */
 	public Distance getMaxDistance() {
 		return delegate.getMaxDistance();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getMinDistance()
+	 */
+	@Override
+	public Distance getMinDistance() {
+		return delegate.getMinDistance();
 	}
 
 	/* 
@@ -252,4 +261,5 @@ public class ConvertingParameterAccessor implements MongoParameterAccessor {
 		 */
 		Object nextConverted(MongoPersistentProperty property);
 	}
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.core.query.TextCriteria;
@@ -34,7 +35,7 @@ public interface MongoParameterAccessor extends ParameterAccessor {
 	 * @return the maximum distance to apply to the geo query or {@literal null} if there's no {@link Distance} parameter
 	 *         at all or the given value for it was {@literal null}.
 	 */
-	Distance getMaxDistance();
+	Range<Distance> getDistanceRange();
 
 	/**
 	 * Returns the {@link Point} to use for a geo-near query.
@@ -50,12 +51,4 @@ public interface MongoParameterAccessor extends ParameterAccessor {
 	 * @since 1.6
 	 */
 	TextCriteria getFullText();
-
-	/**
-	 * Returns a {@link Distance} to be applied to {@literal $minDistance} for MongoDB geo queries.
-	 * 
-	 * @return
-	 * @since 1.7
-	 */
-	Distance getMinDistance();
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,4 +50,12 @@ public interface MongoParameterAccessor extends ParameterAccessor {
 	 * @since 1.6
 	 */
 	TextCriteria getFullText();
+
+	/**
+	 * Returns a {@link Distance} to be applied to {@literal $minDistance} for MongoDB geo queries.
+	 * 
+	 * @return
+	 * @since 1.7
+	 */
+	Distance getMinDistance();
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.core.query.Term;
@@ -44,23 +45,20 @@ public class MongoParametersParameterAccessor extends ParametersParameterAccesso
 		this.method = method;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.MongoParameterAccessor#getMaxDistance()
-	 */
-	public Distance getMaxDistance() {
-		int index = method.getParameters().getDistanceIndex();
-		return index == -1 ? null : (Distance) getValue(index);
-	}
+	public Range<Distance> getDistanceRange() {
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getMinDistance()
-	 */
-	@Override
-	public Distance getMinDistance() {
-		int index = method.getParameters().getMinDistanceParameterIndex();
-		return index == -1 ? null : (Distance) getValue(index);
+		MongoParameters mongoParameters = method.getParameters();
+
+		int rangeIndex = mongoParameters.getRangeIndex();
+
+		if (rangeIndex != -1) {
+			return getValue(rangeIndex);
+		}
+
+		int maxDistanceIndex = mongoParameters.getMaxDistanceIndex();
+		Distance maxDistance = maxDistanceIndex == -1 ? null : (Distance) getValue(maxDistanceIndex);
+
+		return new Range<Distance>(null, maxDistance);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,16 @@ public class MongoParametersParameterAccessor extends ParametersParameterAccesso
 	 */
 	public Distance getMaxDistance() {
 		int index = method.getParameters().getDistanceIndex();
+		return index == -1 ? null : (Distance) getValue(index);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getMinDistance()
+	 */
+	@Override
+	public Distance getMinDistance() {
+		int index = method.getParameters().getMinDistanceParameterIndex();
 		return index == -1 ? null : (Distance) getValue(index);
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
@@ -207,8 +208,10 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 				return criteria.is(false);
 			case NEAR:
 
-				Distance distance = accessor.getMaxDistance();
-				Distance minDistance = accessor.getMinDistance();
+				Range<Distance> range = accessor.getDistanceRange();
+				Distance distance = range.getUpperBound();
+				Distance minDistance = range.getLowerBound();
+
 				Point point = accessor.getGeoNearLocation();
 				point = point == null ? nextAs(parameters, Point.class) : point;
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
@@ -278,6 +278,45 @@ public class GeoJsonTests {
 		assertThat(result.geoJsonGeometryCollection, equalTo(obj.geoJsonGeometryCollection));
 	}
 
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void nearWithMinDistance() {
+
+		Point point = new GeoJsonPoint(-73.99171, 40.738868);
+		List<Venue2DSphere> venues = template.find(query(where("location").near(point).minDistance(0.01)),
+				Venue2DSphere.class);
+
+		assertThat(venues.size(), is(11));
+	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void nearSphereWithMinDistance() {
+
+		Point point = new GeoJsonPoint(-73.99171, 40.738868);
+		List<Venue2DSphere> venues = template.find(query(where("location").nearSphere(point).minDistance(0.01)),
+				Venue2DSphere.class);
+
+		assertThat(venues.size(), is(11));
+	}
+
+	/**
+	 * @see DATAMONGO-1135
+	 */
+	@Test
+	public void nearWithMinAndMaxDistance() {
+
+		GeoJsonPoint point = new GeoJsonPoint(-73.99171, 40.738868);
+
+		Query query = query(where("location").near(point).minDistance(0.01).maxDistance(100));
+		List<Venue2DSphere> venues = template.find(query, Venue2DSphere.class);
+		assertThat(venues.size(), is(2));
+	}
+
 	private void addVenues() {
 
 		template.insert(new Venue2DSphere("Penn Station", -73.99408, 40.75057));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatial2DTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatial2DTests.java
@@ -70,6 +70,16 @@ public class GeoSpatial2DTests extends AbstractGeoSpatialTests {
 		assertThat(fields, hasItem(IndexField.geo("location")));
 	}
 
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void nearPointWithMinDistance() {
+		Point point = new Point(-73.99171, 40.738868);
+		List<Venue> venues = template.find(query(where("location").near(point).minDistance(0.01)), Venue.class);
+		assertThat(venues.size(), is(5));
+	}
+
 	@Override
 	protected void createIndex() {
 		template.indexOps(Venue.class).ensureIndex(new GeospatialIndex("location").typed(GeoSpatialIndexType.GEO_2D));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatial2DTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatial2DTests.java
@@ -70,16 +70,6 @@ public class GeoSpatial2DTests extends AbstractGeoSpatialTests {
 		assertThat(fields, hasItem(IndexField.geo("location")));
 	}
 
-	/**
-	 * @see DATAMONGO-1110
-	 */
-	@Test
-	public void nearPointWithMinDistance() {
-		Point point = new Point(-73.99171, 40.738868);
-		List<Venue> venues = template.find(query(where("location").near(point).minDistance(0.01)), Venue.class);
-		assertThat(venues.size(), is(5));
-	}
-
 	@Override
 	protected void createIndex() {
 		template.indexOps(Venue.class).ensureIndex(new GeospatialIndex("location").typed(GeoSpatialIndexType.GEO_2D));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
@@ -211,4 +211,40 @@ public class CriteriaTests {
 
 		assertThat(dbo, IsBsonObject.isBsonObject().containing("foo.$nearSphere.$maxDistance", 50D));
 	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void minDistanceShouldBeMappedInsideNearWhenUsedAlongWithGeoJsonType() {
+
+		DBObject dbo = new Criteria("foo").near(new GeoJsonPoint(100, 200)).minDistance(50D).getCriteriaObject();
+
+		assertThat(dbo, IsBsonObject.isBsonObject().containing("foo.$near.$minDistance", 50D));
+	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void minDistanceShouldBeMappedInsideNearSphereWhenUsedAlongWithGeoJsonType() {
+
+		DBObject dbo = new Criteria("foo").nearSphere(new GeoJsonPoint(100, 200)).minDistance(50D).getCriteriaObject();
+
+		assertThat(dbo, IsBsonObject.isBsonObject().containing("foo.$nearSphere.$minDistance", 50D));
+	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void minAndMaxDistanceShouldBeMappedInsideNearSphereWhenUsedAlongWithGeoJsonType() {
+
+		DBObject dbo = new Criteria("foo").nearSphere(new GeoJsonPoint(100, 200)).minDistance(50D).maxDistance(100D)
+				.getCriteriaObject();
+
+		assertThat(dbo, IsBsonObject.isBsonObject().containing("foo.$nearSphere.$minDistance", 50D));
+		assertThat(dbo, IsBsonObject.isBsonObject().containing("foo.$nearSphere.$maxDistance", 100D));
+	}
+
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.repository;
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.data.geo.Metrics.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -1176,8 +1178,9 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 		dave.setLocation(point);
 		repository.save(dave);
 
-		GeoResults<Person> results = repository.findPersonByLocationNear(new Point(-73.99, 40.73), new Distance(0.01,
-				Metrics.KILOMETERS), new Distance(2000, Metrics.KILOMETERS));
+		Range<Distance> range = Distance.between(new Distance(0.01, KILOMETERS), new Distance(2000, KILOMETERS));
+
+		GeoResults<Person> results = repository.findPersonByLocationNear(new Point(-73.99, 40.73), range);
 		assertThat(results.getContent().isEmpty(), is(false));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -1165,4 +1165,19 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 			result.close();
 		}
 	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void executesGeoNearQueryForResultsCorrectlyWhenGivenMinAndMaxDistance() {
+
+		Point point = new Point(-73.99171, 40.738868);
+		dave.setLocation(point);
+		repository.save(dave);
+
+		GeoResults<Person> results = repository.findPersonByLocationNear(new Point(-73.99, 40.73), new Distance(0.01,
+				Metrics.KILOMETERS), new Distance(2000, Metrics.KILOMETERS));
+		assertThat(results.getContent().isEmpty(), is(false));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.geo.Point;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
 import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -32,6 +33,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 @Document
 public class Person extends Contact {
@@ -49,7 +51,7 @@ public class Person extends Contact {
 
 	List<String> skills;
 
-	@GeoSpatialIndexed private Point location;
+	@GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE) private Point location;
 
 	private @Field("add") Address address;
 	private Set<Address> shippingAddresses;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Box;
@@ -169,8 +170,10 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 
 	GeoResults<Person> findByLocationNear(Point point, Distance maxDistance);
 
-	/** @see DATAMONGO-1110 */
-	GeoResults<Person> findPersonByLocationNear(Point point, Distance maxDistance, Distance minDistance);
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	GeoResults<Person> findPersonByLocationNear(Point point, Range<Distance> distance);
 
 	GeoPage<Person> findByLocationNear(Point point, Distance maxDistance, Pageable pageable);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -169,6 +169,9 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 
 	GeoResults<Person> findByLocationNear(Point point, Distance maxDistance);
 
+	/** @see DATAMONGO-1110 */
+	GeoResults<Person> findPersonByLocationNear(Point point, Distance maxDistance, Distance minDistance);
+
 	GeoPage<Person> findByLocationNear(Point point, Distance maxDistance, Pageable pageable);
 
 	List<Person> findByCreator(User user);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,11 +96,32 @@ public class MongoParametersParameterAccessorUnitTests {
 				equalTo("{ \"$text\" : { \"$search\" : \"data\"}}"));
 	}
 
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void shouldDetectMinAndMaxDistance() throws NoSuchMethodException, SecurityException {
+
+		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Distance.class, Distance.class);
+		MongoQueryMethod queryMethod = new MongoQueryMethod(method, metadata, context);
+
+		Distance min = new Distance(10, Metrics.KILOMETERS);
+		Distance max = new Distance(20, Metrics.KILOMETERS);
+
+		MongoParameterAccessor accessor = new MongoParametersParameterAccessor(queryMethod, new Object[] {
+				new Point(10, 20), min, max });
+
+		assertThat(accessor.getMinDistance(), is(min));
+		assertThat(accessor.getMaxDistance(), is(max));
+	}
+
 	interface PersonRepository extends Repository<Person, Long> {
 
 		List<Person> findByLocationNear(Point point);
 
 		List<Person> findByLocationNear(Point point, Distance distance);
+
+		List<Person> findByLocationNear(Point point, Distance minDistance, Distance maxDistance);
 
 		List<Person> findByFirstname(String firstname, TextCriteria fullText);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersUnitTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Point;
@@ -50,7 +51,7 @@ public class MongoParametersUnitTests {
 		MongoParameters parameters = new MongoParameters(method, false);
 
 		assertThat(parameters.getNumberOfParameters(), is(2));
-		assertThat(parameters.getMaxDistanceParameterIndex(), is(1));
+		assertThat(parameters.getMaxDistanceIndex(), is(1));
 		assertThat(parameters.getBindableParameters().getNumberOfParameters(), is(1));
 
 		Parameter parameter = parameters.getParameter(1);
@@ -127,11 +128,11 @@ public class MongoParametersUnitTests {
 	@Test
 	public void shouldFindMinAndMaxDistanceParameters() throws NoSuchMethodException, SecurityException {
 
-		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Distance.class, Distance.class);
+		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Range.class);
 		MongoParameters parameters = new MongoParameters(method, false);
 
-		assertThat(parameters.getMinDistanceParameterIndex(), is(1));
-		assertThat(parameters.getMaxDistanceParameterIndex(), is(2));
+		assertThat(parameters.getRangeIndex(), is(1));
+		assertThat(parameters.getMaxDistanceIndex(), is(-1));
 	}
 
 	/**
@@ -144,8 +145,8 @@ public class MongoParametersUnitTests {
 		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Distance.class);
 		MongoParameters parameters = new MongoParameters(method, false);
 
-		assertThat(parameters.getMinDistanceParameterIndex(), is(-1));
-		assertThat(parameters.getMaxDistanceParameterIndex(), is(1));
+		assertThat(parameters.getRangeIndex(), is(-1));
+		assertThat(parameters.getMaxDistanceIndex(), is(1));
 	}
 
 	interface PersonRepository {
@@ -164,6 +165,6 @@ public class MongoParametersUnitTests {
 
 		List<Person> findByNameAndText(String name, TextCriteria text);
 
-		List<Person> findByLocationNear(Point point, Distance min, Distance max);
+		List<Person> findByLocationNear(Point point, Range<Distance> range);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoParametersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class MongoParametersUnitTests {
 		MongoParameters parameters = new MongoParameters(method, false);
 
 		assertThat(parameters.getNumberOfParameters(), is(2));
-		assertThat(parameters.getDistanceIndex(), is(1));
+		assertThat(parameters.getMaxDistanceParameterIndex(), is(1));
 		assertThat(parameters.getBindableParameters().getNumberOfParameters(), is(1));
 
 		Parameter parameter = parameters.getParameter(1);
@@ -121,6 +121,33 @@ public class MongoParametersUnitTests {
 		assertThat(parameters.getParameter(parameters.getFullTextParameterIndex()).isSpecialParameter(), is(true));
 	}
 
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void shouldFindMinAndMaxDistanceParameters() throws NoSuchMethodException, SecurityException {
+
+		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Distance.class, Distance.class);
+		MongoParameters parameters = new MongoParameters(method, false);
+
+		assertThat(parameters.getMinDistanceParameterIndex(), is(1));
+		assertThat(parameters.getMaxDistanceParameterIndex(), is(2));
+	}
+
+	/**
+	 * @see DATAMONGO-1110
+	 */
+	@Test
+	public void shouldNotHaveMinDistanceIfOnlyOneDistanceParameterPresent() throws NoSuchMethodException,
+			SecurityException {
+
+		Method method = PersonRepository.class.getMethod("findByLocationNear", Point.class, Distance.class);
+		MongoParameters parameters = new MongoParameters(method, false);
+
+		assertThat(parameters.getMinDistanceParameterIndex(), is(-1));
+		assertThat(parameters.getMaxDistanceParameterIndex(), is(1));
+	}
+
 	interface PersonRepository {
 
 		List<Person> findByLocationNear(Point point, Distance distance);
@@ -136,5 +163,7 @@ public class MongoParametersUnitTests {
 		GeoResults<Person> validDoubleArrays(double[] first, @Near double[] second);
 
 		List<Person> findByNameAndText(String name, TextCriteria text);
+
+		List<Person> findByLocationNear(Point point, Distance min, Distance max);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
@@ -543,11 +544,10 @@ public class MongoQueryCreatorUnitTests {
 	public void shouldCreateNearQueryForMinMaxDistance() {
 
 		Point point = new Point(10, 20);
-		Distance min = new Distance(10);
-		Distance max = new Distance(20);
+		Range<Distance> range = Distance.between(new Distance(10), new Distance(20));
 
 		PartTree tree = new PartTree("findByAddress_GeoNear", User.class);
-		MongoQueryCreator creator = new MongoQueryCreator(tree, getAccessor(converter, point, min, max), context);
+		MongoQueryCreator creator = new MongoQueryCreator(tree, getAccessor(converter, point, range), context);
 		Query query = creator.createQuery();
 
 		assertThat(query, is(query(where("address.geo").near(point).minDistance(10D).maxDistance(20D))));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,13 @@ import org.springframework.data.repository.query.ParameterAccessor;
  * Simple {@link ParameterAccessor} that returns the given parameters unfiltered.
  * 
  * @author Oliver Gierke
+ * @author Christoh Strobl
  */
 class StubParameterAccessor implements MongoParameterAccessor {
 
 	private final Object[] values;
 	private Distance distance;
+	private Distance minDistance;
 
 	/**
 	 * Creates a new {@link ConvertingParameterAccessor} backed by a {@link StubParameterAccessor} simply returning the
@@ -54,7 +56,12 @@ class StubParameterAccessor implements MongoParameterAccessor {
 
 		for (Object value : values) {
 			if (value instanceof Distance) {
-				this.distance = (Distance) value;
+				if (this.distance == null) {
+					this.distance = (Distance) value;
+				} else {
+					this.minDistance = this.distance;
+					this.distance = (Distance) value;
+				}
 			}
 		}
 	}
@@ -97,6 +104,11 @@ class StubParameterAccessor implements MongoParameterAccessor {
 	 */
 	public Distance getMaxDistance() {
 		return distance;
+	}
+
+	@Override
+	public Distance getMinDistance() {
+		return minDistance;
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
@@ -35,8 +36,7 @@ import org.springframework.data.repository.query.ParameterAccessor;
 class StubParameterAccessor implements MongoParameterAccessor {
 
 	private final Object[] values;
-	private Distance distance;
-	private Distance minDistance;
+	private Range<Distance> range = new Range<Distance>(null, null);
 
 	/**
 	 * Creates a new {@link ConvertingParameterAccessor} backed by a {@link StubParameterAccessor} simply returning the
@@ -50,18 +50,16 @@ class StubParameterAccessor implements MongoParameterAccessor {
 		return new ConvertingParameterAccessor(converter, new StubParameterAccessor(parameters));
 	}
 
+	@SuppressWarnings("unchecked")
 	public StubParameterAccessor(Object... values) {
 
 		this.values = values;
 
 		for (Object value : values) {
-			if (value instanceof Distance) {
-				if (this.distance == null) {
-					this.distance = (Distance) value;
-				} else {
-					this.minDistance = this.distance;
-					this.distance = (Distance) value;
-				}
+			if (value instanceof Range) {
+				this.range = (Range<Distance>) value;
+			} else if (value instanceof Distance) {
+				this.range = new Range<Distance>(null, (Distance) value);
 			}
 		}
 	}
@@ -98,17 +96,13 @@ class StubParameterAccessor implements MongoParameterAccessor {
 		return null;
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.MongoParameterAccessor#getMaxDistance()
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getDistanceRange()
 	 */
-	public Distance getMaxDistance() {
-		return distance;
-	}
-
 	@Override
-	public Distance getMinDistance() {
-		return minDistance;
+	public Range<Distance> getDistanceRange() {
+		return range;
 	}
 
 	/*

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -210,6 +210,14 @@ NOTE: Note that for version 1.0 we currently don't support referring to paramete
 | `findByLocationNear(Point point)`
 | `{"location" : {"$near" : [x,y]}}`
 
+| `Near`
+| `findByLocationNear(Point point, Distance max)`
+| `{"location" : {"$near" : [x,y], "$maxDistance" : max}}`
+
+| `Near`
+| `findByLocationNear(Point point, Distance min, Distance max)`
+| `{"location" : {"$near" : [x,y], "$minDistance" : min, "$maxDistance" : max}}`
+
 | `Within`
 | `findByLocationWithin(Circle circle)`
 | `{"location" : {"$geoWithin" : {"$center" : [ [x, y], distance]}}}`
@@ -283,6 +291,8 @@ Distance distance = new Distance(200, Metrics.KILOMETERS);
 
 As you can see using a `Distance` equipped with a `Metric` causes `$nearSphere` clause to be added instead of a plain `$near`. Beyond that the actual distance gets calculated according to the `Metrics` used.
 
+NOTE: Using `@GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)` on the target property forces usage of `$nearSphere` operator.
+
 ==== Geo-near queries
 
 [source,java]
@@ -296,6 +306,11 @@ public interface PersonRepository extends MongoRepository<Person, String>
   // Metric: {'geoNear' : 'person', 'near' : [x, y], 'maxDistance' : distance,
   //          'distanceMultiplier' : metric.multiplier, 'spherical' : true }
   GeoResults<Person> findByLocationNear(Point location, Distance distance);
+  
+  // Metric: {'geoNear' : 'person', 'near' : [x, y], 'minDistance' : min,
+  //          'maxDistance' : max, 'distanceMultiplier' : metric.multiplier,
+  //          'spherical' : true }
+  GeoResults<Person> findByLocationNear(Point location, Distance min, Distance max);
 
   // {'geoNear' : 'location', 'near' : [x, y] }
   GeoResults<Person> findByLocationNear(Point location);

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1013,6 +1013,7 @@ There are also methods on the Criteria class for geospatial queries. Here is a l
 * `Criteria` *withinSphere* `(Circle circle)` Creates a geospatial criterion using `$geoWithin $center` operators.
 * `Criteria` *near* `(Point point)` Creates a geospatial criterion using a `$near `operation
 * `Criteria` *nearSphere* `(Point point)` Creates a geospatial criterion using `$nearSphere$center` operations. This is only available for MongoDB 1.7 and higher.
+* `Criteria` *minDistance* `(double minDistance)` Creates a geospatial criterion using the `$minDistance` operation, for use with $near.
 * `Criteria` *maxDistance* `(double maxDistance)` Creates a geospatial criterion using the `$maxDistance` operation, for use with $near.
 
 The `Query` class has some additional methods used to provide options for the query.
@@ -1111,13 +1112,20 @@ List<Venue> venues =
     template.find(new Query(Criteria.where("location").within(box)), Venue.class);
 ----
 
-To find venues near a `Point`, the following query can be used
+To find venues near a `Point`, the following queries can be used
 
 [source,java]
 ----
 Point point = new Point(-73.99171, 40.738868);
 List<Venue> venues =
     template.find(new Query(Criteria.where("location").near(point).maxDistance(0.01)), Venue.class);
+----
+
+[source,java]
+----
+Point point = new Point(-73.99171, 40.738868);
+List<Venue> venues =
+    template.find(new Query(Criteria.where("location").near(point).minDistance(0.01).maxDistance(100)), Venue.class);
 ----
 
 To find venues near a `Point` using spherical coordines the following query can be used


### PR DESCRIPTION
We now support `$minDistance` for `NearQuery` and `Criteria`. Please keep in mind that `$minDistance` is only available for MongoDB 2.6 and better and can only be combined with `$near` or `$nearSphere` operator depending on the defined index type. Usage of `$minDistance` with `NearQuery` is only possible when a `2dsphere` index is present.

Further on query derivation now allows a 2nd `Distance` parameter for the `near` keyword. This allows to define near queries like:

```
findByLocationNear(Point point, Distance min, Distance max);
```

The _first_ `Distance` parameter is treated as the minimum distance while the _second_ one defines the maximum distance from the given point, while the distance parameter will server as maximum distance in case only one `Distance` parameter is provided.