### PR TITLE
DATAMONGO-990 - Add support for SpEL expressions in @Query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-990-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -31,6 +31,7 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.util.CloseableIterator;
@@ -51,20 +52,25 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 
 	private final MongoQueryMethod method;
 	private final MongoOperations operations;
+	private final EvaluationContextProvider evaluationContextProvider;
 
 	/**
 	 * Creates a new {@link AbstractMongoQuery} from the given {@link MongoQueryMethod} and {@link MongoOperations}.
 	 * 
 	 * @param method must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
+	 * @param evaluationContextProvider must not be {@literal null}.
 	 */
-	public AbstractMongoQuery(MongoQueryMethod method, MongoOperations operations) {
+	public AbstractMongoQuery(MongoQueryMethod method, MongoOperations operations,
+			EvaluationContextProvider evaluationContextProvider) {
 
 		Assert.notNull(operations);
 		Assert.notNull(method);
+		Assert.notNull(evaluationContextProvider, "ExpressionEvaluationContextProvider must not be null!");
 
 		this.method = method;
 		this.operations = operations;
+		this.evaluationContextProvider = evaluationContextProvider;
 	}
 
 	/* 
@@ -157,6 +163,10 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 	 * @since 1.5
 	 */
 	protected abstract boolean isDeleteQuery();
+
+	public EvaluationContextProvider getEvaluationContextProvider() {
+		return evaluationContextProvider;
+	}
 
 	private abstract class Execution {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ConvertingParameterAccessor.java
@@ -41,6 +41,7 @@ import com.mongodb.DBRef;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 public class ConvertingParameterAccessor implements MongoParameterAccessor {
 
@@ -238,6 +239,14 @@ public class ConvertingParameterAccessor implements MongoParameterAccessor {
 		}
 
 		return source.getClass().isArray() ? CollectionUtils.arrayToList(source) : Collections.singleton(source);
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getValues()
+	 */
+	@Override
+	public Object[] getValues() {
+		return delegate.getValues();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParameterAccessor.java
@@ -26,6 +26,7 @@ import org.springframework.data.repository.query.ParameterAccessor;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 public interface MongoParameterAccessor extends ParameterAccessor {
 
@@ -51,4 +52,12 @@ public interface MongoParameterAccessor extends ParameterAccessor {
 	 * @since 1.6
 	 */
 	TextCriteria getFullText();
+
+	/**
+	 * Returns the raw parameter values of the underlying query method.
+	 * 
+	 * @return
+	 * @since 1.8
+	 */
+	Object[] getValues();
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoParametersParameterAccessor.java
@@ -29,20 +29,23 @@ import org.springframework.util.ClassUtils;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 public class MongoParametersParameterAccessor extends ParametersParameterAccessor implements MongoParameterAccessor {
 
 	private final MongoQueryMethod method;
+	private final Object[] values;
 
 	/**
 	 * Creates a new {@link MongoParametersParameterAccessor}.
 	 * 
 	 * @param method must not be {@literal null}.
-	 * @param values must not be {@@iteral null}.
+	 * @param values must not be {@literal null}.
 	 */
 	public MongoParametersParameterAccessor(MongoQueryMethod method, Object[] values) {
 		super(method.getParameters(), values);
 		this.method = method;
+		this.values = values;
 	}
 
 	public Range<Distance> getDistanceRange() {
@@ -120,5 +123,13 @@ public class MongoParametersParameterAccessor extends ParametersParameterAccesso
 		throw new IllegalArgumentException(String.format(
 				"Expected full text parameter to be one of String, Term or TextCriteria but found %s.",
 				ClassUtils.getShortName(fullText.getClass())));
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getValues()
+	 */
+	@Override
+	public Object[] getValues() {
+		return values;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
@@ -22,6 +22,7 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.TextCriteria;
+import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.PartTree;
@@ -34,6 +35,7 @@ import com.mongodb.util.JSONParseException;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 public class PartTreeMongoQuery extends AbstractMongoQuery {
 
@@ -45,11 +47,13 @@ public class PartTreeMongoQuery extends AbstractMongoQuery {
 	 * Creates a new {@link PartTreeMongoQuery} from the given {@link QueryMethod} and {@link MongoTemplate}.
 	 * 
 	 * @param method must not be {@literal null}.
-	 * @param template must not be {@literal null}.
+	 * @param mongoOperations must not be {@literal null}.
+	 * @param evaluationContextProvider must not be {@literal null}.
 	 */
-	public PartTreeMongoQuery(MongoQueryMethod method, MongoOperations mongoOperations) {
+	public PartTreeMongoQuery(MongoQueryMethod method, MongoOperations mongoOperations,
+			EvaluationContextProvider evaluationContextProvider) {
 
-		super(method, mongoOperations);
+		super(method, mongoOperations, evaluationContextProvider);
 		this.tree = new PartTree(method.getName(), method.getEntityInformation().getJavaType());
 		this.isGeoNearQuery = method.isGeoNearQuery();
 		this.context = mongoOperations.getConverter().getMappingContext();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -34,6 +34,7 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.mongodb.repository.Person.Sex;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Sample repository managing {@link Person} entities.
@@ -333,4 +334,22 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	 */
 	@Query("{ firstname : { $in : ?0 }}")
 	Stream<Person> findByCustomQueryWithStreamingCursorByFirstnames(List<String> firstnames);
+	
+	/**
+	 * @see DATAMONGO-990
+	 */
+	@Query("{ firstname : ?#{[0]}}")
+	List<Person> findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly(String firstname);
+	
+	/**
+	 * @see DATAMONGO-990
+	 */
+	@Query("{ firstname : ?#{[0]}, email: ?#{principal.email} }")
+	List<Person> findWithSpelByFirstnameAndCurrentUserWithCustomQuery(String firstname);
+	
+	/**
+	 * @see DATAMONGO-990
+	 */
+	@Query("{ firstname : :#{#firstname}}")
+	List<Person> findWithSpelByFirstnameForSpELExpressionWithParameterVariableOnly(@Param("firstname") String firstname);
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests.java
@@ -15,6 +15,14 @@
  */
 package org.springframework.data.mongodb.repository;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.mongodb.repository.SampleEvaluationContextExtension.SampleSecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -24,4 +32,43 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Thomas Darimont
  */
 @ContextConfiguration
-public class PersonRepositoryIntegrationTests extends AbstractPersonRepositoryIntegrationTests {}
+public class PersonRepositoryIntegrationTests extends AbstractPersonRepositoryIntegrationTests {
+
+	/**
+	 * @see DATAMONGO-990 
+	 */
+	@Test
+	public void shouldFindByFirstnameForSpELExpressionWithParameterIndexOnly() {
+
+		List<Person> users = repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Dave");
+
+		assertThat(users, hasSize(1));
+		assertThat(users.get(0), is(dave));
+	}
+	
+	/**
+	 * @see DATAMONGO-990 
+	 */
+	@Test
+	public void shouldFindByFirstnameAndCurrentUserWithCustomQuery() {
+
+		SampleSecurityContextHolder.getCurrent().setPrincipal(dave);
+		List<Person> users = repository.findWithSpelByFirstnameAndCurrentUserWithCustomQuery("Dave");
+
+		assertThat(users, hasSize(1));
+		assertThat(users.get(0), is(dave));
+	}
+	
+	/**
+	 * @see DATAMONGO-990 
+	 */
+	@Test
+	public void shouldFindByFirstnameForSpELExpressionWithParameterVariableOnly() {
+
+		List<Person> users = repository.findWithSpelByFirstnameForSpELExpressionWithParameterVariableOnly("Dave");
+
+		assertThat(users, hasSize(1));
+		assertThat(users.get(0), is(dave));
+	}	
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SampleEvaluationContextExtension.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SampleEvaluationContextExtension.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.data.repository.query.spi.EvaluationContextExtension;
+import org.springframework.data.repository.query.spi.EvaluationContextExtensionSupport;
+
+/**
+ * A sample implementation of a custom {@link EvaluationContextExtension}.
+ * 
+ * @author Thomas Darimont
+ */
+public class SampleEvaluationContextExtension extends EvaluationContextExtensionSupport {
+
+	@Override
+	public String getExtensionId() {
+		return "security";
+	}
+
+	@Override
+	public Map<String, Object> getProperties() {
+		return Collections.singletonMap("principal", SampleSecurityContextHolder.getCurrent().getPrincipal());
+	}
+
+	/**
+	 * @author Thomas Darimont
+	 */
+	public static class SampleSecurityContextHolder {
+
+		private static ThreadLocal<SampleAuthentication> auth = new ThreadLocal<SampleAuthentication>() {
+
+			protected SampleAuthentication initialValue() {
+				return new SampleAuthentication(new SampleUser(-1, "anonymous"));
+			}
+
+		};
+
+		public static SampleAuthentication getCurrent() {
+			return auth.get();
+		}
+
+		public static void clear() {
+			auth.remove();
+		}
+	}
+
+	/**
+	 * @author Thomas Darimont
+	 */
+	public static class SampleAuthentication {
+
+		private Object principal;
+
+		public SampleAuthentication(Object principal) {
+			this.principal = principal;
+		}
+
+		public Object getPrincipal() {
+			return principal;
+		}
+
+		public void setPrincipal(Object principal) {
+			this.principal = principal;
+		}
+	}
+
+	/**
+	 * @author Thomas Darimont
+	 */
+	public static class SampleUser {
+
+		private Object id;
+		private String name;
+
+		public SampleUser(Object id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Object getId() {
+			return id;
+		}
+
+		public void setId(Object id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public SampleUser withName(String name) {
+
+			this.name = name;
+			return this;
+		}
+
+		public SampleUser withId(Object id) {
+
+			this.id = id;
+			return this;
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,14 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -54,6 +58,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.Meta;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
 
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
@@ -64,6 +69,7 @@ import com.mongodb.WriteResult;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractMongoQueryUnitTests {
@@ -314,7 +320,7 @@ public class AbstractMongoQueryUnitTests {
 		private boolean isDeleteQuery;
 
 		public MongoQueryFake(MongoQueryMethod method, MongoOperations operations) {
-			super(method, operations);
+			super(method, operations, DefaultEvaluationContextProvider.INSTANCE);
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
@@ -15,10 +15,11 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.data.mongodb.core.query.IsTextQuery.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.data.mongodb.core.query.IsTextQuery.isTextQuery;
 
 import java.lang.reflect.Method;
 
@@ -43,6 +44,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Person;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
 
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.util.JSONParseException;
@@ -52,6 +54,7 @@ import com.mongodb.util.JSONParseException;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PartTreeMongoQueryUnitTests {
@@ -169,7 +172,7 @@ public class PartTreeMongoQueryUnitTests {
 			Method method = Repo.class.getMethod(methodName, paramTypes);
 			MongoQueryMethod queryMethod = new MongoQueryMethod(method, metadataMock, mappingContext);
 
-			return new PartTreeMongoQuery(queryMethod, mongoOperationsMock);
+			return new PartTreeMongoQuery(queryMethod, mongoOperationsMock, DefaultEvaluationContextProvider.INSTANCE);
 		} catch (NoSuchMethodException e) {
 			throw new IllegalArgumentException(e.getMessage(), e);
 		} catch (SecurityException e) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StubParameterAccessor.java
@@ -32,6 +32,7 @@ import org.springframework.data.repository.query.ParameterAccessor;
  * 
  * @author Oliver Gierke
  * @author Christoh Strobl
+ * @author Thomas Darimont
  */
 class StubParameterAccessor implements MongoParameterAccessor {
 
@@ -128,5 +129,13 @@ class StubParameterAccessor implements MongoParameterAccessor {
 	@Override
 	public TextCriteria getFullText() {
 		return null;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.MongoParameterAccessor#getValues()
+	 */
+	@Override
+	public Object[] getValues() {
+		return this.values;
 	}
 }

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests-context.xml
@@ -26,6 +26,12 @@
 				</constructor-arg>
 			</bean>
 		</property>
+		<property name="evaluationContextProvider" ref="extensionAwareEvaluationContextProvider"/>
 	</bean>
 
+	<bean id="sampleEvaluationContextExtension" class="org.springframework.data.mongodb.repository.SampleEvaluationContextExtension"/>
+
+	<bean id="extensionAwareEvaluationContextProvider" class="org.springframework.data.repository.query.ExtensionAwareEvaluationContextProvider">
+		<constructor-arg ref="sampleEvaluationContextExtension"/>
+	</bean>
 </beans>


### PR DESCRIPTION
Ported and adapted support for SpEL expressions @Query annotations from Spring Data JPA. StringBasedMongoQuery can now evaluate SpEL fragments in queries with the help of the given EvaluationContextProvider. Introduced EvaluationContextProvider to AbstractMongoQuery. Exposed access to actual parameter values in MongoParameterAccessor.