### PR TITLE
DATAMONGO-1193 - Prevent unnecessary db lookups when resolving DBRefs on 2.x driver.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -106,7 +106,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 	 */
 	@Override
 	public DBObject fetch(DBRef dbRef) {
-		return ReflectiveDBRefResolver.fetch(mongoDbFactory.getDb(), dbRef);
+		return ReflectiveDBRefResolver.fetch(mongoDbFactory, dbRef);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/ReflectiveDBRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/ReflectiveDBRefResolver.java
@@ -20,9 +20,9 @@ import static org.springframework.util.ReflectionUtils.*;
 
 import java.lang.reflect.Method;
 
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.util.Assert;
 
-import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
@@ -51,12 +51,14 @@ class ReflectiveDBRefResolver {
 	 * @param ref must not be {@literal null}.
 	 * @return the document that this references.
 	 */
-	public static DBObject fetch(DB db, DBRef ref) {
+	public static DBObject fetch(MongoDbFactory factory, DBRef ref) {
 
 		Assert.notNull(ref, "DBRef to fetch must not be null!");
 
 		if (isMongo3Driver()) {
-			return db.getCollection(ref.getCollectionName()).findOne(ref.getId());
+
+			Assert.notNull(factory, "DbFactory to fetch DB from must not be null!");
+			return factory.getDb().getCollection(ref.getCollectionName()).findOne(ref.getId());
 		}
 
 		return (DBObject) invokeMethod(FETCH_METHOD, ref);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/ReflectiveDBRefResolverUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/ReflectiveDBRefResolverUnitTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.util.MongoClientVersion.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mongodb.MongoDbFactory;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBRef;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReflectiveDBRefResolverUnitTests {
+
+	@Mock MongoDbFactory dbFactoryMock;
+	@Mock DBRef dbRefMock;
+	@Mock DB dbMock;
+	@Mock DBCollection collectionMock;
+
+	@Before
+	public void setUp() {
+
+		when(dbRefMock.getCollectionName()).thenReturn("collection-1");
+		when(dbRefMock.getId()).thenReturn("id-1");
+		when(dbFactoryMock.getDb()).thenReturn(dbMock);
+		when(dbMock.getCollection(eq("collection-1"))).thenReturn(collectionMock);
+		when(collectionMock.findOne(eq("id-1"))).thenReturn(new BasicDBObject("_id", "id-1"));
+	}
+
+	/**
+	 * @see DATAMONGO-1193
+	 */
+	@Test
+	public void fetchShouldNotLookUpDbWhenUsingDriverVersion2() {
+
+		assumeThat(isMongo3Driver(), is(false));
+
+		ReflectiveDBRefResolver.fetch(dbFactoryMock, dbRefMock);
+
+		verify(dbFactoryMock, never()).getDb();
+		verify(dbFactoryMock, never()).getDb(anyString());
+	}
+
+	/**
+	 * @see DATAMONGO-1193
+	 */
+	@Test
+	public void fetchShouldUseDbToResolveDbRefWhenUsingDriverVersion3() {
+
+		assumeThat(isMongo3Driver(), is(true));
+
+		assertThat(ReflectiveDBRefResolver.fetch(dbFactoryMock, dbRefMock), notNullValue());
+		verify(dbFactoryMock, times(1)).getDb();
+	}
+
+	/**
+	 * @see DATAMONGO-1193
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void fetchShouldThrowExceptionWhenDbFactoryIsNullUsingDriverVersion3() {
+
+		assumeThat(isMongo3Driver(), is(true));
+
+		ReflectiveDBRefResolver.fetch(null, dbRefMock);
+	}
+}


### PR DESCRIPTION
We now check against the used driver version before requesting `DB` from `MongoDbFactory`. 

Potential improvements on fetch strategy for MongoDB Java Driver 3 will be handled in [DATAMONGO-1194](https://jira.spring.io/browse/DATAMONGO-1194).