### PR TITLE
Update ObjectPath.java comparison for dbrefs

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/ObjectPath.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/ObjectPath.java
@@ -103,8 +103,8 @@ class ObjectPath {
 			if (item.getIdValue() == null) {
 				continue;
 			}
-
-			if (collection.equals(item.getCollection()) && id.equals(item.getIdValue())) {
+// on mongo 3.0.0 driver equals is not comparing String and ObjectId, so if id is String then some other equals should be
+			if (collection.equals(item.getCollection()) && id.equals(item.getIdValue() instanceof String ? new ObjectId(item.getIdValue()) : item.getIdValue())) {
 				return object;
 			}
 		}


### PR DESCRIPTION
// on mongo 3.0.0 driver equals is not comparing String and ObjectId, so if id is String then some other equals should be.
Details: https://github.com/mongodb/mongo-java-driver/commit/aa4b4355c808e045ce00cc1dfbdd0bf78fb6901a
"... equals method will no longer compare equal to anything but an ObjectId ..."
Please fix this issue. I am not sure my fix is 100% correct.