### PR TITLE
Write the type hint _class always after all other fields.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -508,12 +508,12 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		Object existingValue = accessor.get(prop);
 		BasicDBObject propDbObj = existingValue instanceof BasicDBObject ? (BasicDBObject) existingValue
 				: new BasicDBObject();
-		addCustomTypeKeyIfNecessary(ClassTypeInformation.from(prop.getRawType()), obj, propDbObj);
 
 		MongoPersistentEntity<?> entity = isSubtype(prop.getType(), obj.getClass()) ? mappingContext
 				.getPersistentEntity(obj.getClass()) : mappingContext.getPersistentEntity(type);
 
 		writeInternal(obj, propDbObj, entity);
+		addCustomTypeKeyIfNecessary(ClassTypeInformation.from(prop.getRawType()), obj, propDbObj);
 		accessor.put(prop, propDbObj);
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -344,13 +344,13 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		boolean handledByCustomConverter = conversions.getCustomWriteTarget(entityType, DBObject.class) != null;
 		TypeInformation<? extends Object> type = ClassTypeInformation.from(entityType);
 
-		if (!handledByCustomConverter && !(dbo instanceof BasicDBList)) {
-			typeMapper.writeType(type, dbo);
-		}
-
 		Object target = obj instanceof LazyLoadingProxy ? ((LazyLoadingProxy) obj).getTarget() : obj;
 
 		writeInternal(target, dbo, type);
+
+		if (!handledByCustomConverter && !(dbo instanceof BasicDBList)) {
+			typeMapper.writeType(type, dbo);
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2297,8 +2297,8 @@ public class MongoTemplateTests {
 
 		template.save(doc);
 
-		Update update = new Update().pushAll("string1", new Object[]{"data", "mongodb"});
-		update.pushAll("string2", new String[]{"two", "three"});
+		Update update = new Update().pushAll("string1", new Object[] { "data", "mongodb" });
+		update.pushAll("string2", new String[] { "two", "three" });
 
 		Query findQuery = new Query(Criteria.where("id").is(doc.id));
 		template.updateFirst(findQuery, update, DocumentWithMultipleCollections.class);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2297,8 +2297,8 @@ public class MongoTemplateTests {
 
 		template.save(doc);
 
-		Update update = new Update().pushAll("string1", new Object[] { "data", "mongodb" });
-		update.pushAll("string2", new String[] { "two", "three" });
+		Update update = new Update().pushAll("string1", new Object[]{"data", "mongodb"});
+		update.pushAll("string2", new String[]{"two", "three"});
 
 		Query findQuery = new Query(Criteria.where("id").is(doc.id));
 		template.updateFirst(findQuery, update, DocumentWithMultipleCollections.class);
@@ -2721,6 +2721,28 @@ public class MongoTemplateTests {
 
 		template.remove(object, "collection");
 		assertThat(template.findAll(DBObject.class, "collection"), hasSize(0));
+	}
+
+	@Test
+	public void findAndModifyAddToSetWithEachShouldNotAddDuplicatesForComplexObjects() {
+		DocumentWithCollection doc = new DocumentWithCollection(Arrays.<Model>asList(new ModelA("value1")));
+
+		template.save(doc);
+
+		Query query = query(where("id").is(doc.id));
+
+		assertThat(template.findOne(query, DocumentWithCollection.class), notNullValue());
+
+		Update update = new Update().addToSet("models").each(Arrays.asList(new ModelA("value2"), new ModelA("value1")));
+
+		template.findAndModify(query, update, DocumentWithCollection.class);
+
+		DocumentWithCollection retrieved = template.findOne(query, DocumentWithCollection.class);
+
+		assertThat(retrieved, notNullValue());
+		assertThat(retrieved.models, hasSize(2));
+		assertThat(retrieved.models.get(0).value(), is("value1"));
+		assertThat(retrieved.models.get(1).value(), is("value2"));
 	}
 
 	static class DoucmentWithNamedIdField {


### PR DESCRIPTION
FindAndModify writes the type hint _class either before or after all other fields, whereas save writes it always after. Because of that, MongoDBs addToSet/forEach treats two objects as different, even though they only differ in the position of _class. As a consequence, findAndModify/addToSet/forEach adds duplicates to collections.

The proposed change fixes this by always writing the type hint after all fields.

Unfortunately, this works only for collection fields of complex documents, when both save and findAndModify write the type hint. Please see my other pull request for a test that demonstrates the erroneous behaviour in case of simple documents, where the type hint is written by findAndModify.
