### PR TITLE
Demonstrate erroneous behaviour of findAndModify/addToSet/withEach

### DIFF
--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2609,6 +2609,29 @@ public class MongoTemplateTests {
 		assertThat(template.findOne(query, DocumentWithCollectionOfSimpleType.class).values, hasSize(3));
 	}
 
+	@Test
+	public void findAndModifyAddToSetWithEachShouldNotAddDuplicatesNorTypeHintForSimpleDocuments() {
+		DocumentWithCollectionOfSamples doc = new DocumentWithCollectionOfSamples();
+		doc.samples = Arrays.asList(new Sample(null, "sample1"));
+
+		template.save(doc);
+
+		Query query = query(where("id").is(doc.id));
+
+		assertThat(template.findOne(query, DocumentWithCollectionOfSamples.class), notNullValue());
+
+		Update update = new Update().addToSet("samples").each(Arrays.asList(new Sample(null, "sample2"), new Sample(null, "sample1")));
+
+		template.findAndModify(query, update, DocumentWithCollectionOfSamples.class);
+
+		DocumentWithCollectionOfSamples retrieved = template.findOne(query, DocumentWithCollectionOfSamples.class);
+
+		assertThat(retrieved, notNullValue());
+		assertThat(retrieved.samples, hasSize(2));
+		assertThat(retrieved.samples.get(0).field, is("sample1"));
+		assertThat(retrieved.samples.get(1).field, is("sample2"));
+	}
+
 	/**
 	 * @see DATAMONGO-888
 	 */
@@ -2796,6 +2819,12 @@ public class MongoTemplateTests {
 
 		@Id String id;
 		List<String> values;
+	}
+
+	static class DocumentWithCollectionOfSamples
+	{
+		@Id String id;
+		List<Sample> samples;
 	}
 
 	static class DocumentWithMultipleCollections {


### PR DESCRIPTION
Add test that demonstrates that findAndModify/addToSet/withEach adds duplicate elements to collections of simple documents.

The problem stems from the inconsistent handling of type hints (_class):
MongoTemplate.save does not add a type hint, but findAndModify does. The same values are then treated differently by MongoDB, depending on whether they have a type hint or not. To verify this behaviour, you can manually add the (superfluous) type hint to the 'save'd object - findAndModify will then work as expected.
The behaviour of MongoDB is consistent with the documentation: http://docs.mongodb.org/manual/reference/operator/update/addToSet/: "If the value is a document, MongoDB determines that the document is a duplicate if an existing document in the array matches the to-be-added document exactly;...As such, field order matters..."