### PR TITLE
DATAMONGO-1210 - Inconsistent usage of _class type hint within Update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1210-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -816,7 +816,7 @@ public class QueryMapper {
 
 			try {
 
-				PropertyPath path = PropertyPath.from(pathExpression, entity.getTypeInformation());
+				PropertyPath path = PropertyPath.from(pathExpression.replaceAll("\\.\\d", ""), entity.getTypeInformation());
 				PersistentPropertyPath<MongoPersistentProperty> propertyPath = mappingContext.getPersistentPropertyPath(path);
 
 				Iterator<MongoPersistentProperty> iterator = propertyPath.iterator();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -97,14 +97,14 @@ public class UpdateMapper extends QueryMapper {
 
 		if (rawValue instanceof Modifier) {
 
-			value = getMappedValue((Modifier) rawValue);
+			value = getMappedValue(field, (Modifier) rawValue);
 
 		} else if (rawValue instanceof Modifiers) {
 
 			DBObject modificationOperations = new BasicDBObject();
 
 			for (Modifier modifier : ((Modifiers) rawValue).getModifiers()) {
-				modificationOperations.putAll(getMappedValue(modifier).toMap());
+				modificationOperations.putAll(getMappedValue(field, modifier).toMap());
 			}
 
 			value = modificationOperations;
@@ -132,10 +132,21 @@ public class UpdateMapper extends QueryMapper {
 		return value instanceof Query;
 	}
 
-	private DBObject getMappedValue(Modifier modifier) {
+	private DBObject getMappedValue(Field field, Modifier modifier) {
 
-		Object value = converter.convertToMongoType(modifier.getValue(), ClassTypeInformation.OBJECT);
+		Object value = converter.convertToMongoType(modifier.getValue(),
+				requiresTypeHint(field) ? ClassTypeInformation.OBJECT : null);
 		return new BasicDBObject(modifier.getKey(), value);
+	}
+
+	private boolean requiresTypeHint(Field field) {
+
+		if (field == null || field.getProperty() == null) {
+			return true;
+		}
+
+		return field.getProperty().getActualType().isInterface()
+				|| java.lang.reflect.Modifier.isAbstract(field.getProperty().getActualType().getModifiers());
 	}
 
 	/* 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -244,7 +244,35 @@ public class UpdateMapper extends QueryMapper {
 			protected String mapPropertyName(MongoPersistentProperty property) {
 
 				String mappedName = PropertyToFieldNameConverter.INSTANCE.convert(property);
-				return iterator.hasNext() && iterator.next().equals("$") ? String.format("%s.$", mappedName) : mappedName;
+
+				boolean inspect = iterator.hasNext();
+				while (inspect) {
+
+					String partial = iterator.next();
+
+					boolean isPositional = isPositionalParameter(partial);
+					if (isPositional) {
+						mappedName += "." + partial;
+					}
+
+					inspect = isPositional && iterator.hasNext();
+				}
+
+				return mappedName;
+			}
+
+			boolean isPositionalParameter(String partial) {
+
+				if (partial.equals("$")) {
+					return true;
+				}
+
+				try {
+					Long.valueOf(partial);
+					return true;
+				} catch (NumberFormatException e) {
+					return false;
+				}
 			}
 
 		}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2210,11 +2210,12 @@ public class MongoTemplateTests {
 		assertThat(retrieved.model.value(), equalTo("value2"));
 	}
 
-	// Rewrite the whole collection
-	// Passes in 1.6.0+, but changes order position of type hint _class
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnDocumentWithNestedCollection()
-	{
+	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnDocumentWithNestedCollectionWhenWholeCollectionIsReplaced() {
+
 		DocumentWithNestedCollection doc = new DocumentWithNestedCollection();
 
 		Map<String, Model> entry = new HashMap<String, Model>();
@@ -2246,12 +2247,12 @@ public class MongoTemplateTests {
 		assertThat(retrieved.models.get(0).get("key2").value(), equalTo("value2"));
 	}
 
-
-	// Update first list element
-	// Fails in 1.6.2+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnDocumentWithNestedCollection2()
-	{
+	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnDocumentWithNestedCollectionWhenFirstElementIsReplaced() {
+
 		DocumentWithNestedCollection doc = new DocumentWithNestedCollection();
 
 		Map<String, Model> entry = new HashMap<String, Model>();
@@ -2283,11 +2284,12 @@ public class MongoTemplateTests {
 		assertThat(retrieved.models.get(0).get("key2").value(), equalTo("value2"));
 	}
 
-	// Add second list element
-	// Fails in 1.6.2+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldAddTypeInformationOnDocumentWithNestedCollection2()
-	{
+	public void findAndModifyShouldAddTypeInformationOnDocumentWithNestedCollectionObjectInsertedAtSecondIndex() {
+
 		DocumentWithNestedCollection doc = new DocumentWithNestedCollection();
 
 		Map<String, Model> entry = new HashMap<String, Model>();
@@ -2318,15 +2320,18 @@ public class MongoTemplateTests {
 		assertThat(retrieved.models.get(1).get("key2").value(), equalTo("value2"));
 	}
 
-	// Update the collection of the embedded document
-	// Fails in 1.6.0+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollection() throws Exception
-	{
+	public void findAndModifyShouldRetainTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollectionWhenUpdatingPositionedElement()
+			throws Exception {
+
 		List<Model> models = new ArrayList<Model>();
 		models.add(new ModelA("value1"));
 
-		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(new DocumentWithCollection(models));
+		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(
+				new DocumentWithCollection(models));
 
 		template.save(doc);
 
@@ -2337,22 +2342,26 @@ public class MongoTemplateTests {
 
 		template.findAndModify(query, update, DocumentWithEmbeddedDocumentWithCollection.class);
 
-		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query, DocumentWithEmbeddedDocumentWithCollection.class);
+		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query,
+				DocumentWithEmbeddedDocumentWithCollection.class);
 
 		assertThat(retrieved, notNullValue());
 		assertThat(retrieved.embeddedDocument.models, hasSize(1));
 		assertThat(retrieved.embeddedDocument.models.get(0).value(), is("value2"));
 	}
 
-	// Update the collection of the embedded document
-	// Fails in 1.6.0+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollection2() throws Exception
-	{
+	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollectionWhenUpdatingSecondElement()
+			throws Exception {
+
 		List<Model> models = new ArrayList<Model>();
 		models.add(new ModelA("value1"));
 
-		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(new DocumentWithCollection(models));
+		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(
+				new DocumentWithCollection(models));
 
 		template.save(doc);
 
@@ -2363,7 +2372,8 @@ public class MongoTemplateTests {
 
 		template.findAndModify(query, update, DocumentWithEmbeddedDocumentWithCollection.class);
 
-		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query, DocumentWithEmbeddedDocumentWithCollection.class);
+		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query,
+				DocumentWithEmbeddedDocumentWithCollection.class);
 
 		assertThat(retrieved, notNullValue());
 		assertThat(retrieved.embeddedDocument.models, hasSize(2));
@@ -2371,35 +2381,42 @@ public class MongoTemplateTests {
 		assertThat(retrieved.embeddedDocument.models.get(1).value(), is("value2"));
 	}
 
-	// Rewrite the embedded document
-	// Fails in 1.6.0+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollection3() throws Exception
-	{
-		List<Model> models = Arrays.<Model>asList(new ModelA("value1"));
+	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnEmbeddedDocumentWithCollectionWhenRewriting()
+			throws Exception {
 
-		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(new DocumentWithCollection(models));
+		List<Model> models = Arrays.<Model> asList(new ModelA("value1"));
+
+		DocumentWithEmbeddedDocumentWithCollection doc = new DocumentWithEmbeddedDocumentWithCollection(
+				new DocumentWithCollection(models));
 
 		template.save(doc);
 
 		Query query = query(where("id").is(doc.id));
-		Update update = Update.update("embeddedDocument", new DocumentWithCollection(Arrays.<Model>asList(new ModelA("value2"))));
+		Update update = Update.update("embeddedDocument",
+				new DocumentWithCollection(Arrays.<Model> asList(new ModelA("value2"))));
 
 		assertThat(template.findOne(query, DocumentWithEmbeddedDocumentWithCollection.class), notNullValue());
 
 		template.findAndModify(query, update, DocumentWithEmbeddedDocumentWithCollection.class);
 
-		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query, DocumentWithEmbeddedDocumentWithCollection.class);
+		DocumentWithEmbeddedDocumentWithCollection retrieved = template.findOne(query,
+				DocumentWithEmbeddedDocumentWithCollection.class);
 
 		assertThat(retrieved, notNullValue());
 		assertThat(retrieved.embeddedDocument.models, hasSize(1));
 		assertThat(retrieved.embeddedDocument.models.get(0).value(), is("value2"));
 	}
 
-	// Fails in 1.6.0+
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
-	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnDocumentWithNestedLists()
-	{
+	public void findAndModifyShouldAddTypeInformationWithinUpdatedTypeOnDocumentWithNestedLists() {
+
 		DocumentWithNestedList doc = new DocumentWithNestedList();
 
 		List<Model> entry = new ArrayList<Model>();
@@ -3079,25 +3096,21 @@ public class MongoTemplateTests {
 		List<String> string2;
 	}
 
-	static class DocumentWithNestedCollection
-	{
+	static class DocumentWithNestedCollection {
 		@Id String id;
 		List<Map<String, Model>> models = new ArrayList<Map<String, Model>>();
 	}
 
-	static class DocumentWithNestedList
-	{
+	static class DocumentWithNestedList {
 		@Id String id;
 		List<List<Model>> models = new ArrayList<List<Model>>();
-    }
+	}
 
-	static class DocumentWithEmbeddedDocumentWithCollection
-	{
+	static class DocumentWithEmbeddedDocumentWithCollection {
 		@Id String id;
 		DocumentWithCollection embeddedDocument;
 
-		DocumentWithEmbeddedDocumentWithCollection(DocumentWithCollection embeddedDocument)
-		{
+		DocumentWithEmbeddedDocumentWithCollection(DocumentWithCollection embeddedDocument) {
 			this.embeddedDocument = embeddedDocument;
 		}
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -192,6 +192,7 @@ public class MongoTemplateTests {
 		template.dropCollection(SomeContent.class);
 		template.dropCollection(SomeTemplate.class);
 		template.dropCollection(Address.class);
+		template.dropCollection(DocumentWithCollectionOfSamples.class);
 	}
 
 	@Test
@@ -2611,8 +2612,12 @@ public class MongoTemplateTests {
 		assertThat(template.findOne(query, DocumentWithCollectionOfSimpleType.class).values, hasSize(3));
 	}
 
+	/**
+	 * @see DATAMONGO-1210
+	 */
 	@Test
 	public void findAndModifyAddToSetWithEachShouldNotAddDuplicatesNorTypeHintForSimpleDocuments() {
+
 		DocumentWithCollectionOfSamples doc = new DocumentWithCollectionOfSamples();
 		doc.samples = Arrays.asList(new Sample(null, "sample1"));
 
@@ -2622,7 +2627,7 @@ public class MongoTemplateTests {
 
 		assertThat(template.findOne(query, DocumentWithCollectionOfSamples.class), notNullValue());
 
-		Update update = new Update().addToSet("samples").each(Arrays.asList(new Sample(null, "sample2"), new Sample(null, "sample1")));
+		Update update = new Update().addToSet("samples").each(new Sample(null, "sample2"), new Sample(null, "sample1"));
 
 		template.findAndModify(query, update, DocumentWithCollectionOfSamples.class);
 
@@ -2840,8 +2845,7 @@ public class MongoTemplateTests {
 		List<String> values;
 	}
 
-	static class DocumentWithCollectionOfSamples
-	{
+	static class DocumentWithCollectionOfSamples {
 		@Id String id;
 		List<Sample> samples;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2611,6 +2611,29 @@ public class MongoTemplateTests {
 		assertThat(template.findOne(query, DocumentWithCollectionOfSimpleType.class).values, hasSize(3));
 	}
 
+	@Test
+	public void findAndModifyAddToSetWithEachShouldNotAddDuplicatesNorTypeHintForSimpleDocuments() {
+		DocumentWithCollectionOfSamples doc = new DocumentWithCollectionOfSamples();
+		doc.samples = Arrays.asList(new Sample(null, "sample1"));
+
+		template.save(doc);
+
+		Query query = query(where("id").is(doc.id));
+
+		assertThat(template.findOne(query, DocumentWithCollectionOfSamples.class), notNullValue());
+
+		Update update = new Update().addToSet("samples").each(Arrays.asList(new Sample(null, "sample2"), new Sample(null, "sample1")));
+
+		template.findAndModify(query, update, DocumentWithCollectionOfSamples.class);
+
+		DocumentWithCollectionOfSamples retrieved = template.findOne(query, DocumentWithCollectionOfSamples.class);
+
+		assertThat(retrieved, notNullValue());
+		assertThat(retrieved.samples, hasSize(2));
+		assertThat(retrieved.samples.get(0).field, is("sample1"));
+		assertThat(retrieved.samples.get(1).field, is("sample2"));
+	}
+
 	/**
 	 * @see DATAMONGO-888
 	 */
@@ -2815,6 +2838,12 @@ public class MongoTemplateTests {
 
 		@Id String id;
 		List<String> values;
+	}
+
+	static class DocumentWithCollectionOfSamples
+	{
+		@Id String id;
+		List<Sample> samples;
 	}
 
 	static class DocumentWithMultipleCollections {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/IsBsonObject.java
@@ -90,6 +90,10 @@ public class IsBsonObject<T extends BSONObject> extends TypeSafeMatcher<T> {
 				return false;
 			}
 
+			if (o != null && expectation.not) {
+				return false;
+			}
+
 		}
 		return true;
 	}


### PR DESCRIPTION
We now inspect the given property and its type for more fine graind distinction on type hints. Furthermore we retain positional parameters even for deeply nested structures such as `List<List<SomeType...`.

Prior to this change `Update` mapping showed several inconsistencies in terms of providing type hints (aka) `_class` properties which potentially lead to duplicates using `$addToSet`, invalid documents and ignored positional parameters in case of `$set`.

This PR includes (next to others) fixes for the test cases provided in #290 and #291.
