### PR TITLE
DATAMONGO-1218 - Deprecate non-MongoClient related configuration options in XML namespace.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 by the original author(s).
+ * Copyright 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 import com.mongodb.Mongo;
+import com.mongodb.MongoClientURI;
 import com.mongodb.MongoURI;
 
 /**
@@ -42,6 +43,7 @@ import com.mongodb.MongoURI;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 
@@ -64,28 +66,26 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 
-		Object source = parserContext.extractSource(element);
-
-		BeanComponentDefinitionBuilder helper = new BeanComponentDefinitionBuilder(element, parserContext);
-
-		String uri = element.getAttribute("uri");
-		String mongoRef = element.getAttribute("mongo-ref");
-		String dbname = element.getAttribute("dbname");
-
-		BeanDefinition userCredentials = getUserCredentialsBeanDefinition(element, parserContext);
-
 		// Common setup
 		BeanDefinitionBuilder dbFactoryBuilder = BeanDefinitionBuilder.genericBeanDefinition(SimpleMongoDbFactory.class);
 		setPropertyValue(dbFactoryBuilder, element, "write-concern", "writeConcern");
 
-		if (StringUtils.hasText(uri)) {
-			if (StringUtils.hasText(mongoRef) || StringUtils.hasText(dbname) || userCredentials != null) {
-				parserContext.getReaderContext().error("Configure either Mongo URI or details individually!", source);
+		BeanDefinition mongoUri = getMongoURI(element);
+		if (mongoUri != null) {
+			if (element.getAttributes().getLength() >= 2 && !element.hasAttribute("write-concern")) {
+				parserContext.getReaderContext().error("Configure either Mongo URI or details individually!",
+						parserContext.extractSource(element));
 			}
-
-			dbFactoryBuilder.addConstructorArgValue(getMongoUri(uri));
+			dbFactoryBuilder.addConstructorArgValue(mongoUri);
 			return getSourceBeanDefinition(dbFactoryBuilder, parserContext, element);
 		}
+
+		BeanComponentDefinitionBuilder helper = new BeanComponentDefinitionBuilder(element, parserContext);
+
+		String mongoRef = element.getAttribute("mongo-ref");
+		String dbname = element.getAttribute("dbname");
+
+		BeanDefinition userCredentials = getUserCredentialsBeanDefinition(element, parserContext);
 
 		// Defaulting
 		if (StringUtils.hasText(mongoRef)) {
@@ -147,14 +147,24 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 	}
 
 	/**
-	 * Creates a {@link BeanDefinition} for a {@link MongoURI}.
+	 * Creates a {@link BeanDefinition} for a {@link MongoURI} or {@link MongoClientURI} depending on configured
+	 * attributes.
 	 * 
-	 * @param uri
-	 * @return
+	 * @param element
+	 * @return {@literal null} in case no client-/uri defined.
 	 */
-	private BeanDefinition getMongoUri(String uri) {
+	private BeanDefinition getMongoURI(Element element) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(MongoURI.class);
+		boolean hasClientUri = element.hasAttribute("client-uri");
+
+		if (!hasClientUri && !element.hasAttribute("uri")) {
+			return null;
+		}
+
+		Class<?> type = hasClientUri ? MongoClientURI.class : MongoURI.class;
+		String uri = hasClientUri ? element.getAttribute("client-uri") : element.getAttribute("uri");
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(type);
 		builder.addConstructorArgValue(uri);
 
 		return builder.getBeanDefinition();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbUtils.java
@@ -123,7 +123,7 @@ public abstract class MongoDbUtils {
 
 		DB db = mongo.getDB(databaseName);
 
-		if (requiresAuthDbAuthentication(credentials)) {
+		if (!(mongo instanceof MongoClient) && requiresAuthDbAuthentication(credentials)) {
 			ReflectiveDbInvoker.authenticate(mongo, db, credentials, authenticationDatabaseName);
 		}
 

--- a/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
@@ -5,4 +5,5 @@ http\://www.springframework.org/schema/data/mongo/spring-mongo-1.3.xsd=org/sprin
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.4.xsd=org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.5.xsd=org/springframework/data/mongodb/config/spring-mongo-1.5.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.7.xsd=org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
-http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo-1.8.xsd=org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.8.xsd

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
@@ -107,7 +107,13 @@ Deprecated since 1.7 - Please use MongoClient internal authentication. The passw
 			<xsd:attribute name="uri" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-The Mongo URI string.]]></xsd:documentation>
+Deprecated since 1.8 - Please use client-uri instead. The Mongo URI string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="client-uri" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The MongoClientURI string.]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="write-concern">

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.mongodb.DB;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
 import com.mongodb.MongoURI;
 import com.mongodb.WriteConcern;
 
@@ -172,6 +173,29 @@ public class MongoDbFactoryParserIntegrationTests {
 	@Test(expected = BeanDefinitionParsingException.class)
 	public void rejectsUriPlusDetailedConfiguration() {
 		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-uri-and-details.xml"));
+	}
+
+	/**
+	 * @see DATAMONGO-1218
+	 */
+	@Test
+	public void setsUpMongoDbFactoryUsingAMongoClientUri() {
+
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri.xml"));
+		BeanDefinition definition = factory.getBeanDefinition("mongoDbFactory");
+		ConstructorArgumentValues constructorArguments = definition.getConstructorArgumentValues();
+
+		assertThat(constructorArguments.getArgumentCount(), is(1));
+		ValueHolder argument = constructorArguments.getArgumentValue(0, MongoClientURI.class);
+		assertThat(argument, is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAMONGO-1218
+	 */
+	@Test(expected = BeanDefinitionParsingException.class)
+	public void rejectsClientUriPlusDetailedConfiguration() {
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri-and-details.xml"));
 	}
 
 	private static void assertWriteConcern(ClassPathXmlApplicationContext ctx, WriteConcern expectedWriteConcern) {

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-and-details.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-and-details.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory client-uri="mongodb://username:password@localhost/database" username="username" />
+
+</beans>

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory client-uri="mongodb://username:password@localhost/database" />
+
+</beans>


### PR DESCRIPTION
We added deprecation hints to the description sections of elements and attributes within the _spring-mongo-1.7.xsd_

Additionally we’ve added (for 1.8) a configuration attribute to _db-factory_ allowing to set a _client-uri_ creating a `MongoClientURI` instead of a `MongoURI` that will be passed on to `MongoDbFactory`. Just as _uri_, _client-uri_ will not allow additional configuration options like _username_, _password_ next to it.

We also now skip authentication via an explicit _AuthDB_ when requesting a `DB` via a `MongoClient` instance.