### PR TITLE
SimpleMongoRepository/findAll(): handle a concurrent addition

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
@@ -215,6 +215,7 @@ public class SimpleMongoRepository<T, ID extends Serializable> implements MongoR
 
 		Long count = count();
 		List<T> list = findAll(new Query().with(pageable));
+		count = Math.max(count, list.size()); // to handle a concurrent addition
 
 		return new PageImpl<T>(list, pageable, count);
 	}


### PR DESCRIPTION
The method findAll is not thread safe. When an addition occurs between
count(); and findAll(new Query().with(pageable)); 
if there's only one page we will have list.size() > count which causes an error in the constructor of PageImpl<T> :
Assert.isTrue(total >= content.size(), "Total must not be less than the number of elements given!");
