### PR TITLE
DATAMONGO-1236 - Update does not include type hint correctly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1236-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -25,6 +25,7 @@ import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsIterableContainingInOrder;
@@ -680,8 +681,85 @@ public class UpdateMapperUnitTests {
 				context.getPersistentEntity(DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes.class));
 
 		assertThat(mappedUpdate, isBsonObject().notContaining("$set.concreteTypeWithListAttributeOfInterfaceType._class"));
-		assertThat(mappedUpdate, isBsonObject()
-				.containing("$set.concreteTypeWithListAttributeOfInterfaceType.models.[0]._class", ModelImpl.class.getName()));
+		assertThat(
+				mappedUpdate,
+				isBsonObject().containing("$set.concreteTypeWithListAttributeOfInterfaceType.models.[0]._class",
+						ModelImpl.class.getName()));
+	}
+
+	/**
+	 * @see DATAMONGO-1236
+	 */
+	@Test
+	public void mappingShouldRetainTypeInformationForObjectValues() {
+
+		Update update = new Update().set("value", new NestedDocument("kaladin"));
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithObject.class));
+
+		assertThat(mappedUpdate, isBsonObject().containing("$set.value.name", "kaladin"));
+		assertThat(mappedUpdate, isBsonObject().containing("$set.value._class", NestedDocument.class.getName()));
+	}
+
+	/**
+	 * @see DATAMONGO-1236
+	 */
+	@Test
+	public void mappingShouldNotRetainTypeInformationForConcreteValues() {
+
+		Update update = new Update().set("concreteValue", new NestedDocument("shallan"));
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithObject.class));
+
+		assertThat(mappedUpdate, isBsonObject().containing("$set.concreteValue.name", "shallan"));
+		assertThat(mappedUpdate, isBsonObject().notContaining("$set.concreteValue._class"));
+	}
+
+	/**
+	 * @see DATAMONGO-1236
+	 */
+	@Test
+	public void mappingShouldRetainTypeInformationForObjectValuesWithAlias() {
+
+		Update update = new Update().set("value", new NestedDocument("adolin"));
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithAliasedObject.class));
+
+		assertThat(mappedUpdate, isBsonObject().containing("$set.renamed-value.name", "adolin"));
+		assertThat(mappedUpdate, isBsonObject().containing("$set.renamed-value._class", NestedDocument.class.getName()));
+	}
+
+	/**
+	 * @see DATAMONGO-1236
+	 */
+	@Test
+	public void mappingShouldRetrainTypeInformationWhenValueTypeOfMapDoesNotMatchItsDeclaration() {
+
+		Map<Object, Object> map = Collections.<Object, Object> singletonMap("szeth", new NestedDocument("son-son-vallano"));
+
+		Update update = new Update().set("map", map);
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithObjectMap.class));
+
+		assertThat(mappedUpdate, isBsonObject().containing("$set.map.szeth.name", "son-son-vallano"));
+		assertThat(mappedUpdate, isBsonObject().containing("$set.map.szeth._class", NestedDocument.class.getName()));
+	}
+
+	/**
+	 * @see DATAMONGO-1236
+	 */
+	@Test
+	public void mappingShouldNotContainTypeInformationWhenValueTypeOfMapMatchesDeclaration() {
+
+		Map<Object, NestedDocument> map = Collections.<Object, NestedDocument> singletonMap("jasnah", new NestedDocument(
+				"kholin"));
+
+		Update update = new Update().set("concreteMap", map);
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithObjectMap.class));
+
+		assertThat(mappedUpdate, isBsonObject().containing("$set.concreteMap.jasnah.name", "kholin"));
+		assertThat(mappedUpdate, isBsonObject().notContaining("$set.concreteMap.jasnah._class"));
 	}
 
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
@@ -888,5 +966,22 @@ public class UpdateMapperUnitTests {
 			super();
 			this.name = name;
 		}
+	}
+
+	static class EntityWithObject {
+
+		Object value;
+		NestedDocument concreteValue;
+	}
+
+	static class EntityWithAliasedObject {
+
+		@Field("renamed-value") Object value;
+	}
+
+	static class EntityWithObjectMap {
+
+		Map<Object, Object> map;
+		Map<Object, NestedDocument> concreteMap;
 	}
 }


### PR DESCRIPTION
We now use property type information when mapping fields affected by an update in case we do not have proper entity information within the context. This allows more precise type resolution required for determining the need to write type hints for a given property.