### PR TITLE
DATAMONGO-1232 - IngoreCase should escape query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1232-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -565,6 +565,102 @@ public class MongoQueryCreatorUnitTests {
 		assertThat(new MongoQueryCreator(tree, accessor, context).createQuery(), is(notNullValue()));
 	}
 
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void ignoreCaseShouldEscapeSource() {
+
+		PartTree tree = new PartTree("findByUsernameIgnoreCase", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "con.flux+");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+
+		assertThat(query, is(query(where("username").regex("^\\Qcon.flux+\\E$", "i"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void ignoreCaseShouldEscapeSourceWhenUsedForStartingWith() {
+
+		PartTree tree = new PartTree("findByUsernameStartingWithIgnoreCase", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "dawns.light+");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+
+		assertThat(query, is(query(where("username").regex("^\\Qdawns.light+\\E", "i"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void ignoreCaseShouldEscapeSourceWhenUsedForEndingWith() {
+
+		PartTree tree = new PartTree("findByUsernameEndingWithIgnoreCase", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "new.ton+");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+
+		assertThat(query, is(query(where("username").regex("\\Qnew.ton+\\E$", "i"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void likeShouldEscapeSourceWhenUsedWithLeadingAndTrailingWildcard() {
+
+		PartTree tree = new PartTree("findByUsernameLike", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "*fire.fight+*");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+
+		assertThat(query, is(query(where("username").regex(".*\\Qfire.fight+\\E.*"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void likeShouldEscapeSourceWhenUsedWithLeadingWildcard() {
+
+		PartTree tree = new PartTree("findByUsernameLike", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "*steel.heart+");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+
+		assertThat(query, is(query(where("username").regex(".*\\Qsteel.heart+\\E"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void likeShouldEscapeSourceWhenUsedWithTrailingWildcard() {
+
+		PartTree tree = new PartTree("findByUsernameLike", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "cala.mity+*");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+		assertThat(query, is(query(where("username").regex("\\Qcala.mity+\\E.*"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1232
+	 */
+	@Test
+	public void likeShouldBeTreatedCorrectlyWhenUsedWithWildcardOnly() {
+
+		PartTree tree = new PartTree("findByUsernameLike", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, "*");
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+		assertThat(query, is(query(where("username").regex(".*"))));
+	}
+
 	interface PersonRepository extends Repository<Person, Long> {
 
 		List<Person> findByLocationNearAndFirstname(Point location, Distance maxDistance, String firstname);


### PR DESCRIPTION
We now quote the original criteria before actually wrapping it inside of a regex for case insensitive search. This happens not only to case insensitive _is_, _startsWith_, _endsWith_ but also to those using _like_. In that case we quote the part between leading and trailing wildcard if required.