### PR TITLE
DATAMONGO-1157 - Throw meaningful exception when @DbRef is used with unsupported types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1157-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.mapping;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -310,6 +311,7 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 
 			potentiallyAssertTextScoreType(persistentProperty);
 			potentiallyAssertLanguageType(persistentProperty);
+			potentiallyAssertDBRefTargetType(persistentProperty);
 		}
 
 		private void potentiallyAssertLanguageType(MongoPersistentProperty persistentProperty) {
@@ -326,6 +328,21 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 			}
 		}
 
+		/**
+		 * @since 1.8
+		 */
+		private void potentiallyAssertDBRefTargetType(MongoPersistentProperty persistentProperty) {
+
+			if (persistentProperty.isDbReference() && persistentProperty.getDBRef().lazy()) {
+				if (persistentProperty.isArray() || Modifier.isFinal(persistentProperty.getActualType().getModifiers())) {
+					throw new MappingException(String.format(
+							"Invalid lazy DBRef property for %s. Found %s which must not be an array nor a final class.",
+							persistentProperty.getField(), persistentProperty.getActualType()));
+				}
+			}
+
+		}
+
 		private void assertPropertyType(MongoPersistentProperty persistentProperty, Class<?>... validMatches) {
 
 			for (Class<?> potentialMatch : validMatches) {
@@ -339,5 +356,4 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 					StringUtils.arrayToCommaDelimitedString(validMatches)));
 		}
 	}
-
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
@@ -143,6 +143,85 @@ public class BasicMongoPersistentEntityUnitTests {
 		verify(propertyMock, never()).getActualType();
 	}
 
+	/**
+	 * @see DATAMONGO-1157
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test(expected = MappingException.class)
+	public void verifyShouldThrowErrorForLazyDBRefOnFinalClass() {
+
+		BasicMongoPersistentEntity<AnyDocument> entity = new BasicMongoPersistentEntity<AnyDocument>(
+				ClassTypeInformation.from(AnyDocument.class));
+		org.springframework.data.mongodb.core.mapping.DBRef dbRefMock = mock(org.springframework.data.mongodb.core.mapping.DBRef.class);
+		when(propertyMock.isDbReference()).thenReturn(true);
+		when(propertyMock.getDBRef()).thenReturn(dbRefMock);
+		when(dbRefMock.lazy()).thenReturn(true);
+		when(propertyMock.getActualType()).thenReturn((Class) Class.class);
+		entity.addPersistentProperty(propertyMock);
+
+		entity.verify();
+	}
+
+	/**
+	 * @see DATAMONGO-1157
+	 */
+	@Test(expected = MappingException.class)
+	public void verifyShouldThrowErrorForLazyDBRefArray() {
+
+		BasicMongoPersistentEntity<AnyDocument> entity = new BasicMongoPersistentEntity<AnyDocument>(
+				ClassTypeInformation.from(AnyDocument.class));
+		org.springframework.data.mongodb.core.mapping.DBRef dbRefMock = mock(org.springframework.data.mongodb.core.mapping.DBRef.class);
+		when(propertyMock.isDbReference()).thenReturn(true);
+		when(propertyMock.getDBRef()).thenReturn(dbRefMock);
+		when(dbRefMock.lazy()).thenReturn(true);
+		when(propertyMock.isArray()).thenReturn(true);
+		entity.addPersistentProperty(propertyMock);
+
+		entity.verify();
+	}
+
+	/**
+	 * @see DATAMONGO-1157
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void verifyShouldPassForLazyDBRefOnNonArrayNonFinalClass() {
+
+		BasicMongoPersistentEntity<AnyDocument> entity = new BasicMongoPersistentEntity<AnyDocument>(
+				ClassTypeInformation.from(AnyDocument.class));
+		org.springframework.data.mongodb.core.mapping.DBRef dbRefMock = mock(org.springframework.data.mongodb.core.mapping.DBRef.class);
+		when(propertyMock.isDbReference()).thenReturn(true);
+		when(propertyMock.getDBRef()).thenReturn(dbRefMock);
+		when(dbRefMock.lazy()).thenReturn(true);
+		when(propertyMock.getActualType()).thenReturn((Class) Object.class);
+		entity.addPersistentProperty(propertyMock);
+
+		entity.verify();
+
+		verify(propertyMock, times(1)).isDbReference();
+	}
+
+	/**
+	 * @see DATAMONGO-1157
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void verifyShouldPassForNonLazyDBRefOnFinalClass() {
+
+		BasicMongoPersistentEntity<AnyDocument> entity = new BasicMongoPersistentEntity<AnyDocument>(
+				ClassTypeInformation.from(AnyDocument.class));
+		org.springframework.data.mongodb.core.mapping.DBRef dbRefMock = mock(org.springframework.data.mongodb.core.mapping.DBRef.class);
+		when(propertyMock.isDbReference()).thenReturn(true);
+		when(propertyMock.getDBRef()).thenReturn(dbRefMock);
+		when(dbRefMock.lazy()).thenReturn(false);
+		when(propertyMock.getActualType()).thenReturn((Class) Class.class);
+		entity.addPersistentProperty(propertyMock);
+
+		entity.verify();
+
+		verify(dbRefMock, times(1)).lazy();
+	}
+
 	@Document(collection = "contacts")
 	class Contact {
 


### PR DESCRIPTION
We now eagerly check lazy `DBRef` properties for invalid definitions such as final class or array. In that case we throw a `MappingException` when _verify_ is called.