### PR TITLE
DATAMONGO-1269 - Retain position parameter in property path.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1269-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -867,7 +867,7 @@ public class QueryMapper {
 		 * @return
 		 */
 		protected Converter<MongoPersistentProperty, String> getPropertyConverter() {
-			return PropertyToFieldNameConverter.INSTANCE;
+			return new PositionParameterRetainingPropertyKeyConverter(name);
 		}
 
 		/**
@@ -879,6 +879,24 @@ public class QueryMapper {
 		 */
 		protected Converter<MongoPersistentProperty, String> getAssociationConverter() {
 			return new AssociationConverter(getAssociation());
+		}
+
+		/**
+		 * @author Christoph Strobl
+		 * @since 1.8
+		 */
+		static class PositionParameterRetainingPropertyKeyConverter implements Converter<MongoPersistentProperty, String> {
+
+			private final KeyMapper keyMapper;
+
+			PositionParameterRetainingPropertyKeyConverter(String rawKey) {
+				this.keyMapper = new KeyMapper(rawKey);
+			}
+
+			@Override
+			public String convert(MongoPersistentProperty source) {
+				return keyMapper.mapPropertyName(source);
+			}
 		}
 
 		/* 
@@ -901,6 +919,63 @@ public class QueryMapper {
 
 			return NESTED_DOCUMENT;
 		}
+
+		/**
+		 * @author Christoph Strobl
+		 * @since 1.8
+		 */
+		static class KeyMapper {
+
+			Iterator<String> iterator;
+
+			public KeyMapper(String key) {
+
+				this.iterator = Arrays.asList(key.split("\\.")).iterator();
+				this.iterator.next();
+			}
+
+			/**
+			 * Maps the property name while retaining potential positional operator {@literal $}.
+			 * 
+			 * @param property
+			 * @return
+			 */
+			protected String mapPropertyName(MongoPersistentProperty property) {
+
+				String mappedName = PropertyToFieldNameConverter.INSTANCE.convert(property);
+
+				boolean inspect = iterator.hasNext();
+				while (inspect) {
+
+					String partial = iterator.next();
+
+					boolean isPositional = (isPositionalParameter(partial) && (property.isMap() || property.isCollectionLike() || property
+							.isArray()));
+					if (isPositional) {
+						mappedName += "." + partial;
+					}
+
+					inspect = isPositional && iterator.hasNext();
+				}
+
+				return mappedName;
+			}
+
+			boolean isPositionalParameter(String partial) {
+
+				if (partial.equals("$")) {
+					return true;
+				}
+
+				try {
+					Long.valueOf(partial);
+					return true;
+				} catch (NumberFormatException e) {
+					return false;
+				}
+			}
+		}
+
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -790,6 +790,34 @@ public class QueryMapperUnitTests {
 		assertThat(dbo, isBsonObject().containing("geoJsonPoint.$geoIntersects.$geometry.coordinates"));
 	}
 
+	/**
+	 * @see DATAMONGO-1269
+	 */
+	@Test
+	public void mappingShouldRetainNumericMapKey() {
+
+		Query query = query(where("map.1.stringProperty").is("ba'alzamon"));
+
+		DBObject dbo = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(EntityWithComplexValueTypeMap.class));
+
+		assertThat(dbo.containsField("map.1.stringProperty"), is(true));
+	}
+
+	/**
+	 * @see DATAMONGO-1269
+	 */
+	@Test
+	public void mappingShouldRetainNumericPositionInList() {
+
+		Query query = query(where("list.1.stringProperty").is("ba'alzamon"));
+
+		DBObject dbo = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(EntityWithComplexValueTypeList.class));
+
+		assertThat(dbo.containsField("list.1.stringProperty"), is(true));
+	}
+
 	@Document
 	public class Foo {
 		@Id private ObjectId id;
@@ -889,5 +917,19 @@ public class QueryMapperUnitTests {
 		Point legacyPoint;
 		GeoJsonPoint geoJsonPoint;
 		@Field("geoJsonPointWithNameViaFieldAnnotation") GeoJsonPoint namedGeoJsonPoint;
+	}
+
+	static class SimpeEntityWithoutId {
+
+		String stringProperty;
+		Integer integerProperty;
+	}
+
+	static class EntityWithComplexValueTypeMap {
+		Map<Integer, SimpeEntityWithoutId> map;
+	}
+
+	static class EntityWithComplexValueTypeList {
+		List<SimpeEntityWithoutId> list;
 	}
 }


### PR DESCRIPTION
We now retain position parameters in paths used in queries when mapping the fieldname. This allows to map `list.1.name` to the name property of the first element in the list. 
The change also fixes a glitch in mapping `java.util.Map` like structures having numeric keys.