### PR TITLE
DATAMONGO-1256 - Provide a collectionName in MongoMappingEvents.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.8.0.BUILD-SNAPSHOT</version>
+			<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.8.0.BUILD-SNAPSHOT</version>
+		<version>1.8.0.DATAMONGO-1256-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AbstractDeleteEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AbstractDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 by the original author(s).
+ * Copyright 2013-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.mongodb.DBObject;
  * Base class for delete events.
  * 
  * @author Martin Baumgartner
+ * @author Christoph Strobl
  */
 public abstract class AbstractDeleteEvent<T> extends MongoMappingEvent<DBObject> {
 
@@ -31,11 +32,25 @@ public abstract class AbstractDeleteEvent<T> extends MongoMappingEvent<DBObject>
 	 * Creates a new {@link AbstractDeleteEvent} for the given {@link DBObject} and type.
 	 * 
 	 * @param dbo must not be {@literal null}.
-	 * @param type , possibly be {@literal null}.
+	 * @param type can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #AbstractDeleteEvent(DBObject, Class, String)}
 	 */
+	@Deprecated
 	public AbstractDeleteEvent(DBObject dbo, Class<T> type) {
+		this(dbo, type, null);
+	}
 
-		super(dbo, dbo);
+	/**
+	 * Creates a new {@link AbstractDeleteEvent} for the given {@link DBObject} and type.
+	 * 
+	 * @param dbo must not be {@literal null}.
+	 * @param type can be {@literal null}.
+	 * @param collectionName can be {@literal null}
+	 * @since 1.8
+	 */
+	public AbstractDeleteEvent(DBObject dbo, Class<T> type, String collectionName) {
+
+		super(dbo, dbo, collectionName);
 		this.type = type;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.mongodb.core.mapping.event;
 
 import com.mongodb.DBObject;
 
 /**
+ * {@link MongoMappingEvent} thrown after convert of a document.
+ * 
  * @author Jon Brisbin <jbrisbin@vmware.com>
+ * @author Christoph Strobl
  */
 public class AfterConvertEvent<E> extends MongoMappingEvent<E> {
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Creates new {@link AfterConvertEvent}.
+	 * 
+	 * @param dbo can be {@literal null}.
+	 * @param source must not be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #AfterConvertEvent(DBObject, Object, String)}.
+	 */
+	@Deprecated
 	public AfterConvertEvent(DBObject dbo, E source) {
-		super(source, dbo);
+		this(dbo, source, null);
+	}
+
+	/**
+	 * Creates new {@link AfterConvertEvent}.
+	 * 
+	 * @param dbo can be {@literal null}.
+	 * @param source must not be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public AfterConvertEvent(DBObject dbo, E source, String collectionName) {
+		super(source, dbo, collectionName);
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterDeleteEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 by the original author(s).
+ * Copyright 2013-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.mongodb.DBObject;
  * will be the query document <em>after</am> it has been mapped onto the domain type handled.
  * 
  * @author Martin Baumgartner
+ * @author Christoph Strobl
  */
 public class AfterDeleteEvent<T> extends AbstractDeleteEvent<T> {
 
@@ -32,8 +33,22 @@ public class AfterDeleteEvent<T> extends AbstractDeleteEvent<T> {
 	 * 
 	 * @param dbo must not be {@literal null}.
 	 * @param type can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #AfterDeleteEvent(DBObject, Class, String)}.
 	 */
+	@Deprecated
 	public AfterDeleteEvent(DBObject dbo, Class<T> type) {
-		super(dbo, type);
+		this(dbo, type, null);
+	}
+
+	/**
+	 * Creates a new {@link AfterDeleteEvent} for the given {@link DBObject}, type and collectionName.
+	 * 
+	 * @param dbo must not be {@literal null}.
+	 * @param type can be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public AfterDeleteEvent(DBObject dbo, Class<T> type, String collectionName) {
+		super(dbo, type, collectionName);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterLoadEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.mongodb.DBObject;
  * @author Oliver Gierke
  * @author Jon Brisbin
  * @author Christoph Leiter
+ * @author Christoph Strobl
  */
 public class AfterLoadEvent<T> extends MongoMappingEvent<DBObject> {
 
@@ -36,11 +37,25 @@ public class AfterLoadEvent<T> extends MongoMappingEvent<DBObject> {
 	 * Creates a new {@link AfterLoadEvent} for the given {@link DBObject} and type.
 	 * 
 	 * @param dbo must not be {@literal null}.
-	 * @param type must not be {@literal null}.
+	 * @param type can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #AfterLoadEvent(DBObject, Class, String)}.
 	 */
+	@Deprecated
 	public AfterLoadEvent(DBObject dbo, Class<T> type) {
+		this(dbo, type, null);
+	}
 
-		super(dbo, dbo);
+	/**
+	 * Creates a new {@link AfterLoadEvent} for the given {@link DBObject}, type and collectionName.
+	 * 
+	 * @param dbo must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public AfterLoadEvent(DBObject dbo, Class<T> type, String collectionName) {
+
+		super(dbo, dbo, collectionName);
 
 		Assert.notNull(type, "Type must not be null!");
 		this.type = type;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterSaveEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterSaveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,37 @@ package org.springframework.data.mongodb.core.mapping.event;
 import com.mongodb.DBObject;
 
 /**
+ * {@link MongoMappingEvent} triggered after save of a document.
+ * 
  * @author Jon Brisbin <jbrisbin@vmware.com>
+ * @author Christoph Strobl
  */
 public class AfterSaveEvent<E> extends MongoMappingEvent<E> {
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Creates new {@link AfterSaveEvent}
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #AfterSaveEvent(Object, DBObject, String)}.
+	 */
+	@Deprecated
 	public AfterSaveEvent(E source, DBObject dbo) {
 		super(source, dbo);
+	}
+
+	/**
+	 * Creates new {@link AfterSaveEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public AfterSaveEvent(E source, DBObject dbo, String collectionName) {
+		super(source, dbo, collectionName);
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,31 @@ package org.springframework.data.mongodb.core.mapping.event;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class BeforeConvertEvent<T> extends MongoMappingEvent<T> {
 
 	private static final long serialVersionUID = 252614269008845243L;
 
+	/**
+	 * Creates new {@link BeforeConvertEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #BeforeConvertEvent(Object, String)}
+	 */
+	@Deprecated
 	public BeforeConvertEvent(T source) {
-		super(source, null);
+		this(source, null);
+	}
+
+	/**
+	 * Creates new {@link BeforeConvertEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public BeforeConvertEvent(T source, String collectionName) {
+		super(source, null, collectionName);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeDeleteEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 by the original author(s).
+ * Copyright 2013-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.mongodb.DBObject;
  * document <em>before</em> being mapped based on the domain class handled.
  * 
  * @author Martin Baumgartner
+ * @author Christoph Strobl
  */
 public class BeforeDeleteEvent<T> extends AbstractDeleteEvent<T> {
 
@@ -32,8 +33,22 @@ public class BeforeDeleteEvent<T> extends AbstractDeleteEvent<T> {
 	 * 
 	 * @param dbo must not be {@literal null}.
 	 * @param type can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #BeforeDeleteEvent(DBObject, Class, String)}.
 	 */
+	@Deprecated
 	public BeforeDeleteEvent(DBObject dbo, Class<T> type) {
-		super(dbo, type);
+		this(dbo, type, null);
+	}
+
+	/**
+	 * Creates a new {@link BeforeDeleteEvent} for the given {@link DBObject}, type and collectionName.
+	 * 
+	 * @param dbo must not be {@literal null}.
+	 * @param type can be {@literal null}.
+	 * @param collectionName can be {@literal null}
+	 * @since 1.8
+	 */
+	public BeforeDeleteEvent(DBObject dbo, Class<T> type, String collectionName) {
+		super(dbo, type, collectionName);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,37 @@ package org.springframework.data.mongodb.core.mapping.event;
 import com.mongodb.DBObject;
 
 /**
+ * {@link MongoMappingEvent} triggered before save of a document.
+ * 
  * @author Jon Brisbin <jbrisbin@vmware.com>
+ * @author Christoph Strobl
  */
 public class BeforeSaveEvent<E> extends MongoMappingEvent<E> {
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Creates new {@link BeforeSaveEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #BeforeSaveEvent(Object, DBObject, String)}.
+	 */
+	@Deprecated
 	public BeforeSaveEvent(E source, DBObject dbo) {
 		super(source, dbo);
+	}
+
+	/**
+	 * Creates new {@link BeforeSaveEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 * @since 1.8
+	 */
+	public BeforeSaveEvent(E source, DBObject dbo, String collectionName) {
+		super(source, dbo, collectionName);
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/MongoMappingEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/MongoMappingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,69 @@
 
 package org.springframework.data.mongodb.core.mapping.event;
 
-import com.mongodb.DBObject;
 import org.springframework.context.ApplicationEvent;
 
+import com.mongodb.DBObject;
+
 /**
+ * Base {@link ApplicationEvent} triggered by Spring Data MongoDB.
+ * 
  * @author Jon Brisbin <jbrisbin@vmware.com>
+ * @author Christoph Strobl
  */
 public class MongoMappingEvent<T> extends ApplicationEvent {
 
 	private static final long serialVersionUID = 1L;
 	private final DBObject dbo;
+	private final String collectionName;
 
+	/**
+	 * Creates new {@link MongoMappingEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @deprecated since 1.8. Please use {@link #MongoMappingEvent(Object, DBObject, String)}.
+	 */
+	@Deprecated
 	public MongoMappingEvent(T source, DBObject dbo) {
-		super(source);
-		this.dbo = dbo;
+		this(source, dbo, null);
 	}
 
+	/**
+	 * Creates new {@link MongoMappingEvent}.
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param dbo can be {@literal null}.
+	 * @param collectionName can be {@literal null}.
+	 */
+	public MongoMappingEvent(T source, DBObject dbo, String collectionName) {
+
+		super(source);
+		this.dbo = dbo;
+		this.collectionName = collectionName;
+	}
+
+	/**
+	 * @return {@literal null} if not set.
+	 */
 	public DBObject getDBObject() {
 		return dbo;
 	}
 
+	/**
+	 * Get the collection the event refers to.
+	 * 
+	 * @return {@literal null} if not set.
+	 * @since 1.8
+	 */
+	public String getCollectionName() {
+		return collectionName;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.EventObject#getSource()
+	 */
 	@SuppressWarnings({ "unchecked" })
 	@Override
 	public T getSource() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AuditingIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AuditingIntegrationTests.java
@@ -47,7 +47,7 @@ public class AuditingIntegrationTests {
 		mappingContext.getPersistentEntity(Entity.class);
 
 		Entity entity = new Entity();
-		BeforeConvertEvent<Entity> event = new BeforeConvertEvent<Entity>(entity);
+		BeforeConvertEvent<Entity> event = new BeforeConvertEvent<Entity>(entity, "collection-1");
 		context.publishEvent(event);
 
 		assertThat(entity.created, is(notNullValue()));
@@ -55,7 +55,7 @@ public class AuditingIntegrationTests {
 
 		Thread.sleep(10);
 		entity.id = 1L;
-		event = new BeforeConvertEvent<Entity>(entity);
+		event = new BeforeConvertEvent<Entity>(entity, "collection-1");
 		context.publishEvent(event);
 
 		assertThat(entity.created, is(notNullValue()));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UnwrapAndReadDbObjectCallbackUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UnwrapAndReadDbObjectCallbackUnitTests.java
@@ -50,7 +50,7 @@ public class UnwrapAndReadDbObjectCallbackUnitTests {
 		MappingMongoConverter converter = new MappingMongoConverter(new DefaultDbRefResolver(factory),
 				new MongoMappingContext());
 
-		this.callback = template.new UnwrapAndReadDbObjectCallback<Target>(converter, Target.class);
+		this.callback = template.new UnwrapAndReadDbObjectCallback<Target>(converter, Target.class, "collection-1");
 	}
 
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AbstractMongoEventListenerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AbstractMongoEventListenerUnitTests.java
@@ -39,7 +39,7 @@ public class AbstractMongoEventListenerUnitTests {
 	@Test
 	public void invokesCallbackForEventForPerson() {
 
-		MongoMappingEvent<Person> event = new BeforeConvertEvent<Person>(new Person("Dave", "Matthews"));
+		MongoMappingEvent<Person> event = new BeforeConvertEvent<Person>(new Person("Dave", "Matthews"), "collection-1");
 		SamplePersonEventListener listener = new SamplePersonEventListener();
 		listener.onApplicationEvent(event);
 		assertThat(listener.invokedOnBeforeConvert, is(true));
@@ -54,11 +54,11 @@ public class AbstractMongoEventListenerUnitTests {
 		SamplePersonEventListener listener = new SamplePersonEventListener();
 		context.addApplicationListener(listener);
 
-		context.publishEvent(new BeforeConvertEvent<Person>(new Person("Dave", "Matthews")));
+		context.publishEvent(new BeforeConvertEvent<Person>(new Person("Dave", "Matthews"), "collection-1"));
 		assertThat(listener.invokedOnBeforeConvert, is(true));
 
 		listener.invokedOnBeforeConvert = false;
-		context.publishEvent(new BeforeConvertEvent<String>("Test"));
+		context.publishEvent(new BeforeConvertEvent<String>("Test", "collection-1"));
 		assertThat(listener.invokedOnBeforeConvert, is(false));
 
 		context.close();
@@ -71,7 +71,7 @@ public class AbstractMongoEventListenerUnitTests {
 	public void afterLoadEffectGetsHandledCorrectly() {
 
 		SamplePersonEventListener listener = new SamplePersonEventListener();
-		listener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class));
+		listener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class, "collection-1"));
 		assertThat(listener.invokedOnAfterLoad, is(true));
 	}
 
@@ -83,8 +83,8 @@ public class AbstractMongoEventListenerUnitTests {
 
 		SamplePersonEventListener personListener = new SamplePersonEventListener();
 		SampleAccountEventListener accountListener = new SampleAccountEventListener();
-		personListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class));
-		accountListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class));
+		personListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class, "collection-1"));
+		accountListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class, "collection-1"));
 
 		assertThat(personListener.invokedOnAfterLoad, is(true));
 		assertThat(accountListener.invokedOnAfterLoad, is(false));
@@ -98,8 +98,8 @@ public class AbstractMongoEventListenerUnitTests {
 
 		SamplePersonEventListener personListener = new SamplePersonEventListener();
 		SampleContactEventListener contactListener = new SampleContactEventListener();
-		personListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class));
-		contactListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class));
+		personListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class, "collection-1"));
+		contactListener.onApplicationEvent(new AfterLoadEvent<Person>(new BasicDBObject(), Person.class, "collection-1"));
 
 		assertThat(personListener.invokedOnAfterLoad, is(true));
 		assertThat(contactListener.invokedOnAfterLoad, is(true));
@@ -113,8 +113,8 @@ public class AbstractMongoEventListenerUnitTests {
 
 		SamplePersonEventListener personListener = new SamplePersonEventListener();
 		SampleContactEventListener contactListener = new SampleContactEventListener();
-		personListener.onApplicationEvent(new AfterLoadEvent<Contact>(new BasicDBObject(), Contact.class));
-		contactListener.onApplicationEvent(new AfterLoadEvent<Contact>(new BasicDBObject(), Contact.class));
+		personListener.onApplicationEvent(new AfterLoadEvent<Contact>(new BasicDBObject(), Contact.class, "collection-1"));
+		contactListener.onApplicationEvent(new AfterLoadEvent<Contact>(new BasicDBObject(), Contact.class, "collection-1"));
 
 		assertThat(personListener.invokedOnAfterLoad, is(false));
 		assertThat(contactListener.invokedOnAfterLoad, is(true));
@@ -137,7 +137,7 @@ public class AbstractMongoEventListenerUnitTests {
 	@Test
 	public void invokeContactCallbackForPersonEvent() {
 
-		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Person>(new BasicDBObject(), Person.class);
+		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Person>(new BasicDBObject(), Person.class, "collection-1");
 		SampleContactEventListener listener = new SampleContactEventListener();
 		listener.onApplicationEvent(event);
 
@@ -150,7 +150,7 @@ public class AbstractMongoEventListenerUnitTests {
 	@Test
 	public void invokePersonCallbackForPersonEvent() {
 
-		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Person>(new BasicDBObject(), Person.class);
+		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Person>(new BasicDBObject(), Person.class, "collection-1");
 		SamplePersonEventListener listener = new SamplePersonEventListener();
 		listener.onApplicationEvent(event);
 
@@ -163,7 +163,8 @@ public class AbstractMongoEventListenerUnitTests {
 	@Test
 	public void dontInvokePersonCallbackForAccountEvent() {
 
-		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Account>(new BasicDBObject(), Account.class);
+		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Account>(new BasicDBObject(), Account.class,
+				"collection-1");
 		SamplePersonEventListener listener = new SamplePersonEventListener();
 		listener.onApplicationEvent(event);
 
@@ -176,7 +177,7 @@ public class AbstractMongoEventListenerUnitTests {
 	@Test
 	public void donInvokePersonCallbackForUntypedEvent() {
 
-		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Account>(new BasicDBObject(), null);
+		MongoMappingEvent<DBObject> event = new BeforeDeleteEvent<Account>(new BasicDBObject(), null, "collection-1");
 		SamplePersonEventListener listener = new SamplePersonEventListener();
 		listener.onApplicationEvent(event);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AuditingEventListenerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AuditingEventListenerUnitTests.java
@@ -78,7 +78,7 @@ public class AuditingEventListenerUnitTests {
 	public void triggersCreationMarkForObjectWithEmptyId() {
 
 		Sample sample = new Sample();
-		listener.onApplicationEvent(new BeforeConvertEvent<Object>(sample));
+		listener.onApplicationEvent(new BeforeConvertEvent<Object>(sample, "collection-1"));
 
 		verify(handler, times(1)).markCreated(sample);
 		verify(handler, times(0)).markModified(any(Sample.class));
@@ -92,7 +92,7 @@ public class AuditingEventListenerUnitTests {
 
 		Sample sample = new Sample();
 		sample.id = "id";
-		listener.onApplicationEvent(new BeforeConvertEvent<Object>(sample));
+		listener.onApplicationEvent(new BeforeConvertEvent<Object>(sample, "collection-1"));
 
 		verify(handler, times(0)).markCreated(any(Sample.class));
 		verify(handler, times(1)).markModified(sample);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/PersonBeforeSaveListener.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/PersonBeforeSaveListener.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.data.mongodb.core.mapping.PersonPojoStringId;
 
-import com.mongodb.DBObject;
-
 public class PersonBeforeSaveListener extends AbstractMongoEventListener<PersonPojoStringId> {
 
 	public final List<ApplicationEvent> seenEvents = new ArrayList<ApplicationEvent>();
@@ -32,7 +30,7 @@ public class PersonBeforeSaveListener extends AbstractMongoEventListener<PersonP
 	 * @see org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener#onBeforeSave(java.lang.Object, com.mongodb.DBObject)
 	 */
 	@Override
-	public void onBeforeSave(PersonPojoStringId source, DBObject dbo) {
-		seenEvents.add(new BeforeSaveEvent<PersonPojoStringId>(source, dbo));
+	public void onBeforeSave(BeforeSaveEvent<PersonPojoStringId> event) {
+		seenEvents.add(event);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/SimpleMappingEventListener.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/SimpleMappingEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,12 @@ package org.springframework.data.mongodb.core.mapping.event;
 
 import java.util.ArrayList;
 
-import com.mongodb.DBObject;
-
+/**
+ * @author Mark Pollak
+ * @author Oliver Gierke
+ * @author Christoph Leiter
+ * @author Christoph Strobl
+ */
 public class SimpleMappingEventListener extends AbstractMongoEventListener<Object> {
 
 	public final ArrayList<BeforeConvertEvent<Object>> onBeforeConvertEvents = new ArrayList<BeforeConvertEvent<Object>>();
@@ -26,29 +30,41 @@ public class SimpleMappingEventListener extends AbstractMongoEventListener<Objec
 	public final ArrayList<AfterSaveEvent<Object>> onAfterSaveEvents = new ArrayList<AfterSaveEvent<Object>>();
 	public final ArrayList<AfterLoadEvent<Object>> onAfterLoadEvents = new ArrayList<AfterLoadEvent<Object>>();
 	public final ArrayList<AfterConvertEvent<Object>> onAfterConvertEvents = new ArrayList<AfterConvertEvent<Object>>();
+	public final ArrayList<BeforeDeleteEvent<Object>> onBeforeDeleteEvents = new ArrayList<BeforeDeleteEvent<Object>>();
+	public final ArrayList<AfterDeleteEvent<Object>> onAfterDeleteEvents = new ArrayList<AfterDeleteEvent<Object>>();
 
 	@Override
-	public void onBeforeConvert(Object source) {
-		onBeforeConvertEvents.add(new BeforeConvertEvent<Object>(source));
+	public void onBeforeConvert(BeforeConvertEvent<Object> event) {
+		onBeforeConvertEvents.add(event);
 	}
 
 	@Override
-	public void onBeforeSave(Object source, DBObject dbo) {
-		onBeforeSaveEvents.add(new BeforeSaveEvent<Object>(source, dbo));
+	public void onBeforeSave(BeforeSaveEvent<Object> event) {
+		onBeforeSaveEvents.add(event);
 	}
 
 	@Override
-	public void onAfterSave(Object source, DBObject dbo) {
-		onAfterSaveEvents.add(new AfterSaveEvent<Object>(source, dbo));
+	public void onAfterSave(AfterSaveEvent<Object> event) {
+		onAfterSaveEvents.add(event);
 	}
 
 	@Override
-	public void onAfterLoad(DBObject dbo) {
-		onAfterLoadEvents.add(new AfterLoadEvent<Object>(dbo, Object.class));
+	public void onAfterLoad(AfterLoadEvent<Object> event) {
+		onAfterLoadEvents.add(event);
 	}
 
 	@Override
-	public void onAfterConvert(DBObject dbo, Object source) {
-		onAfterConvertEvents.add(new AfterConvertEvent<Object>(dbo, source));
+	public void onAfterConvert(AfterConvertEvent<Object> event) {
+		onAfterConvertEvents.add(event);
+	}
+
+	@Override
+	public void onAfterDelete(AfterDeleteEvent<Object> event) {
+		onAfterDeleteEvents.add(event);
+	}
+
+	@Override
+	public void onBeforeDelete(BeforeDeleteEvent<Object> event) {
+		onBeforeDeleteEvents.add(event);
 	}
 }


### PR DESCRIPTION
We now directly expose the collection name via `MongoMappingEvent#getCollectionName()`. Therefore we added new constructors to all the events, deprecating the previous ones. 

Several overloads have been added to `AbstractMongoEventListener`, deprecating previous api. We’ll call the deprecated from the new ones until their removal.