### PR TITLE
Update MongoChangeSetPersister.java

### DIFF
--- a/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
+++ b/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
@@ -109,9 +109,9 @@ public class MongoChangeSetPersister implements ChangeSetPersister<Object> {
 	 * @see org.springframework.data.crossstore.ChangeSetPersister#getPersistentId(org.springframework.data.crossstore.ChangeSetBacked, org.springframework.data.crossstore.ChangeSet)
 	 */
 	public Object getPersistentId(ChangeSetBacked entity, ChangeSet cs) throws DataAccessException {
-
-		log.debug("getPersistentId called on " + entity);
-
+		if (log.isDebugEnabled()) {
+			log.debug("getPersistentId called on " + entity);
+		}
 		if (entityManagerFactory == null) {
 			throw new DataAccessResourceFailureException("EntityManagerFactory cannot be null");
 		}


### PR DESCRIPTION
Add checking for debug enabling in the ```getPersistentId``` method. It is not a serious change, but, I think it would be good to have common approach for whole class to ```debug()``` method using, where parameter is a concatenated ```String```.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/spring-projects/spring-data-mongodb/317)
<!-- Reviewable:end -->
