### PR TITLE
DATA-1293 - Allowed id attribute in addition to client-uri attribute in MongoDbFactoryParser.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
@@ -18,6 +18,10 @@ package org.springframework.data.mongodb.config;
 import static org.springframework.data.config.ParsingUtils.*;
 import static org.springframework.data.mongodb.config.MongoParsingUtils.*;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
@@ -47,6 +51,15 @@ import com.mongodb.MongoURI;
  * @author Viktor Khoroshko
  */
 public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
+	private static final Set<String> MONGO_URI_ALLOWED_ADDITIONAL_ATTRIBUTES;
+
+	static {
+		Set<String> mongoUriAllowedAdditionalAttributes = new HashSet<String>();
+		mongoUriAllowedAdditionalAttributes.add("id");
+		mongoUriAllowedAdditionalAttributes.add("write-concern");
+
+		MONGO_URI_ALLOWED_ADDITIONAL_ATTRIBUTES = Collections.unmodifiableSet(mongoUriAllowedAdditionalAttributes);
+	}
 
 	/* 
 	 * (non-Javadoc)
@@ -74,10 +87,14 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 		BeanDefinition mongoUri = getMongoUri(element);
 
 		if (mongoUri != null) {
-			if (element.hasAttribute("mongo-ref") || element.hasAttribute("dbname")
-					|| element.hasAttribute("authentication-dbname")
-					|| element.hasAttribute("port") || element.hasAttribute("host")
-					|| element.hasAttribute("username") || element.hasAttribute("password")) {
+			int allowedAttributesCount = 1;
+			for (String attribute : MONGO_URI_ALLOWED_ADDITIONAL_ATTRIBUTES) {
+				if (element.hasAttribute(attribute)) {
+					allowedAttributesCount++;
+				}
+			}
+
+			if (element.getAttributes().getLength() > allowedAttributesCount) {
 				parserContext.getReaderContext().error("Configure either Mongo URI or details individually!",
 						parserContext.extractSource(element));
 			}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoDbFactoryParser.java
@@ -44,6 +44,7 @@ import com.mongodb.MongoURI;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Viktor Khoroshko
  */
 public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 
@@ -73,7 +74,10 @@ public class MongoDbFactoryParser extends AbstractBeanDefinitionParser {
 		BeanDefinition mongoUri = getMongoUri(element);
 
 		if (mongoUri != null) {
-			if (element.getAttributes().getLength() >= 2 && !element.hasAttribute("write-concern")) {
+			if (element.hasAttribute("mongo-ref") || element.hasAttribute("dbname")
+					|| element.hasAttribute("authentication-dbname")
+					|| element.hasAttribute("port") || element.hasAttribute("host")
+					|| element.hasAttribute("username") || element.hasAttribute("password")) {
 				parserContext.getReaderContext().error("Configure either Mongo URI or details individually!",
 						parserContext.extractSource(element));
 			}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoDbFactoryParserIntegrationTests.java
@@ -50,6 +50,7 @@ import com.mongodb.WriteConcern;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Viktor Khoroshko
  */
 public class MongoDbFactoryParserIntegrationTests {
 
@@ -196,6 +197,50 @@ public class MongoDbFactoryParserIntegrationTests {
 	@Test(expected = BeanDefinitionParsingException.class)
 	public void rejectsClientUriPlusDetailedConfiguration() {
 		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri-and-details.xml"));
+	}
+
+	/**
+	 * @see DATAMONGO-1293
+	 */
+	@Test
+	public void setsUpClientUriWithId() {
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri-and-id.xml"));
+		BeanDefinition definition = factory.getBeanDefinition("testMongo");
+		ConstructorArgumentValues constructorArguments = definition.getConstructorArgumentValues();
+
+		assertThat(constructorArguments.getArgumentCount(), is(1));
+		ValueHolder argument = constructorArguments.getArgumentValue(0, MongoClientURI.class);
+		assertThat(argument, is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAMONGO-1293
+	 */
+	@Test
+	public void setsUpUriWithId() {
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-uri-and-id.xml"));
+		BeanDefinition definition = factory.getBeanDefinition("testMongo");
+		ConstructorArgumentValues constructorArguments = definition.getConstructorArgumentValues();
+
+		assertThat(constructorArguments.getArgumentCount(), is(1));
+		ValueHolder argument = constructorArguments.getArgumentValue(0, MongoClientURI.class);
+		assertThat(argument, is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAMONGO-1293
+	 */
+	@Test(expected = BeanDefinitionParsingException.class)
+	public void rejectsClientUriPlusDetailedConfigurationAndWriteConcern() {
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri-write-concern-and-details.xml"));
+	}
+
+	/**
+	 * @see DATAMONGO-1293
+	 */
+	@Test(expected = BeanDefinitionParsingException.class)
+	public void rejectsUriPlusDetailedConfigurationAndWriteConcern() {
+		reader.loadBeanDefinitions(new ClassPathResource("namespace/mongo-client-uri-write-concern-and-details.xml"));
 	}
 
 	private static void assertWriteConcern(ClassPathXmlApplicationContext ctx, WriteConcern expectedWriteConcern) {

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-and-id.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-and-id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory id="testMongo" client-uri="mongodb://username:password@localhost/database" />
+
+</beans>

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-write-concern-and-details.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-client-uri-write-concern-and-details.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory client-uri="mongodb://username:password@localhost/database" write-concern="NORMAL" username="username" />
+
+</beans>

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-uri-and-id.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-uri-and-id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory id="testMongo" uri="mongodb://username:password@localhost/database" />
+
+</beans>

--- a/spring-data-mongodb/src/test/resources/namespace/mongo-uri-write-concern-and-details.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongo-uri-write-concern-and-details.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<mongo:db-factory uri="mongodb://username:password@localhost/database" write-concern="NORMAL" username="username" />
+
+</beans>


### PR DESCRIPTION
Additionally, the previous approach allowed any attribute to be set if write-concern attribute was set. Fixed that also.