### PR TITLE
DATAMONGO-1288 - Add conversion for AtomicInteger & AtomicLong.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.9.0.BUILD-SNAPSHOT</version>
+			<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1288-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/CustomConversions.java
@@ -47,6 +47,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverters.BigIntegerT
 import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToNamedMongoScriptCoverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.DBObjectToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.NamedMongoScriptToDBObjectConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.NumberToNumberConverterFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigIntegerConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToURLConverter;
@@ -122,6 +123,7 @@ public class CustomConversions {
 		toRegister.add(TermToStringConverter.INSTANCE);
 		toRegister.add(NamedMongoScriptToDBObjectConverter.INSTANCE);
 		toRegister.add(DBObjectToNamedMongoScriptCoverter.INSTANCE);
+		toRegister.add(NumberToNumberConverterFactory.INSTANCE);
 
 		toRegister.addAll(JodaTimeConverters.getConvertersToRegister());
 		toRegister.addAll(GeoConverters.getConvertersToRegister());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -19,16 +19,21 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.bson.types.Code;
 import org.bson.types.ObjectId;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalConverter;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mongodb.core.query.Term;
 import org.springframework.data.mongodb.core.script.NamedMongoScript;
+import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBObject;
@@ -226,6 +231,52 @@ abstract class MongoConverters {
 			builder.append("value", new Code(source.getCode()));
 
 			return builder.get();
+		}
+	}
+
+	/**
+	 * {@link ConverterFactory} implementation using {@link NumberUtils} for number conversion and parsing. Additionally
+	 * deals with {@link AtomicInteger} and {@link AtomicLong} by calling {@code get()} before performing the actual
+	 * conversion.
+	 * 
+	 * @author Christoph Strobl
+	 * @since 1.9
+	 */
+	@WritingConverter
+	public static enum NumberToNumberConverterFactory implements ConverterFactory<Number, Number>, ConditionalConverter {
+
+		INSTANCE;
+
+		@Override
+		public <T extends Number> Converter<Number, T> getConverter(Class<T> targetType) {
+			return new NumberToNumber<T>(targetType);
+		}
+
+		@Override
+		public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+			return !sourceType.equals(targetType);
+		}
+
+		private final static class NumberToNumber<T extends Number> implements Converter<Number, T> {
+
+			private final Class<T> targetType;
+
+			public NumberToNumber(Class<T> targetType) {
+				this.targetType = targetType;
+			}
+
+			@Override
+			public T convert(Number source) {
+
+				if (source instanceof AtomicInteger) {
+					return NumberUtils.convertNumberToTargetClass(((AtomicInteger) source).get(), this.targetType);
+				}
+				if (source instanceof AtomicLong) {
+					return NumberUtils.convertNumberToTargetClass(((AtomicLong) source).get(), this.targetType);
+				}
+
+				return NumberUtils.convertNumberToTargetClass(source, this.targetType);
+			}
 		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/NumberToNumberConverterFactoryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/NumberToNumberConverterFactoryUnitTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.data.mongodb.core.convert.MongoConverters.NumberToNumberConverterFactory;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(Parameterized.class)
+public class NumberToNumberConverterFactoryUnitTests {
+
+	public @Parameter(0) Number source;
+
+	public @Parameter(1) Number expected;
+
+	@Parameters
+	public static Collection<Number[]> parameters() {
+
+		Number[] longToInt = new Number[] { new Long(10), new Integer(10) };
+		Number[] atomicIntToInt = new Number[] { new AtomicInteger(10), new Integer(10) };
+		Number[] atomicIntToDouble = new Number[] { new AtomicInteger(10), new Double(10) };
+		Number[] atomicLongToInt = new Number[] { new AtomicLong(10), new Integer(10) };
+		Number[] atomicLongToLong = new Number[] { new AtomicLong(10), new Long(10) };
+
+		return Arrays.<Number[]> asList(longToInt, atomicIntToInt, atomicIntToDouble, atomicLongToInt, atomicLongToLong);
+	}
+
+	/**
+	 * @see DATAMONGO-1288
+	 */
+	@Test
+	public void convertsToTargetTypeCorrectly() {
+		assertThat(NumberToNumberConverterFactory.INSTANCE.getConverter(expected.getClass()).convert(source), is(expected));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -27,9 +27,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.core.Is;
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
 import org.junit.Test;
@@ -794,7 +796,7 @@ public class UpdateMapperUnitTests {
 	}
 
 	/**
-	 * see DATAMONGO-1251
+	 * @see DATAMONGO-1251
 	 */
 	@Test
 	public void mapsNullValueCorrectlyForSimpleTypes() {
@@ -810,7 +812,7 @@ public class UpdateMapperUnitTests {
 	}
 
 	/**
-	 * see DATAMONGO-1251
+	 * @see DATAMONGO-1251
 	 */
 	@Test
 	public void mapsNullValueCorrectlyForJava8Date() {
@@ -826,7 +828,7 @@ public class UpdateMapperUnitTests {
 	}
 
 	/**
-	 * see DATAMONGO-1251
+	 * @see DATAMONGO-1251
 	 */
 	@Test
 	public void mapsNullValueCorrectlyForCollectionTypes() {
@@ -842,7 +844,7 @@ public class UpdateMapperUnitTests {
 	}
 
 	/**
-	 * see DATAMONGO-1251
+	 * @see DATAMONGO-1251
 	 */
 	@Test
 	public void mapsNullValueCorrectlyForPropertyOfNestedDocument() {
@@ -855,6 +857,34 @@ public class UpdateMapperUnitTests {
 		DBObject $set = DBObjectTestUtils.getAsDBObject(mappedUpdate, "$set");
 		assertThat($set.containsField("concreteValue.name"), is(true));
 		assertThat($set.get("concreteValue.name"), nullValue());
+	}
+
+	/**
+	 * @see DATAMONGO-1288
+	 */
+	@Test
+	public void mapsAtomicIntegerToIntegerCorrectly() {
+
+		Update update = new Update().set("intValue", new AtomicInteger(10));
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(SimpleValueHolder.class));
+
+		DBObject $set = DBObjectTestUtils.getAsDBObject(mappedUpdate, "$set");
+		assertThat($set.get("intValue"), Is.<Object> is(10));
+	}
+
+	/**
+	 * @see DATAMONGO-1288
+	 */
+	@Test
+	public void mapsAtomicIntegerToPrimitiveIntegerCorrectly() {
+
+		Update update = new Update().set("primIntValue", new AtomicInteger(10));
+		DBObject mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(SimpleValueHolder.class));
+
+		DBObject $set = DBObjectTestUtils.getAsDBObject(mappedUpdate, "$set");
+		assertThat($set.get("primIntValue"), Is.<Object> is(10));
 	}
 
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
@@ -1130,5 +1160,11 @@ public class UpdateMapperUnitTests {
 	static class ClassWithJava8Date {
 
 		LocalDate date;
+	}
+
+	static class SimpleValueHolder {
+
+		Integer intValue;
+		int primIntValue;
 	}
 }


### PR DESCRIPTION
We now convert `AtomicInteger` and `AtomicLong` to the required `Number` target type by calling `get()` followed by the actual conversion. This allows to directly use these types eg. as part of an `Update`.

```java
new Update().set("intValue", new AtomicInteger(10));
```

----

Depends on [DATAMONGO-1302](https://jira.spring.io/browse/DATAMONGO-1302) (PR #330).