### PR TITLE
DATAMONGO-1289 - NullPointerException when saving an object with no "id" field or @Id annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.9.0.BUILD-SNAPSHOT</version>
+			<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1289-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class MongoRepositoryFactory extends RepositoryFactorySupport {
 
@@ -88,7 +89,8 @@ public class MongoRepositoryFactory extends RepositoryFactorySupport {
 	@Override
 	protected Object getTargetRepository(RepositoryInformation information) {
 
-		MongoEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
+		MongoEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType(),
+				information);
 		return getTargetRepositoryViaReflection(information, entityInformation, mongoOperations);
 	}
 
@@ -105,18 +107,25 @@ public class MongoRepositoryFactory extends RepositoryFactorySupport {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.RepositoryFactorySupport#getEntityInformation(java.lang.Class)
 	 */
-	@Override
-	@SuppressWarnings("unchecked")
+	// TODO: would be worth discussing if we could alter RepositoryFactorySupport#getEntityInformation to be called with
+	// RepositoryMetadata instead of the acual domain type class.
 	public <T, ID extends Serializable> MongoEntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
+		return getEntityInformation(domainClass, null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T, ID extends Serializable> MongoEntityInformation<T, ID> getEntityInformation(Class<T> domainClass,
+			RepositoryInformation information) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(domainClass);
 
 		if (entity == null) {
-			throw new MappingException(
-					String.format("Could not lookup mapping metadata for domain class %s!", domainClass.getName()));
+			throw new MappingException(String.format("Could not lookup mapping metadata for domain class %s!",
+					domainClass.getName()));
 		}
 
-		return new MappingMongoEntityInformation<T, ID>((MongoPersistentEntity<T>) entity);
+		return new MappingMongoEntityInformation<T, ID>((MongoPersistentEntity<T>) entity,
+				information != null ? (Class<ID>) information.getIdType() : null);
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/NoExplicitIdTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/NoExplicitIdTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class NoExplicitIdTests {
+
+	@Configuration
+	@EnableMongoRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractMongoConfiguration {
+
+		@Override
+		protected String getDatabaseName() {
+			return "test";
+		}
+
+		@Override
+		public Mongo mongo() throws Exception {
+			return new MongoClient();
+		}
+	}
+
+	@Autowired MongoOperations mongoOps;
+	@Autowired TypeWithoutExplicitIdPropertyRepository repo;
+
+	@Before
+	public void setUp() {
+		mongoOps.dropCollection(TypeWithoutIdProperty.class);
+	}
+
+	/**
+	 * @see DATAMONGO-1289
+	 */
+	@Test
+	public void saveAndRetrieveTypeWithoutIdPorpertyViaTemplate() {
+
+		TypeWithoutIdProperty noid = new TypeWithoutIdProperty();
+		noid.someString = "o.O";
+
+		mongoOps.save(noid);
+
+		TypeWithoutIdProperty retrieved = mongoOps.findOne(query(where("someString").is(noid.someString)),
+				TypeWithoutIdProperty.class);
+
+		assertThat(retrieved.someString, is(noid.someString));
+	}
+
+	/**
+	 * @see DATAMONGO-1289
+	 */
+	@Test
+	public void saveAndRetrieveTypeWithoutIdPorpertyViaRepository() {
+
+		TypeWithoutIdProperty noid = new TypeWithoutIdProperty();
+		noid.someString = "o.O";
+
+		repo.save(noid);
+
+		TypeWithoutIdProperty retrieved = repo.findBySomeString(noid.someString);
+		assertThat(retrieved.someString, is(noid.someString));
+	}
+
+	/**
+	 * @see DATAMONGO-1289
+	 */
+	@Test
+	public void saveAndRetrieveTypeWithoutIdPorpertyViaRepositoryFindOne() {
+
+		TypeWithoutIdProperty noid = new TypeWithoutIdProperty();
+		noid.someString = "o.O";
+
+		repo.save(noid);
+
+		Map<String, Object> map = mongoOps.findOne(query(where("someString").is(noid.someString)), Map.class,
+				"typeWithoutIdProperty");
+
+		TypeWithoutIdProperty retrieved = repo.findOne(map.get("_id").toString());
+		assertThat(retrieved.someString, is(noid.someString));
+	}
+
+	static class TypeWithoutIdProperty {
+
+		String someString;
+	}
+
+	static interface TypeWithoutExplicitIdPropertyRepository extends MongoRepository<TypeWithoutIdProperty, String> {
+
+		TypeWithoutIdProperty findBySomeString(String someString);
+	}
+}


### PR DESCRIPTION
**!!! DO NOT MERGE !!!** Opened for discussion.

We now use `RepositoryMetdata.getIdType()` to provide a fallback id type once the `EntityInformation` does not hold an id property which is perfectly valid for mongodb. This is a bit more sophisticated than just defaulting to `ObjectId` but requires us to use the `RepositoryMetadata` which is not available when calling `RepositoryFactorySupport.getEntityInformation`. 

Having that said we might want to think about changing the method signature of `getEntityInformation` so it takes `RepositoryMetdata` wich would allow us to access the required data. 

