### PR TITLE
DATAMONGO-1337 - General code quality improvements

### DIFF
--- a/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
+++ b/spring-data-mongodb-cross-store/src/main/java/org/springframework/data/mongodb/crossstore/MongoChangeSetPersister.java
@@ -45,7 +45,7 @@ public class MongoChangeSetPersister implements ChangeSetPersister<Object> {
 	private static final String ENTITY_FIELD_NAME = "_entity_field_name";
 	private static final String ENTITY_FIELD_CLASS = "_entity_field_class";
 
-	protected final Logger log = LoggerFactory.getLogger(getClass());
+	private static final Logger log = LoggerFactory.getLogger(getClass());
 
 	private MongoTemplate mongoTemplate;
 	private EntityManagerFactory entityManagerFactory;

--- a/spring-data-mongodb-log4j/src/main/java/org/springframework/data/mongodb/log4j/MongoLog4jAppender.java
+++ b/spring-data-mongodb-log4j/src/main/java/org/springframework/data/mongodb/log4j/MongoLog4jAppender.java
@@ -160,7 +160,7 @@ public class MongoLog4jAppender extends AppenderSkeleton {
 
 		// Copy properties into document
 		Map<Object, Object> props = event.getProperties();
-		if (null != props && props.size() > 0) {
+		if (null != props && !props.isEmpty()) {
 			BasicDBObject propsDbo = new BasicDBObject();
 			for (Map.Entry<Object, Object> entry : props.entrySet()) {
 				propsDbo.put(entry.getKey().toString(), entry.getValue().toString());

--- a/spring-data-mongodb-log4j/src/test/java/org/springframework/data/mongodb/log4j/MongoLog4jAppenderIntegrationTests.java
+++ b/spring-data-mongodb-log4j/src/test/java/org/springframework/data/mongodb/log4j/MongoLog4jAppenderIntegrationTests.java
@@ -39,7 +39,7 @@ public class MongoLog4jAppenderIntegrationTests {
 
 	static final String NAME = MongoLog4jAppenderIntegrationTests.class.getName();
 
-	Logger log = Logger.getLogger(NAME);
+	private static final Logger log = Logger.getLogger(NAME);
 	Mongo mongo;
 	DB db;
 	String collection;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -153,7 +153,7 @@ public class Aggregation {
 	protected Aggregation(List<AggregationOperation> aggregationOperations, AggregationOptions options) {
 
 		Assert.notNull(aggregationOperations, "AggregationOperations must not be null!");
-		Assert.isTrue(aggregationOperations.size() > 0, "At least one AggregationOperation has to be provided");
+		Assert.isTrue(!aggregationOperations.isEmpty(), "At least one AggregationOperation has to be provided");
 		Assert.notNull(options, "AggregationOptions must not be null!");
 
 		this.operations = aggregationOperations;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -966,7 +966,7 @@ public class QueryMapper {
 
 			private static boolean isPositionalParameter(String partial) {
 
-				if (partial.equals("$")) {
+				if ("$".equals(partial)) {
 					return true;
 				}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -118,7 +118,7 @@ public class Criteria implements CriteriaDefinition {
 	}
 
 	private boolean lastOperatorWasNot() {
-		return this.criteria.size() > 0 && "$not".equals(this.criteria.keySet().toArray()[this.criteria.size() - 1]);
+		return !this.criteria.isEmpty() && "$not".equals(this.criteria.keySet().toArray()[this.criteria.size() - 1]);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/AbstractMonitor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/AbstractMonitor.java
@@ -32,7 +32,7 @@ import com.mongodb.MongoException;
  */
 public abstract class AbstractMonitor {
 
-	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private static final Logger logger = LoggerFactory.getLogger(getClass());
 
 	protected Mongo mongo;
 	private String username;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -420,7 +420,7 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 			return PUNCTATION_PATTERN.matcher(source).find() ? Pattern.quote(source) : source;
 		}
 
-		if (source.equals("*")) {
+		if ("*".equals(source)) {
 			return ".*";
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoAdminIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoAdminIntegrationTests.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration("classpath:infrastructure.xml")
 public class MongoAdminIntegrationTests {
 
-	private static Log logger = LogFactory.getLog(MongoAdminIntegrationTests.class);
+	private static final Log logger = LogFactory.getLog(MongoAdminIntegrationTests.class);
 
 	@SuppressWarnings("unused")
 	private DB testAdminDb;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2402,10 +2402,10 @@ public class MappingMongoConverterUnitTests {
 				return null;
 			}
 
-			if (source.equals("foo-enum-value")) {
+			if ("foo-enum-value".equals(source)) {
 				return FooBarEnum.FOO;
 			}
-			if (source.equals("bar-enum-value")) {
+			if ("bar-enum-value".equals(source)) {
 				return FooBarEnum.BAR;
 			}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
@@ -118,13 +118,13 @@ public class MapReduceTests {
 
 		int size = 0;
 		for (ContentAndVersion cv : results) {
-			if (cv.getId().equals("Resume")) {
+			if ("Resume".equals(cv.getId())) {
 				assertEquals(6, cv.getValue().longValue());
 			}
-			if (cv.getId().equals("Schema")) {
+			if ("Schema".equals(cv.getId())) {
 				assertEquals(2, cv.getValue().longValue());
 			}
-			if (cv.getId().equals("mongoDB How-To")) {
+			if ("mongoDB How-To".equals(cv.getId())) {
 				assertEquals(2, cv.getValue().longValue());
 			}
 			size++;
@@ -141,13 +141,13 @@ public class MapReduceTests {
 				new MapReduceOptions().outputCollection("jmr2_out"), NumberAndVersion.class);
 		int size = 0;
 		for (NumberAndVersion nv : results) {
-			if (nv.getId().equals("1")) {
+			if ("1".equals(nv.getId())) {
 				assertEquals(2, nv.getValue().longValue());
 			}
-			if (nv.getId().equals("2")) {
+			if ("2".equals(nv.getId())) {
 				assertEquals(6, nv.getValue().longValue());
 			}
-			if (nv.getId().equals("3")) {
+			if ("3".equals(nv.getId())) {
 				assertEquals(2, nv.getValue().longValue());
 			}
 			size++;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule: 
squid:S1312 - Loggers should be private static final and should share a naming convention
squid:S1132 - String literals should be placed on the left side when checking for equality
squid:S1155 - Collection.isEmpty() should be used to test for emptiness of collections

You can find more information about the issue here: 
dev.eclipse.org/sonar/rules/show/squid:S1312
dev.eclipse.org/sonar/rules/show/squid:S1132
dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Christian