### PR TITLE
DATAMONGO-1334 - Honor MapReduceOptions.limit for mapReduce operations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.9.0.BUILD-SNAPSHOT</version>
+			<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1334-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1599,13 +1599,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 				throw new InvalidDataAccessApiUsageException(
 						"Can not use skip or field specification with map reduce operations");
 			}
-
-			if (query.getLimit() > 0) {
+			if (query.getLimit() > 0 && mapReduceOptions.getLimit() == null) {
 				mapReduceCommand.setLimit(query.getLimit());
 			}
 			if (query.getSortObject() != null) {
 				mapReduceCommand.setSort(queryMapper.getMappedObject(query.getSortObject(), null));
 			}
+		}
+
+		if (mapReduceOptions.getLimit() != null && mapReduceOptions.getLimit().intValue() > 0) {
+			mapReduceCommand.setLimit(mapReduceOptions.getLimit());
 		}
 
 		if (mapReduceOptions.getJavaScriptMode() != null) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
@@ -45,6 +45,8 @@ public class MapReduceOptions {
 
 	private Boolean verbose = true;
 
+	private Integer limit;
+
 	private Map<String, Object> extraOptions = new HashMap<String, Object>();
 
 	/**
@@ -64,6 +66,8 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions limit(int limit) {
+
+		this.limit = limit;
 		return this;
 	}
 
@@ -247,6 +251,16 @@ public class MapReduceOptions {
 		return this.scopeVariables;
 	}
 
+	/**
+	 * Get the maximum number of documents for the input into the map function.
+	 * 
+	 * @return {@literal null} if not set.
+	 * @since 1.7
+	 */
+	public Integer getLimit() {
+		return limit;
+	}
+
 	public DBObject getOptionsObject() {
 		BasicDBObject cmd = new BasicDBObject();
 
@@ -262,6 +276,10 @@ public class MapReduceOptions {
 
 		if (scopeVariables != null) {
 			cmd.put("scope", scopeVariables);
+		}
+
+		if (limit != null) {
+			cmd.put("limit", limit);
 		}
 
 		if (!extraOptions.keySet().isEmpty()) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptionsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptionsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,40 @@
  */
 package org.springframework.data.mongodb.core.mapreduce;
 
+import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
+
 import org.junit.Test;
 
+/**
+ * @author Mark Pollack
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ */
 public class MapReduceOptionsTests {
 
 	@Test
 	public void testFinalize() {
 		new MapReduceOptions().finalizeFunction("code");
+	}
+
+	/**
+	 * @see DATAMONGO-1334
+	 */
+	@Test
+	public void limitShouldBeIncludedCorrectly() {
+
+		MapReduceOptions options = new MapReduceOptions();
+		options.limit(10);
+
+		assertThat(options.getOptionsObject(), isBsonObject().containing("limit", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-1334
+	 */
+	@Test
+	public void limitShouldNotBePresentInDboWhenNotSet() {
+		assertThat(new MapReduceOptions().getOptionsObject(), isBsonObject().notContaining("limit"));
 	}
 }


### PR DESCRIPTION
We now also consider the `limit` set via `MapReduceOptions` when executing _mapReduce_ operations via `MongoTemplate.mapReduce`. Please note that `MapReduceOptions.limit` supersedes a potential _limit_ set via the `Query` itself. This change also allows to define a _limit_ even when no explicit `Query` is used.