### PR TITLE
DATAMONGO-1348 - Convert GeoJson used in NearQuery.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-1348-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1348-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-1348-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1348-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1348-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -972,7 +972,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Document nearDocument = near.toDocument();
 
 		Document command = new Document("geoNear", collection);
-		command.putAll(nearDocument);
+		command.putAll(queryMapper.getMappedObject(nearDocument, Optional.empty()));
 
 		if (nearDocument.containsKey("query")) {
 			Document query = (Document) nearDocument.get("query");

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core.query;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Metric;
+import org.springframework.data.geo.Metrics;
+
+/**
+ * {@link Metric} and {@link Distance} conversions using the metric system.
+ *
+ * @author Mark Paluch
+ * @since 1.10
+ */
+class MetricConversion {
+
+	private static final BigDecimal METERS_MULTIPLIER = new BigDecimal(Metrics.KILOMETERS.getMultiplier())
+			.multiply(new BigDecimal(1000));
+
+	// to achieve a calculation that is accurate to 0.3 meters
+	private static final int PRECISION = 8;
+
+	/**
+	 * Return meters to {@code metric} multiplier.
+	 *
+	 * @param metric
+	 * @return
+	 */
+	protected static double getMetersToMetricMultiplier(Metric metric) {
+
+		ConversionMultiplier conversionMultiplier = ConversionMultiplier.builder().from(METERS_MULTIPLIER).to(metric)
+				.build();
+		return conversionMultiplier.multiplier().doubleValue();
+	}
+
+	/**
+	 * Return {@code distance} in meters.
+	 *
+	 * @param distance
+	 * @return
+	 */
+	protected static double getDistanceInMeters(Distance distance) {
+		return new BigDecimal(distance.getValue()).multiply(getMetricToMetersMultiplier(distance.getMetric()))
+				.doubleValue();
+	}
+
+	/**
+	 * Return {@code metric} to meters multiplier.
+	 *
+	 * @param metric
+	 * @return
+	 */
+	private static BigDecimal getMetricToMetersMultiplier(Metric metric) {
+
+		ConversionMultiplier conversionMultiplier = ConversionMultiplier.builder().from(metric).to(METERS_MULTIPLIER)
+				.build();
+		return conversionMultiplier.multiplier();
+	}
+
+	/**
+	 * Provides a multiplier to convert between various metrics. Metrics must share the same base scale and provide a
+	 * multiplier to convert between the base scale and its own metric.
+	 *
+	 * @author Mark Paluch
+	 */
+	private static class ConversionMultiplier {
+
+		private final BigDecimal source;
+		private final BigDecimal target;
+
+		ConversionMultiplier(Number source, Number target) {
+
+			if (source instanceof BigDecimal) {
+				this.source = (BigDecimal) source;
+			} else {
+				this.source = new BigDecimal(source.doubleValue());
+			}
+
+			if (target instanceof BigDecimal) {
+				this.target = (BigDecimal) target;
+			} else {
+				this.target = new BigDecimal(target.doubleValue());
+			}
+		}
+
+		/**
+		 * Returns the multiplier to convert a number from the {@code source} metric to the {@code target} metric.
+		 *
+		 * @return
+		 */
+		BigDecimal multiplier() {
+			return target.divide(source, PRECISION, RoundingMode.HALF_UP);
+		}
+
+		/**
+		 * Creates a new {@link ConversionMultiplierBuilder}.
+		 *
+		 * @return
+		 */
+		static ConversionMultiplierBuilder builder() {
+			return new ConversionMultiplierBuilder();
+		}
+
+	}
+
+	/**
+	 * Builder for {@link ConversionMultiplier}.
+	 *
+	 * @author Mark Paluch
+	 */
+	private static class ConversionMultiplierBuilder {
+
+		private Number from;
+		private Number to;
+
+		ConversionMultiplierBuilder() {}
+
+		ConversionMultiplierBuilder from(Number from) {
+			this.from = from;
+			return this;
+		}
+
+		ConversionMultiplierBuilder from(Metric from) {
+			this.from = from.getMultiplier();
+			return this;
+		}
+
+		ConversionMultiplierBuilder to(Number to) {
+			this.to = to;
+			return this;
+		}
+
+		ConversionMultiplierBuilder to(Metric to) {
+			this.to = to.getMultiplier();
+			return this;
+		}
+
+		ConversionMultiplier build() {
+			return new ConversionMultiplier(this.from, this.to);
+		}
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
@@ -27,7 +27,7 @@ import org.springframework.data.geo.Metrics;
  * {@link Metric} and {@link Distance} conversions using the metric system.
  *
  * @author Mark Paluch
- * @since 1.10
+ * @since 2.2
  */
 class MetricConversion {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.mongodb.core.query;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 
 import org.bson.Document;
@@ -25,6 +27,8 @@ import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
 import org.springframework.lang.Nullable;
+import org.springframework.data.mongodb.core.geo.GeoJson;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -46,6 +50,8 @@ public final class NearQuery {
 	private boolean spherical;
 	private @Nullable Long num;
 	private @Nullable Long skip;
+
+	private static int PRECISION = 8;
 
 	/**
 	 * Creates a new {@link NearQuery}.
@@ -416,25 +422,53 @@ public final class NearQuery {
 		}
 
 		if (maxDistance != null) {
-			document.put("maxDistance", maxDistance.getNormalizedValue());
+			document.put("maxDistance", getDistanceValueInRadiantsOrMeters(maxDistance));
 		}
 
 		if (minDistance != null) {
-			document.put("minDistance", minDistance.getNormalizedValue());
+			document.put("minDistance", getDistanceValueInRadiantsOrMeters(minDistance));
 		}
 
 		if (metric != null) {
-			document.put("distanceMultiplier", metric.getMultiplier());
+			document.put(
+					"distanceMultiplier",
+					usesMetricSystem() ? getMetricSystemNormalizer(metric).divide(new BigDecimal(1000), PRECISION + 3,
+							RoundingMode.HALF_UP).doubleValue() : metric.getMultiplier());
 		}
 
 		if (num != null) {
 			document.put("num", num);
 		}
 
-		document.put("near", Arrays.asList(point.getX(), point.getY()));
+		if (point instanceof GeoJsonPoint) {
+			document.put("near", point);
+		} else {
+			document.put("near", Arrays.asList(point.getX(), point.getY()));
+		}
 
-		document.put("spherical", spherical);
+		document.put("spherical", spherical ? spherical : point instanceof GeoJson);
 
 		return document;
 	}
+
+	private double getDistanceValueInRadiantsOrMeters(Distance distance) {
+		return usesMetricSystem() ? getDistanceInMeters(distance) : distance.getNormalizedValue();
+	}
+
+	private double getDistanceInMeters(Distance distance) {
+
+		return new BigDecimal(distance.getValue()).multiply(getMetricSystemNormalizer(distance.getMetric()))
+				.multiply(new BigDecimal(1000)).doubleValue();
+	}
+
+	private BigDecimal getMetricSystemNormalizer(Metric metric) {
+
+		return new BigDecimal(Metrics.KILOMETERS.getMultiplier()).divide(new BigDecimal(metric.getMultiplier()), PRECISION,
+				RoundingMode.HALF_UP);
+	}
+
+	private boolean usesMetricSystem() {
+		return point instanceof GeoJson;
+	}
+
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -1001,10 +1001,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		ArgumentCaptor<Document> capture = ArgumentCaptor.forClass(Document.class);
 		verify(this.db, times(1)).runCommand(capture.capture(), any(Class.class));
 
-		assertThat(
-				capture.getValue(),
-				IsBsonObject.isBsonObject().containing("near.type", "Point").containing("near.coordinates.[0]", 1D)
-						.containing("near.coordinates.[1]", 2D));
+		assertThat(capture.getValue(), IsBsonObject.isBsonObject().containing("near.type", "Point")
+				.containing("near.coordinates.[0]", 1D).containing("near.coordinates.[1]", 2D));
 	}
 
 	static class WithNamedFields {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -23,7 +23,6 @@ import static org.springframework.data.mongodb.core.aggregation.Fields.*;
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 
-import com.mongodb.DBObject;
 import lombok.Builder;
 
 import java.io.BufferedInputStream;
@@ -520,7 +519,7 @@ public class AggregationTests {
 		/*
 		 //complex mongodb aggregation framework example from
 		 https://docs.mongodb.org/manual/tutorial/aggregation-examples/#largest-and-smallest-cities-by-state
-
+		
 		 db.zipcodes.aggregate(
 			 	{
 				   $group: {
@@ -1529,7 +1528,6 @@ public class AggregationTests {
 		assertThat(firstResult.containsKey("distance"), is(true));
 		assertThat((Double) firstResult.get("distance"), closeTo(73.08517, 0.00001));
 	}
-
 
 	@Test // DATAMONGO-1133
 	public void shouldHonorFieldAliasesForFieldReferences() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataAccessException;
@@ -56,6 +57,7 @@ import com.mongodb.client.MongoCollection;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -104,6 +106,36 @@ public class GeoJsonTests {
 		assertThat(result.getAverageDistance().getMetric()).isEqualTo(Metrics.KILOMETERS);
 	}
 
+	@Test // DATAMONGO-1148
+	public void geoNearShouldReturnDistanceCorrectlyUsingGeoJson/*which is using the meters*/() {
+
+		NearQuery geoNear = NearQuery.near(new GeoJsonPoint(-73.99171, 40.738868), Metrics.KILOMETERS).num(10)
+				.maxDistance(0.4);
+
+		GeoResults<Venue2DSphere> result = template.geoNear(geoNear, Venue2DSphere.class);
+
+		assertThat(result.getContent()).hasSize(3);
+		assertThat(result.getAverageDistance().getMetric()).isEqualTo(Metrics.KILOMETERS);
+		assertThat(result.getContent().get(0).getDistance().getValue()).isCloseTo(0.0, offset(0.000001));
+		assertThat(result.getContent().get(1).getDistance().getValue()).isCloseTo(0.0693582, offset(0.000001));
+		assertThat(result.getContent().get(2).getDistance().getValue()).isCloseTo(0.0693582, offset(0.000001));
+	}
+
+	@Test // DATAMONGO-1348
+	public void geoNearShouldReturnDistanceCorrectly/*which is using the meters*/() {
+
+		NearQuery geoNear = NearQuery.near(new Point(-73.99171, 40.738868), Metrics.KILOMETERS).num(10)
+				.maxDistance(0.4);
+
+		GeoResults<Venue2DSphere> result = template.geoNear(geoNear, Venue2DSphere.class);
+
+		assertThat(result.getContent()).hasSize(3);
+		assertThat(result.getAverageDistance().getMetric()).isEqualTo(Metrics.KILOMETERS);
+		assertThat(result.getContent().get(0).getDistance().getValue()).isCloseTo(0.0, offset(0.000001));
+		assertThat(result.getContent().get(1).getDistance().getValue()).isCloseTo(0.0693582, offset(0.000001));
+		assertThat(result.getContent().get(2).getDistance().getValue()).isCloseTo(0.0693582, offset(0.000001));
+	}
+
 	@Test // DATAMONGO-1135
 	public void geoNearWithMiles() {
 
@@ -111,8 +143,8 @@ public class GeoJsonTests {
 
 		GeoResults<Venue2DSphere> result = template.geoNear(geoNear, Venue2DSphere.class);
 
-		assertThat(result.getContent().size(), is(not(0)));
-		assertThat(result.getAverageDistance().getMetric(), is((Metric) Metrics.MILES));
+		assertThat(result.getContent()).isNotEmpty();
+		assertThat(result.getAverageDistance().getMetric()).isEqualTo(Metrics.MILES);
 	}
 
 	@Test // DATAMONGO-1135

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
@@ -105,6 +105,17 @@ public class GeoJsonTests {
 	}
 
 	@Test // DATAMONGO-1135
+	public void geoNearWithMiles() {
+
+		NearQuery geoNear = NearQuery.near(new GeoJsonPoint(-73, 40), Metrics.MILES).num(10).maxDistance(93.2057);
+
+		GeoResults<Venue2DSphere> result = template.geoNear(geoNear, Venue2DSphere.class);
+
+		assertThat(result.getContent().size(), is(not(0)));
+		assertThat(result.getAverageDistance().getMetric(), is((Metric) Metrics.MILES));
+	}
+
+	@Test // DATAMONGO-1135
 	public void withinPolygon() {
 
 		Point first = new Point(-73.99756, 40.73083);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core.query;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Metrics;
+
+/**
+ * Unit tests for {@link MetricConversion}.
+ *
+ * @author Mark Paluch
+ */
+public class MetricConversionUnitTests {
+
+	/**
+	 * @see DATAMONGO-1348
+	 */
+	@Test
+	public void shouldConvertMilesToMeters() {
+
+		Distance distance = new Distance(1, Metrics.MILES);
+		double distanceInMeters = MetricConversion.getDistanceInMeters(distance);
+
+		assertThat(distanceInMeters, is(closeTo(1609.3438343d, 0.000000001)));
+	}
+
+	/**
+	 * @see DATAMONGO-1348
+	 */
+	@Test
+	public void shouldConvertKilometersToMeters() {
+
+		Distance distance = new Distance(1, Metrics.KILOMETERS);
+		double distanceInMeters = MetricConversion.getDistanceInMeters(distance);
+
+		assertThat(distanceInMeters, is(closeTo(1000, 0.000000001)));
+	}
+
+	/**
+	 * @see DATAMONGO-1348
+	 */
+	@Test
+	public void shouldCalculateMetersToKilometersMultiplier() {
+
+		double multiplier = MetricConversion.getMetersToMetricMultiplier(Metrics.KILOMETERS);
+
+		assertThat(multiplier, is(closeTo(0.001, 0.000000001)));
+	}
+
+	/**
+	 * @see DATAMONGO-1348
+	 */
+	@Test
+	public void shouldCalculateMetersToMilesMultiplier() {
+
+		double multiplier = MetricConversion.getMetersToMetricMultiplier(Metrics.MILES);
+
+		assertThat(multiplier, is(closeTo(0.00062137, 0.000000001)));
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,7 @@ import org.springframework.data.geo.Metrics;
  */
 public class MetricConversionUnitTests {
 
-	/**
-	 * @see DATAMONGO-1348
-	 */
-	@Test
+	@Test // DATAMONGO-1348
 	public void shouldConvertMilesToMeters() {
 
 		Distance distance = new Distance(1, Metrics.MILES);
@@ -42,10 +39,7 @@ public class MetricConversionUnitTests {
 		assertThat(distanceInMeters, is(closeTo(1609.3438343d, 0.000000001)));
 	}
 
-	/**
-	 * @see DATAMONGO-1348
-	 */
-	@Test
+	@Test // DATAMONGO-1348
 	public void shouldConvertKilometersToMeters() {
 
 		Distance distance = new Distance(1, Metrics.KILOMETERS);
@@ -54,10 +48,7 @@ public class MetricConversionUnitTests {
 		assertThat(distanceInMeters, is(closeTo(1000, 0.000000001)));
 	}
 
-	/**
-	 * @see DATAMONGO-1348
-	 */
-	@Test
+	@Test // DATAMONGO-1348
 	public void shouldCalculateMetersToKilometersMultiplier() {
 
 		double multiplier = MetricConversion.getMetersToMetricMultiplier(Metrics.KILOMETERS);
@@ -65,10 +56,7 @@ public class MetricConversionUnitTests {
 		assertThat(multiplier, is(closeTo(0.001, 0.000000001)));
 	}
 
-	/**
-	 * @see DATAMONGO-1348
-	 */
-	@Test
+	@Test // DATAMONGO-1348
 	public void shouldCalculateMetersToMilesMultiplier() {
 
 		double multiplier = MetricConversion.getMetersToMetricMultiplier(Metrics.MILES);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/NearQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/NearQueryUnitTests.java
@@ -95,8 +95,9 @@ public class NearQueryUnitTests {
 		Pageable pageable = PageRequest.of(3, 5);
 		NearQuery query = NearQuery.near(new Point(1, 1)).with(pageable);
 
-		assertThat(query.getSkip(), is((long)pageable.getPageNumber() * pageable.getPageSize()));
-		assertThat((Long) query.toDocument().get("num"), is((long)(pageable.getPageNumber() + 1) * pageable.getPageSize()));
+		assertThat(query.getSkip(), is((long) pageable.getPageNumber() * pageable.getPageSize()));
+		assertThat((Long) query.toDocument().get("num"),
+				is((long) (pageable.getPageNumber() + 1) * pageable.getPageSize()));
 	}
 
 	@Test // DATAMONGO-445
@@ -108,7 +109,7 @@ public class NearQueryUnitTests {
 				.query(Query.query(Criteria.where("foo").is("bar")).limit(limit).skip(skip));
 
 		assertThat(query.getSkip(), is(skip));
-		assertThat((Long) query.toDocument().get("num"), is((long)limit));
+		assertThat((Long) query.toDocument().get("num"), is((long) limit));
 	}
 
 	@Test // DATAMONGO-445
@@ -120,8 +121,9 @@ public class NearQueryUnitTests {
 		NearQuery query = NearQuery.near(new Point(1, 1))
 				.query(Query.query(Criteria.where("foo").is("bar")).limit(limit).skip(skip)).with(pageable);
 
-		assertThat(query.getSkip(), is((long)pageable.getPageNumber() * pageable.getPageSize()));
-		assertThat((Long) query.toDocument().get("num"), is((long)(pageable.getPageNumber() + 1) * pageable.getPageSize()));
+		assertThat(query.getSkip(), is((long) pageable.getPageNumber() * pageable.getPageSize()));
+		assertThat((Long) query.toDocument().get("num"),
+				is((long) (pageable.getPageNumber() + 1) * pageable.getPageSize()));
 	}
 
 	@Test // DATAMONGO-829

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1435,6 +1435,177 @@ repo.findByLocationWithin(                              <4>
 <4> Use the legacy format `$polygon` operator.
 ====
 
+==== Metrics and Distance calculation
+
+Then MongoDB `$geoNear` operator allows usage of a GeoJSON Point or legacy coordinate pairs.
+
+====
+[source,java]
+----
+NearQuery.near(new Point(-73.99171, 40.738868))
+----
+[source,json]
+----
+{
+  "$geoNear": {
+    //...
+    "near": [-73.99171, 40.738868]
+  }
+}
+----
+====
+====
+[source,java]
+----
+NearQuery.near(new GeoJsonPoint(-73.99171, 40.738868))
+----
+[source,json]
+----
+{
+  "$geoNear": {
+    //...
+    "near": { "type": "Point", "coordinates": [-73.99171, 40.738868] }
+  }
+}
+
+----
+====
+
+Though syntactically different the server is fine accepting both no matter what format the target Document within the collection
+is using.
+
+WARNING: There is a huge difference in the distance calculation. Using the legacy format operates
+upon _Radians_ on an Earth like sphere, whereas the GeoJSON format uses _Meters_.
+
+To avoid a serious headache make sure to set the `Metric` to the desired unit of measure which ensures the
+distance to be calculated correctly.
+
+In other words:
+
+====
+Assume you've got 5 Documents like the ones below:
+[source,json]
+----
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a5"),
+    "name" : "Penn Station",
+    "location" : { "type" : "Point", "coordinates" : [  -73.99408, 40.75057 ] }
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a6"),
+    "name" : "10gen Office",
+    "location" : { "type" : "Point", "coordinates" : [ -73.99171, 40.738868 ] }
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a9"),
+    "name" : "City Bakery ",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796aa"),
+    "name" : "Splash Bar",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796ab"),
+    "name" : "Momofuku Milk Bar",
+    "location" : { "type" : "Point", "coordinates" : [ -73.985839, 40.731698 ] }
+}
+----
+====
+
+Fetching all Documents within a 400 Meter radius from `[-73.99171, 40.738868]` would look like this using
+GeoJSON:
+
+.GeoNear with GeoJSON
+====
+[source,json]
+----
+{
+    "$geoNear": {
+        "maxDistance": 400, <1>
+        "num": 10,
+        "near": { type: "Point", coordinates: [-73.99171, 40.738868] },
+        "spherical":true, <2>
+        "key": "location",
+        "distanceField": "distance"
+    }
+}
+----
+Returning the following 3 Documents:
+[source,json]
+----
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a6"),
+    "name" : "10gen Office",
+    "location" : { "type" : "Point", "coordinates" : [ -73.99171, 40.738868 ] }
+    "distance" : 0.0 <3>
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a9"),
+    "name" : "City Bakery ",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+    "distance" : 69.3582262492474 <3>
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796aa"),
+    "name" : "Splash Bar",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+    "distance" : 69.3582262492474 <3>
+}
+----
+<1> Maximum distance from center point in _Meters_.
+<2> GeoJSON always operates upon a sphere.
+<3> Distance from center point in _Meters_.
+====
+
+Now, when using legacy coordinate pairs one operates upon _Radians_ as discussed before. So we use `Metrics#KILOMETERS
+when constructing the `$geoNear` command. The `Metric` makes sure the distance multiplier is set correctly.
+
+.GeoNear with Legacy Coordinate Pairs
+====
+[source,json]
+----
+{
+    "$geoNear": {
+        "maxDistance": 0.0000627142377, <1>
+        "distanceMultiplier": 6378.137, <2>
+        "num": 10,
+        "near": [-73.99171, 40.738868],
+        "spherical":true, <3>
+        "key": "location",
+        "distanceField": "distance"
+    }
+}
+----
+Returning the 3 Documents just like the GeoJSON variant:
+[source,json]
+----
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a6"),
+    "name" : "10gen Office",
+    "location" : { "type" : "Point", "coordinates" : [ -73.99171, 40.738868 ] }
+    "distance" : 0.0 <4>
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796a9"),
+    "name" : "City Bakery ",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+    "distance" : 0.0693586286032982 <4>
+}
+{
+    "_id" : ObjectId("5c10f3735d38908db52796aa"),
+    "name" : "Splash Bar",
+    "location" : { "type" : "Point", "coordinates" : [ -73.992491, 40.738673 ] }
+    "distance" : 0.0693586286032982 <4>
+}
+----
+<1> Maximum distance from center point in _Radians_.
+<2> The distance multiplier so we get _Kilometers_ as resulting distance.
+<3> Make sure we operate on a 2d_sphere index.
+<4> Distance from center point in _Kilometers_ - take it times 1000 to match _Meters_ of the GeoJSON variant.
+====
+
 [[mongo.textsearch]]
 === Full-text Queries
 


### PR DESCRIPTION
We now convert `GeoJsonPoint` used in `NearQuery` into its according format. This also requires to convert any given `min/maxDistance` as well as the `distanceMultiplier` into meters (metric system).

Along the way we fixed an issue where the actual `Query` used along with `NearQuery.query()` was not properly mapped to the domain types properties.
