### PR TITLE
Fix Query/BasicQuery getFieldsObject() inconsistency

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
@@ -70,7 +70,11 @@ public class BasicQuery extends Query {
 
 	@Override
 	public DBObject getFieldsObject() {
-		return fieldsObject;
+		if(fieldsObject != null) {
+			return fieldsObject;
+		} else {
+			return super.getFieldsObject();
+		}
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicQueryUnitTests.java
@@ -137,4 +137,21 @@ public class BasicQueryUnitTests {
 		assertThat(query1, is(not(equalTo(query2))));
 		assertThat(query1.hashCode(), is(not(query2.hashCode())));
 	}
+	
+	/**
+	 * @see DATAMONGO-1387
+	 */
+	@Test
+	public void handlesFieldsIncludeCorrectly() {
+		
+		String qry = "{ \"name\" : \"Thomas\"}";
+		
+		BasicQuery query1 = new BasicQuery(qry);
+		query1.fields().include("name");
+		
+		DBObject fieldsObject = query1.getFieldsObject();
+		fieldsObject.containsField("name");
+		assertThat(query1.getFieldsObject(), notNullValue());
+		assertThat(query1.getFieldsObject().containsField("name"), is(true));
+	}
 }


### PR DESCRIPTION
Previously, Query.getFieldsObject() and BasicQuery.getFieldsObject()
would behave differently in the case of fields().include(). For
example:
 Query query = new Query(jsonStr);
 query.fields().include("name");
 DBObject fieldsObject = query.getFieldsObject();
 // fieldsObject contains name, based on the fieldspec

However,
 Query query = new BasicQuery(jsonStr);
 query.fields().include("name");
 DBObject fieldsObject = query.getFieldsObject();
 // fieldsObject is null, because BasicQuery was not created
 // with a fieldsObject in the constructor

This fix changes BasicQuery to use the parent's getFieldsObject() in
the event that the BasicQuery was created without an explicit
fieldsObject in the constructor. In the case when an explicit 
not-null FieldsObject was provided, it will defer to that 
FieldsObject over using the parent class's getFieldsObject().

I ran into this while using BasicQuery but trying to use an 
enumerated list of fields. I was confused why fields().include()
was working for Query but not BasicQuery. After stepping through
it in the debugger, I filed DATAMONGO-1387. 

Issue: DATAMONGO-1387

My contributor number is: 165520160303021604