### PR TITLE
DATAMONGO-1373 - Allow usage of @AliasFor for composed query, mapping, and index annotations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.9.0.BUILD-SNAPSHOT</version>
+	<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.9.0.BUILD-SNAPSHOT</version>
+			<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.DATAMONGO-1373-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -19,6 +19,7 @@
 		<validation>1.0.0.GA</validation>
 		<objenesis>1.3</objenesis>
 		<equalsverifier>1.5</equalsverifier>
+		<springdata.commons>1.12.0.DATACMNS-825-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<dependencies>

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeoSpatialIndexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeoSpatialIndexed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 the original author or authors.
+ * Copyright 2010-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@ import java.lang.annotation.Target;
  * @author Laurent Canet
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GeoSpatialIndexed {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,11 @@ import java.lang.annotation.Target;
  * all fields marked with {@link TextIndexed} are combined into one single index. <br />
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.6
  */
 @Documented
-@Target({ ElementType.FIELD })
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TextIndexed {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
@@ -26,7 +26,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.expression.BeanFactoryAccessor;
 import org.springframework.context.expression.BeanFactoryResolver;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.AssociationHandler;
@@ -78,7 +77,7 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 		Class<?> rawType = typeInformation.getType();
 		String fallback = MongoCollectionUtils.getPreferredCollectionName(rawType);
 
-		Document document = AnnotationUtils.findAnnotation(rawType, Document.class);
+		Document document = this.findAnnotation(Document.class);
 
 		this.expression = detectExpression(document);
 		this.context = new StandardEvaluationContext();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Field.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Field.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2011-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.mongodb.core.mapping;
 
 import java.lang.annotation.Documented;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,11 @@ import org.springframework.data.annotation.QueryAnnotation;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.6
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Documented
 @QueryAnnotation
 public @interface Meta {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import org.springframework.data.annotation.QueryAnnotation;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Documented
 @QueryAnnotation
 public @interface Query {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.geo.GeoPage;
 import org.springframework.data.geo.GeoResult;
@@ -43,6 +44,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class MongoQueryMethod extends QueryMethod {
 
@@ -191,7 +193,7 @@ public class MongoQueryMethod extends QueryMethod {
 	 * @return
 	 */
 	Query getQueryAnnotation() {
-		return method.getAnnotation(Query.class);
+		return AnnotatedElementUtils.findMergedAnnotation(method, Query.class);
 	}
 
 	TypeInformation<?> getReturnType() {
@@ -213,7 +215,7 @@ public class MongoQueryMethod extends QueryMethod {
 	 * @since 1.6
 	 */
 	Meta getMetaAnnotation() {
-		return method.getAnnotation(Meta.class);
+		return AnnotatedElementUtils.findMergedAnnotation(method, Meta.class);
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 by the original author(s).
+ * Copyright 2011-2016 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.util.ClassTypeInformation;
 
@@ -243,6 +244,18 @@ public class BasicMongoPersistentEntityUnitTests {
 		assertThat(entity.getCollection(), is("collection-1"));
 	}
 
+	/**
+	 * @see DATAMONGO-1373
+	 */
+	@Test
+	public void metaInformationShouldBeReadCorrectlyFromComposedDocumentAnnotation() {
+
+		BasicMongoPersistentEntity<DocumentWithComposedAnnotation> entity = new BasicMongoPersistentEntity<DocumentWithComposedAnnotation>(
+				ClassTypeInformation.from(DocumentWithComposedAnnotation.class));
+
+		assertThat(entity.getCollection(), is("custom-collection"));
+	}
+
 	@Document(collection = "contacts")
 	class Contact {
 
@@ -284,9 +297,23 @@ public class BasicMongoPersistentEntityUnitTests {
 
 	}
 
+	@ComposedDocumentAnnotation
+	static class DocumentWithComposedAnnotation {
+
+	}
+
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
 	@Document(collection = "collection-1")
 	static @interface CustomDocumentAnnotation {
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE })
+	@Document
+	static @interface ComposedDocumentAnnotation {
+
+		@AliasFor(annotation = Document.class, attribute = "collection")
+		String name() default "custom-collection";
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ComplexIdRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ComplexIdRepositoryIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.repository;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -129,4 +130,27 @@ public class ComplexIdRepositoryIntegrationTests {
 		assertThat(loaded, is(Matchers.<UserWithComplexId> iterableWithSize(1)));
 		assertThat(loaded, contains(userWithId));
 	}
+	
+	/**
+	 * @see DATAMONGO-1373
+	 */
+	@Test
+	public void composedAnnotationFindQueryShouldWorkWhenUsingComplexId() {
+
+		repo.save(userWithId);
+
+		assertThat(repo.getUserUsingComposedAnnotationByComplexId(id), is(userWithId));
+	}
+	
+	/**
+	 * @see DATAMONGO-1373
+	 */
+	@Test
+	public void composedAnnotationFindMetaShouldWorkWhenUsingComplexId() {
+
+		repo.save(userWithId);
+
+		assertThat(repo.findUsersUsingComposedMetaAnnotationByUserIds(Arrays.asList(id)), hasSize(0));
+	}
+	
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/UserWithComplexIdRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/UserWithComplexIdRepository.java
@@ -15,9 +15,15 @@
  */
 package org.springframework.data.mongodb.repository;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.repository.CrudRepository;
 
 /**
@@ -30,4 +36,31 @@ public interface UserWithComplexIdRepository extends CrudRepository<UserWithComp
 
 	@Query("{'_id': ?0}")
 	UserWithComplexId getUserByComplexId(MyId id);
+	
+	@ComposedQueryAnnotation
+	UserWithComplexId getUserUsingComposedAnnotationByComplexId(MyId id);
+	
+	@ComposedMetaAnnotation
+	@Query("{'_id': {$in: ?0}}")
+	List<UserWithComplexId> findUsersUsingComposedMetaAnnotationByUserIds(Collection<MyId> ids);
+	
+	
+	@Retention(RetentionPolicy.RUNTIME)
+ 	@Target({ ElementType.METHOD })
+ 	@Document
+	@Query
+ 	@interface ComposedQueryAnnotation {
+ 
+ 		@AliasFor(annotation = Query.class, attribute = "value")
+ 		String myQuery() default "{'_id': ?0}";
+ 	}
+	
+	@Retention(RetentionPolicy.RUNTIME)
+ 	@Target({ ElementType.METHOD })
+ 	@Meta
+ 	@interface ComposedMetaAnnotation {
+ 
+ 		@AliasFor(annotation = Meta.class, attribute = "maxScanDocuments")
+ 		long scanDocuments() default 1;
+ 	}
 }

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -1,6 +1,11 @@
 [[new-features]]
 = New & Noteworthy
 
+[[new-features.1-9-0]]
+== What's new in Spring Data MongoDB 1.9
+* The following annotations have been enabled to build own, composed annotations: `@Document`, `@Id`, `@Field`, `@Indexed`, `@CompoundIndex`, `@GeoSpatialIndexed`, `@TextIndexed`, `@Query`, `@Meta`. 
+
+
 [[new-features.1-8-0]]
 == What's new in Spring Data MongoDB 1.8
 


### PR DESCRIPTION
We now resolve aliased attribute values when reading `@Document` on entity types. This allows creation of composed annotations like:

```java
@Retention(RetentionPolicy.RUNTIME)
@Target({ ElementType.TYPE })
@Document
static @interface ComposedDocumentAnnotation {

  @AliasFor(annotation = Document.class, attribute = "collection")
  String name() default "custom-collection-name";
}
```
----

Related issue: DATACMNS-825
Related PR: spring-projects/spring-data-commons#156