### PR TITLE
Add support of $min and $max update operators

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -324,6 +324,7 @@ public class Update {
 	 * @return
 	 */
 	public Update max(String key, Object value) {
+		Assert.notNull(value, "Value must not be 'null'.");
 		addMultiFieldOperation("$max", key, value);
 		return this;
 	}
@@ -337,6 +338,7 @@ public class Update {
 	 * @return
 	 */
 	public Update min(String key, Object value) {
+		Assert.notNull(value, "Value must not be 'null'.");
 		addMultiFieldOperation("$min", key, value);
 		return this;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -314,6 +314,32 @@ public class Update {
 		addMultiFieldOperation("$mul", key, multiplier.doubleValue());
 		return this;
 	}
+	
+	/**
+	 * Update using the {@literal $max} update modifier
+	 *
+	 * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+	 * @param key
+	 * @param value
+	 * @return
+	 */
+	public Update max(String key, Object value) {
+		addMultiFieldOperation("$max", key, value);
+		return this;
+	}
+
+	/**
+	 * Update using the {@literal $max} update modifier
+	 *
+	 * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+	 * @param key
+	 * @param value
+	 * @return
+	 */
+	public Update min(String key, Object value) {
+		addMultiFieldOperation("$min", key, value);
+		return this;
+	}
 
 	/**
 	 * The operator supports bitwise {@code and}, bitwise {@code or}, and bitwise {@code xor} operations.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
@@ -504,4 +504,101 @@ public class UpdateTests {
 		assertThat(pullAll.get("field1"), is(notNullValue()));
 		assertThat(pullAll.get("field2"), is(notNullValue()));
 	}
+
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void maxShouldThrowExceptionForNullMultiplier() {
+		new Update().max("key", null);
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void minShouldThrowExceptionForNullMultiplier() {
+		new Update().min("key", null);
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void getUpdateObjectShouldReturnCorrectRepresentationForMax() {
+
+		Update update = new Update().max("key", 10);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$max", new BasicDBObject("key", 10))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void getUpdateObjectShouldReturnCorrectRepresentationForMin() {
+
+		Update update = new Update().min("key", 10);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$min", new BasicDBObject("key", 10))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void shouldSuppressPreviousValueForMax() {
+
+		Update update = new Update().max("key", 10);
+
+		update.max("key", 99);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$max", new BasicDBObject("key", 99))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void shouldSuppressPreviousValueForMin() {
+
+		Update update = new Update().min("key", 10);
+
+		update.max("key", 99);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$min9", new BasicDBObject("key", 99))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void getUpdateObjectShouldReturnCorrectDateRepresentationForMax() {
+
+		final java.util.Date date = new java.util.Date();
+
+		Update update = new Update().max("key", date);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$max", new BasicDBObject("key", date))
+				.get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1404
+	 */
+	@Test
+	public void getUpdateObjectShouldReturnCorrectDateRepresentationForMin() {
+
+		final java.util.Date date = new java.util.Date();
+
+		Update update = new Update().min("key", date);
+
+		assertThat(update.getUpdateObject(), equalTo(new BasicDBObjectBuilder().add("$min", new BasicDBObject("key", date))
+				.get()));
+	}
 }


### PR DESCRIPTION
For some reason `$min` and `$max` are not yet supported. Diff adds two methods into the `org.springframework.data.mongodb.core.query.Update` class. Diff speaks for itslef and works pretty well for me.