### PR TITLE
DATAMONGO-1411 - Enable MongoDB build on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,28 @@ language: java
 jdk:
   - oraclejdk8
 
-services:
-  - mongodb
+before_script:
+  - mongod --version
 
 env:
   matrix:
     - PROFILE=ci
     - PROFILE=mongo-next
+    - PROFILE=mongo3
+    - PROFILE=mongo3-next
+    - PROFILE=mongo31
+    - PROFILE=mongo32
+    - PROFILE=mongo33-next
+
+# Current MongoDB version is 2.4.2 as of 2016-04, see https://github.com/travis-ci/travis-ci/issues/3694
+# apt-get starts a MongoDB instance so it's not started using before_script
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    packages:
+    - mongodb-org-server
+    - mongodb-org-shell
 
 sudo: false
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
 			<id>mongo-next</id>
 			<properties>
-				<mongo>2.14.0-SNAPSHOT</mongo>
+				<mongo>2.15.0-SNAPSHOT</mongo>
 			</properties>
 
 			<repositories>
@@ -148,16 +148,25 @@
 
 			<id>mongo31</id>
 			<properties>
-				<mongo>3.1.0</mongo>
+				<mongo>3.1.1</mongo>
 			</properties>
 
 		</profile>
 
 		<profile>
 
-			<id>mongo32-next</id>
+			<id>mongo32</id>
 			<properties>
-				<mongo>3.2.0-SNAPSHOT</mongo>
+				<mongo>3.2.2</mongo>
+			</properties>
+
+		</profile>
+
+		<profile>
+
+			<id>mongo33-next</id>
+			<properties>
+				<mongo>3.3.0-SNAPSHOT</mongo>
 			</properties>
 
 			<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1411-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceReplicaSetTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceReplicaSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Ignore;
@@ -37,6 +38,13 @@ import com.mongodb.CommandResult;
 import com.mongodb.Mongo;
 import com.mongodb.ServerAddress;
 
+/**
+ *
+ * @author Mark Pollack
+ * @author Oliver Gierke
+ * @author Thomas Darimont
+ * @author Mark Paluch
+ */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class MongoNamespaceReplicaSetTests {
@@ -70,10 +78,13 @@ public class MongoNamespaceReplicaSetTests {
 
 		assertThat(replicaSetSeeds, is(notNullValue()));
 		assertThat(replicaSetSeeds, hasSize(3));
-		assertThat(
-				replicaSetSeeds,
-				hasItems(new ServerAddress("192.168.174.130", 27017), new ServerAddress("192.168.174.130", 27018),
-						new ServerAddress("192.168.174.130", 27019)));
+
+		List<Integer> ports = new ArrayList<Integer>();
+		for (ServerAddress replicaSetSeed : replicaSetSeeds) {
+			ports.add(replicaSetSeed.getPort());
+		}
+
+		assertThat(ports, hasItems(27017, 27018, 27019));
 	}
 
 	@Test


### PR DESCRIPTION
Builds on TravisCI cause successful DNS reverse lookups for the used ServerAddresses so it's not reliable to check for the host part. Added missing author tags to the test.

TravisCI supports as of now only MongoDB 2.4.2 when adding the MongoDB service to the config section. It's therefore required to upgrade the server. apt-get also starts the MongoDB server which is not obvious.

 Upgrade of profiles, removed promoted snapshot-versions, renamed mongo32-next to mongo32, added mongo33-next build profile.

----
Related ticket: [DATAMONGO-1411](https://jira.spring.io/browse/DATAMONGO-1411)