### PR TITLE
DATAMONGO-1416 - Standard bootstrap issues warning in converter registration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -81,7 +81,10 @@ abstract class MongoConverters {
 		converters.add(DBObjectToNamedMongoScriptCoverter.INSTANCE);
 		converters.add(CurrencyToStringConverter.INSTANCE);
 		converters.add(StringToCurrencyConverter.INSTANCE);
-		converters.add(NumberToNumberConverterFactory.INSTANCE);
+		converters.add(AtomicIntegerToIntegerConverter.INSTANCE);
+		converters.add(AtomicLongToLongConverter.INSTANCE);
+		converters.add(LongToAtomicLongConverter.INSTANCE);
+		converters.add(IntegerToAtomicIntegerConverter.INSTANCE);
 
 		return converters;
 	}
@@ -372,6 +375,70 @@ abstract class MongoConverters {
 
 				return NumberUtils.convertNumberToTargetClass(source, this.targetType);
 			}
+		}
+	}
+
+	/**
+	 * {@link ConverterFactory} implementation converting {@link AtomicLong} into {@link Long}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.10
+	 */
+	@WritingConverter
+	public static enum AtomicLongToLongConverter implements Converter<AtomicLong, Long> {
+		INSTANCE;
+
+		@Override
+		public Long convert(AtomicLong source) {
+			return NumberUtils.convertNumberToTargetClass(source, Long.class);
+		}
+	}
+
+	/**
+	 * {@link ConverterFactory} implementation converting {@link AtomicInteger} into {@link Integer}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.10
+	 */
+	@WritingConverter
+	public static enum AtomicIntegerToIntegerConverter implements Converter<AtomicInteger, Integer> {
+		INSTANCE;
+
+		@Override
+		public Integer convert(AtomicInteger source) {
+			return NumberUtils.convertNumberToTargetClass(source, Integer.class);
+		}
+	}
+
+	/**
+	 * {@link ConverterFactory} implementation converting {@link Long} into {@link AtomicLong}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.10
+	 */
+	@ReadingConverter
+	public static enum LongToAtomicLongConverter implements Converter<Long, AtomicLong> {
+		INSTANCE;
+
+		@Override
+		public AtomicLong convert(Long source) {
+			return source != null ? new AtomicLong(source) : null;
+		}
+	}
+
+	/**
+	 * {@link ConverterFactory} implementation converting {@link Integer} into {@link AtomicInteger}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.10
+	 */
+	@ReadingConverter
+	public static enum IntegerToAtomicIntegerConverter implements Converter<Integer, AtomicInteger> {
+		INSTANCE;
+
+		@Override
+		public AtomicInteger convert(Integer source) {
+			return source != null ? new AtomicInteger(source) : null;
 		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
@@ -20,15 +20,22 @@ import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.util.Currency;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.geo.Shape;
+import org.springframework.data.mongodb.core.convert.MongoConverters.AtomicIntegerToIntegerConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.AtomicLongToLongConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.BigDecimalToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.CurrencyToStringConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.IntegerToAtomicIntegerConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.LongToAtomicLongConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToCurrencyConverter;
 import org.springframework.data.mongodb.core.geo.Sphere;
@@ -139,5 +146,37 @@ public class MongoConvertersUnitTests {
 	@Test
 	public void convertsStringToCurrencyCorrectly() {
 		assertThat(StringToCurrencyConverter.INSTANCE.convert("USD"), is(Currency.getInstance("USD")));
+	}
+
+	/**
+	 * @see DATAMONGO-1416
+	 */
+	@Test
+	public void convertsAtomicLongToLongCorrectly() {
+		assertThat(AtomicLongToLongConverter.INSTANCE.convert(new AtomicLong(100L)), is(100L));
+	}
+
+	/**
+	 * @see DATAMONGO-1416
+	 */
+	@Test
+	public void convertsAtomicIntegerToIntegerCorrectly() {
+		assertThat(AtomicIntegerToIntegerConverter.INSTANCE.convert(new AtomicInteger(100)), is(100));
+	}
+
+	/**
+	 * @see DATAMONGO-1416
+	 */
+	@Test
+	public void convertsLongToAtomicLongCorrectly() {
+		assertThat(LongToAtomicLongConverter.INSTANCE.convert(100L), IsInstanceOf.instanceOf(AtomicLong.class));
+	}
+
+	/**
+	 * @see DATAMONGO-1416
+	 */
+	@Test
+	public void convertsIntegerToAtomicIntegerCorrectly() {
+		assertThat(IntegerToAtomicIntegerConverter.INSTANCE.convert(100), IsInstanceOf.instanceOf(AtomicInteger.class));
 	}
 }


### PR DESCRIPTION
We now use explicit `Converter` s instead of a `ConverterFactory`. This reduces noise in log when registering converters.