### PR TITLE
 DATAMONGO-1451 - Translate write concern timeouts to TransientDataAccessResourceException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.11.0.BUILD-SNAPSHOT</version>
+			<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
We now translate timeouts (caused by replication or write concern timeout) into `TransientDataAccessResourceException`.

---

Related ticket: [DATAMONGO-1451](https://jira.spring.io/browse/DATAMONGO-1451)
