### PR TITLE
DATAMONGO-1447 - Add support for isolations on Update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1447-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1192,6 +1192,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				Document updateObj = update == null ? new Document()
 						: updateMapper.getMappedObject(update.getUpdateObject(), entity);
 
+				if (multi && update.isIsolated() && !queryObj.containsKey("$isolated")) {
+					queryObj.put("$isolated", 1);
+				}
+
 				if (LOGGER.isDebugEnabled()) {
 					LOGGER.debug("Calling update using query: {} and update: {} in collection: {}",
 							serializeToJsonSafely(queryObj), serializeToJsonSafely(updateObj), collectionName);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -53,6 +53,7 @@ public class Update {
 		LAST, FIRST
 	}
 
+	private boolean isolated = false;
 	private Set<String> keysToUpdate = new HashSet<String>();
 	private Map<String, Object> modifierOps = new LinkedHashMap<String, Object>();
 	private Map<String, PushOperatorBuilder> pushCommandBuilders = new LinkedHashMap<String, PushOperatorBuilder>(1);
@@ -73,7 +74,7 @@ public class Update {
 	 * {@literal $set}. This means fields not given in the {@link Document} will be nulled when executing the update. To
 	 * create an only-updating {@link Update} instance of a {@link Document}, call {@link #set(String, Object)} for each
 	 * value in it.
-	 * 
+	 *
 	 * @param object the source {@link Document} to create the update from.
 	 * @param exclude the fields to exclude.
 	 * @return
@@ -362,6 +363,28 @@ public class Update {
 	 */
 	public BitwiseOperatorBuilder bitwise(String key) {
 		return new BitwiseOperatorBuilder(this, key);
+	}
+
+	/**
+	 * Prevents a write operation that affects <strong>multiple</strong> documents from yielding to other reads or writes
+	 * once the first document is written. <br />
+	 * Use with {@link org.springframework.data.mongodb.core.MongoOperations#updateMulti(Query, Update, Class)}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 */
+	public Update isolated() {
+
+		isolated = true;
+		return this;
+	}
+
+	/**
+	 * @return {@literal true} if update isolated is set.
+	 * @since 2.0
+	 */
+	public Boolean isIsolated() {
+		return isolated;
 	}
 
 	public Document getUpdateObject() {


### PR DESCRIPTION
We now allow usage of the [$isolated](https://docs.mongodb.com/manual/reference/operator/update/isolated/#definition) update operator via `Update.isolated()`.
In case isolated is set, the query involved in `MongoOperations.updateMulti` will be enhanced by `'$isolated' : 1` in case the isolation level has not already been set explicitly via eg. `new BasicQuery("{'$isolated' : 0}")`.
