### PR TITLE
DATAMONGO-1457 - Add support for $slice in aggregation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1457-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -352,6 +352,7 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 	 * 
 	 * @author Oliver Gierke
 	 * @author Thomas Darimont
+	 * @author Christoph Strobl
 	 */
 	public static class ProjectionOperationBuilder extends AbstractProjectionOperationBuilder {
 
@@ -564,6 +565,31 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 
 		public ProjectionOperationBuilder size() {
 			return project("size");
+		}
+
+		/**
+		 * Generates a {@code $slice} expression that returns a subset of the array held by the given field. <br />
+		 * If {@literal n} is positive, $slice returns up to the first n elements in the array. <br />
+		 * If {@literal n} is negative, $slice returns up to the last n elements in the array.
+		 *
+		 * @param count max number of elements.
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder slice(int count) {
+			return project("slice", count);
+		}
+
+		/**
+		 * Generates a {@code $slice} expression that returns a subset of the array held by the given field. <br />
+		 *
+		 * @param count max number of elements. Must not be negative.
+		 * @param offset the offset within the array to start from.
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder slice(int count, int offset) {
+			return project("slice", offset, count);
 		}
 
 		/* 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -1228,6 +1228,25 @@ public class AggregationTests {
 				skip(100));
 	}
 
+	/**
+	 * @see DATAMONGO-1457
+	 */
+	@Test
+	public void sliceShouldBeAppliedCorrectly() {
+
+		createUserWithLikesDocuments();
+
+		TypedAggregation<UserWithLikes> agg = newAggregation(UserWithLikes.class, match(new Criteria()),
+				project().and("likes").slice(2));
+
+		AggregationResults<UserWithLikes> result = mongoTemplate.aggregate(agg, UserWithLikes.class);
+
+		assertThat(result.getMappedResults(), hasSize(9));
+		for (UserWithLikes user : result) {
+			assertThat(user.likes.size() <= 2, is(true));
+		}
+	}
+
 	private void createUsersWithReferencedPersons() {
 
 		mongoTemplate.dropCollection(User.class);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import com.mongodb.DBObject;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class ProjectionOperationUnitTests {
 
@@ -369,6 +370,36 @@ public class ProjectionOperationUnitTests {
 
 		DBObject projected = exctractOperation("$project", dbObject);
 		assertThat(projected.get("tags_count"), is((Object) new BasicDBObject("$size", Arrays.asList("$tags"))));
+	}
+
+	/**
+	 * @see DATAMONGO-1457
+	 */
+	@Test
+	public void shouldRenderSliceCorrectly() throws Exception {
+
+		ProjectionOperation operation = Aggregation.project().and("field").slice(10).as("renamed");
+
+		DBObject dbObject = operation.toDBObject(Aggregation.DEFAULT_CONTEXT);
+		DBObject projected = exctractOperation("$project", dbObject);
+
+		assertThat(projected.get("renamed"),
+				is((Object) new BasicDBObject("$slice", Arrays.<Object> asList("$field", 10))));
+	}
+
+	/**
+	 * @see DATAMONGO-1457
+	 */
+	@Test
+	public void shouldRenderSliceWithPositionCorrectly() throws Exception {
+
+		ProjectionOperation operation = Aggregation.project().and("field").slice(10, 5).as("renamed");
+
+		DBObject dbObject = operation.toDBObject(Aggregation.DEFAULT_CONTEXT);
+		DBObject projected = exctractOperation("$project", dbObject);
+
+		assertThat(projected.get("renamed"),
+				is((Object) new BasicDBObject("$slice", Arrays.<Object> asList("$field", 5, 10))));
 	}
 
 	private static DBObject exctractOperation(String field, DBObject fromProjectClause) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/UserWithLikes.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/UserWithLikes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,15 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
+@Data
+@NoArgsConstructor
 public class UserWithLikes {
 
 	String id;
@@ -30,6 +36,7 @@ public class UserWithLikes {
 	Set<String> likes = new HashSet<String>();
 
 	public UserWithLikes(String id, Date joined, String... likes) {
+
 		this.id = id;
 		this.joined = joined;
 		this.likes = new HashSet<String>(Arrays.asList(likes));


### PR DESCRIPTION
We now support `$slice` in aggregation projections via the `ProjectionOperationBuilder`.

```java
    // { $project : { field : { $slice : [$field, 10] } } }
    Aggregation.project().and("field").slice(10);

    // { $project : { field : { $slice : [$field, 20, 10] } } }
    Aggregation.project().and("field").slice(10, 20);
```