### PR TITLE
DATAMONGO-1455, DATAMONGO-1456 - Add support for $caseSensitive and $diacriticSensitive to $text.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1455-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/TextCriteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/TextCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ public class TextCriteria implements CriteriaDefinition {
 
 	private final List<Term> terms;
 	private String language;
+	private Boolean caseSensitive;
+	private Boolean diacriticSensitive;
 
 	/**
 	 * Creates a new {@link TextCriteria}.
@@ -63,8 +65,8 @@ public class TextCriteria implements CriteriaDefinition {
 	}
 
 	/**
-	 * For a full list of supported languages see the mongodb reference manual for <a
-	 * href="http://docs.mongodb.org/manual/reference/text-search-languages/">Text Search Languages</a>.
+	 * For a full list of supported languages see the mongodb reference manual for
+	 * <a href="http://docs.mongodb.org/manual/reference/text-search-languages/">Text Search Languages</a>.
 	 * 
 	 * @param language
 	 * @return
@@ -167,6 +169,32 @@ public class TextCriteria implements CriteriaDefinition {
 		return this;
 	}
 
+	/**
+	 * Optionally enable or disable case sensitive search.
+	 *
+	 * @param caseSensitive boolean flag endable/disable.
+	 * @return never {@literal null}.
+	 * @since 1.10
+	 */
+	public TextCriteria caseSensitive(boolean caseSensitive) {
+
+		this.caseSensitive = caseSensitive;
+		return this;
+	}
+
+	/**
+	 * Optionallly enable or disable diacritic sensitive search against version 3 text indexes.
+	 *
+	 * @param diacriticSensitive boolean flag endable/disable.
+	 * @return never {@literal null}.
+	 * @since 1.10
+	 */
+	public TextCriteria diacriticSensitive(boolean diacriticSensitive) {
+
+		this.diacriticSensitive = diacriticSensitive;
+		return this;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.query.CriteriaDefinition#getKey()
@@ -191,6 +219,14 @@ public class TextCriteria implements CriteriaDefinition {
 
 		if (!terms.isEmpty()) {
 			builder.add("$search", join(terms));
+		}
+
+		if (caseSensitive != null) {
+			builder.add("$caseSensitive", caseSensitive);
+		}
+
+		if (diacriticSensitive != null) {
+			builder.add("$diacriticSensitive", diacriticSensitive);
 		}
 
 		return new BasicDBObject("$text", builder.get());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextCriteriaUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextCriteriaUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.springframework.data.mongodb.core.DBObjectTestUtils;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
 
@@ -113,6 +114,29 @@ public class TextCriteriaUnitTests {
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().notMatchingPhrase("coffee cake");
 		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
 				IsEqual.<DBObject> equalTo(new BasicDBObject("$search", "-\"coffee cake\"")));
+	}
+
+	/**
+	 * @see DATAMONGO-1455
+	 */
+	@Test
+	public void caseSensitiveOperatorShouldBeSetCorrectly() {
+
+		TextCriteria criteria = TextCriteria.forDefaultLanguage().matching("coffee").caseSensitive(true);
+		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"), IsEqual
+				.<DBObject> equalTo(new BasicDBObjectBuilder().add("$search", "coffee").add("$caseSensitive", true).get()));
+	}
+
+	/**
+	 * @see DATAMONGO-1456
+	 */
+	@Test
+	public void diacriticSensitiveOperatorShouldBeSetCorrectly() {
+
+		TextCriteria criteria = TextCriteria.forDefaultLanguage().matching("coffee").diacriticSensitive(true);
+		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
+				IsEqual.<DBObject> equalTo(
+						new BasicDBObjectBuilder().add("$search", "coffee").add("$diacriticSensitive", true).get()));
 	}
 
 	private DBObject searchObject(String json) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextCriteriaUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextCriteriaUnitTests.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.data.mongodb.core.query;
 
-import org.hamcrest.core.IsEqual;
-import org.junit.Assert;
+import static org.hamcrest.core.IsEqual.*;
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.springframework.data.mongodb.core.DBObjectTestUtils;
 
@@ -39,7 +40,7 @@ public class TextCriteriaUnitTests {
 	public void shouldNotHaveLanguageField() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage();
-		Assert.assertThat(criteria.getCriteriaObject(), IsEqual.equalTo(searchObject("{ }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ }")));
 	}
 
 	/**
@@ -49,7 +50,7 @@ public class TextCriteriaUnitTests {
 	public void shouldNotHaveLanguageForNonDefaultLanguageField() {
 
 		TextCriteria criteria = TextCriteria.forLanguage("spanish");
-		Assert.assertThat(criteria.getCriteriaObject(), IsEqual.equalTo(searchObject("{ \"$language\" : \"spanish\" }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ \"$language\" : \"spanish\" }")));
 	}
 
 	/**
@@ -59,7 +60,7 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateSearchFieldForSingleTermCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().matching("cake");
-		Assert.assertThat(criteria.getCriteriaObject(), IsEqual.equalTo(searchObject("{ \"$search\" : \"cake\" }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ \"$search\" : \"cake\" }")));
 	}
 
 	/**
@@ -69,8 +70,7 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateSearchFieldCorrectlyForMultipleTermsCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().matchingAny("bake", "coffee", "cake");
-		Assert.assertThat(criteria.getCriteriaObject(),
-				IsEqual.equalTo(searchObject("{ \"$search\" : \"bake coffee cake\" }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ \"$search\" : \"bake coffee cake\" }")));
 	}
 
 	/**
@@ -80,8 +80,8 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateSearchFieldForPhraseCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().matchingPhrase("coffee cake");
-		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
-				IsEqual.<DBObject> equalTo(new BasicDBObject("$search", "\"coffee cake\"")));
+		assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
+				equalTo((DBObject) new BasicDBObject("$search", "\"coffee cake\"")));
 	}
 
 	/**
@@ -91,7 +91,7 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateNotFieldCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().notMatching("cake");
-		Assert.assertThat(criteria.getCriteriaObject(), IsEqual.equalTo(searchObject("{ \"$search\" : \"-cake\" }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ \"$search\" : \"-cake\" }")));
 	}
 
 	/**
@@ -101,8 +101,7 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateSearchFieldCorrectlyForNotMultipleTermsCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().notMatchingAny("bake", "coffee", "cake");
-		Assert.assertThat(criteria.getCriteriaObject(),
-				IsEqual.equalTo(searchObject("{ \"$search\" : \"-bake -coffee -cake\" }")));
+		assertThat(criteria.getCriteriaObject(), equalTo(searchObject("{ \"$search\" : \"-bake -coffee -cake\" }")));
 	}
 
 	/**
@@ -112,8 +111,8 @@ public class TextCriteriaUnitTests {
 	public void shouldCreateSearchFieldForNotPhraseCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().notMatchingPhrase("coffee cake");
-		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
-				IsEqual.<DBObject> equalTo(new BasicDBObject("$search", "-\"coffee cake\"")));
+		assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
+				equalTo((DBObject) new BasicDBObject("$search", "-\"coffee cake\"")));
 	}
 
 	/**
@@ -123,8 +122,8 @@ public class TextCriteriaUnitTests {
 	public void caseSensitiveOperatorShouldBeSetCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().matching("coffee").caseSensitive(true);
-		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"), IsEqual
-				.<DBObject> equalTo(new BasicDBObjectBuilder().add("$search", "coffee").add("$caseSensitive", true).get()));
+		assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
+				equalTo(new BasicDBObjectBuilder().add("$search", "coffee").add("$caseSensitive", true).get()));
 	}
 
 	/**
@@ -134,9 +133,8 @@ public class TextCriteriaUnitTests {
 	public void diacriticSensitiveOperatorShouldBeSetCorrectly() {
 
 		TextCriteria criteria = TextCriteria.forDefaultLanguage().matching("coffee").diacriticSensitive(true);
-		Assert.assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
-				IsEqual.<DBObject> equalTo(
-						new BasicDBObjectBuilder().add("$search", "coffee").add("$diacriticSensitive", true).get()));
+		assertThat(DBObjectTestUtils.getAsDBObject(criteria.getCriteriaObject(), "$text"),
+				equalTo((DBObject) new BasicDBObjectBuilder().add("$search", "coffee").add("$diacriticSensitive", true).get()));
 	}
 
 	private DBObject searchObject(String json) {

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1356,6 +1356,8 @@ TextQuery.searching(new TextCriteria().matching("\"coffee cake\""));
 TextQuery.searching(new TextCriteria().phrase("coffee cake"));
 ----
 
+The flags for `$caseSensitive` and `$diacriticSensitive` can be set via the according methods on `TextCriteria`. Please note that these two optional flags have been introduced in MongoDB 3.2 and will not be included in the query unless explicitly set.
+
 include::../{spring-data-commons-docs}/query-by-example.adoc[leveloffset=+1]
 include::query-by-example.adoc[leveloffset=+1]
 


### PR DESCRIPTION
We added methods to set values for _$caseSensitive_ and _$diacriticSensitive_ when using `TextCriteria`. Both operators are optional and will not be used until explicitly set.

```java
// { "$text" : { "$search" : "coffee" , "$caseSensitive" : true } }
TextCriteria.forDefaultLanguage().matching("coffee").caseSensitive(true);

// { "$text" : { "$search" : "coffee" , "$diacriticSensitive" : true } }
TextCriteria.forDefaultLanguage().matching("coffee").diacriticSensitive(true);
```
