### PR TITLE
DATAMONGO-1194 - Improve DBRef resolution for collections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1194-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DbRefResolver.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.core.convert;
 
 import java.util.List;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 
@@ -68,11 +69,13 @@ public interface DbRefResolver {
 	DBObject fetch(DBRef dbRef);
 
 	/**
-	 * Loads a given {@link List} of {@link DBRef}s from the datasource in one batch. <br />
+	 * Loads a given {@link List} of {@link DBRef}s from the datasource in one batch. The resulting {@link List} of
+	 * {@link DBObject} will reflect the ordering of the {@link DBRef} passed in.<br />
 	 * The {@link DBRef} elements in the list must not reference different collections.
 	 *
 	 * @param dbRefs must not be {@literal null}.
 	 * @return never {@literal null}.
+	 * @throws InvalidDataAccessApiUsageException in case not all {@link DBRef} target the same collection.
 	 * @since 1.10
 	 */
 	List<DBObject> bulkFetch(List<DBRef> dbRefs);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DbRefResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.data.mongodb.core.convert;
+
+import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -64,4 +66,14 @@ public interface DbRefResolver {
 	 * @since 1.7
 	 */
 	DBObject fetch(DBRef dbRef);
+
+	/**
+	 * Loads a given {@link List} of {@link DBRef}s from the datasource in one batch. <br />
+	 * The {@link DBRef} elements in the list must not reference different collections.
+	 *
+	 * @param dbRefs must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 1.10
+	 */
+	List<DBObject> bulkFetch(List<DBRef> dbRefs);
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -147,7 +147,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 		DB db = mongoDbFactory.getDb();
 		List<DBObject> result = db.getCollection(collection)
 				.find(new BasicDBObjectBuilder().add("_id", new BasicDBObject("$in", ids)).get()).toArray();
-		Collections.sort(result, new DbRefByReferencePositionComperator(ids));
+		Collections.sort(result, new DbRefByReferencePositionComparator(ids));
 		return result;
 	}
 
@@ -445,11 +445,11 @@ public class DefaultDbRefResolver implements DbRefResolver {
 	 * @author Christoph Strobl
 	 * @since 1.10
 	 */
-	private static class DbRefByReferencePositionComperator implements Comparator<DBObject> {
+	private static class DbRefByReferencePositionComparator implements Comparator<DBObject> {
 
 		List<Object> reference;
 
-		public DbRefByReferencePositionComperator(List<Object> referenceIds) {
+		public DbRefByReferencePositionComparator(List<Object> referenceIds) {
 			reference = new ArrayList<Object>(referenceIds);
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolverUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolverUnitTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.collection.IsIterableWithSize.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.DBObjectTestUtils;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.DBRef;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultDbRefResolverUnitTests {
+
+	@Mock MongoDbFactory factoryMock;
+	@Mock DB dbMock;
+	@Mock DBCollection collectionMock;
+	@Mock DBCursor cursorMock;
+	DefaultDbRefResolver resolver;
+
+	@Before
+	public void setUp() {
+
+		when(factoryMock.getDb()).thenReturn(dbMock);
+		when(dbMock.getCollection(anyString())).thenReturn(collectionMock);
+		when(collectionMock.find(any(DBObject.class))).thenReturn(cursorMock);
+		when(cursorMock.toArray()).thenReturn(Collections.<DBObject> emptyList());
+
+		resolver = new DefaultDbRefResolver(factoryMock);
+	}
+
+	/**
+	 * @see DATAMONGO-1194
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void bulkFetchShouldLoadDbRefsCorrectly() {
+
+		DBRef ref1 = new DBRef("collection-1", new ObjectId());
+		DBRef ref2 = new DBRef("collection-1", new ObjectId());
+
+		resolver.bulkFetch(Arrays.asList(ref1, ref2));
+
+		ArgumentCaptor<DBObject> captor = ArgumentCaptor.forClass(DBObject.class);
+
+		verify(collectionMock, times(1)).find(captor.capture());
+
+		DBObject _id = DBObjectTestUtils.getAsDBObject(captor.getValue(), "_id");
+		Iterable<Object> $in = DBObjectTestUtils.getTypedValue(_id, "$in", Iterable.class);
+
+		assertThat($in, iterableWithSize(2));
+	}
+
+	/**
+	 * @see DATAMONGO-1194
+	 */
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void bulkFetchShouldThrowExceptionWhenUsingDifferntCollectionsWithinSetOfReferences() {
+
+		DBRef ref1 = new DBRef("collection-1", new ObjectId());
+		DBRef ref2 = new DBRef("collection-2", new ObjectId());
+
+		resolver.bulkFetch(Arrays.asList(ref1, ref2));
+	}
+
+	/**
+	 * @see DATAMONGO-1194
+	 */
+	@Test
+	public void bulkFetchShouldReturnEarlyForEmptyLists() {
+
+		resolver.bulkFetch(Collections.<DBRef> emptyList());
+
+		verify(collectionMock, never()).find(any(DBObject.class));
+	}
+
+	/**
+	 * @see DATAMONGO-1194
+	 */
+	@Test
+	public void bulkFetchShouldRestoreOriginalOrder() {
+
+		DBObject o1 = new BasicDBObject("_id", new ObjectId());
+		DBObject o2 = new BasicDBObject("_id", new ObjectId());
+
+		DBRef ref1 = new DBRef("collection-1", o1.get("_id"));
+		DBRef ref2 = new DBRef("collection-1", o2.get("_id"));
+
+		when(cursorMock.toArray()).thenReturn(Arrays.asList(o2, o1));
+
+		assertThat(resolver.bulkFetch(Arrays.asList(ref1, ref2)), contains(o1, o2));
+	}
+}


### PR DESCRIPTION
We now bulk load collections of referenced objects as long as they are stored in the same collection. This reduces db roundtrips and network traffic.

---

Benchmark compare fetching list of dbrefs before and after this change:

```
        |    10    |   100   |   1000  |  // nr referenced Address objects
--------+----------+---------+---------+            
before  | 1317 /s  |  147 /s |   13 /s |  
after   | 3880 /s  |  776 /s |   38 /s |
```

```java
class Customer {
	@Id String id;
	String name;
	@DBRef List<Address> list;
}

class Address {
	@Id String id;
	String city, street;
}
```