### PR TITLE
DATAMONGO-1467 - Support partial filter expressions in indexing.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
@@ -173,7 +173,9 @@ public class DefaultIndexOperations implements IndexOperations {
 					boolean dropDuplicates = ix.containsField("dropDups") ? (Boolean) ix.get("dropDups") : false;
 					boolean sparse = ix.containsField("sparse") ? (Boolean) ix.get("sparse") : false;
 					String language = ix.containsField("default_language") ? (String) ix.get("default_language") : "";
-					indexInfoList.add(new IndexInfo(indexFields, name, unique, dropDuplicates, sparse, language));
+					String partialFilter = ix.containsField("partialFilterExpression")
+							? ix.get("partialFilterExpression").toString() : "";
+					indexInfoList.add(new IndexInfo(indexFields, name, unique, dropDuplicates, sparse, language, partialFilter));
 				}
 
 				return indexInfoList;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
+import com.mongodb.util.JSON;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.query.Order;
 import org.springframework.util.Assert;
@@ -31,6 +32,7 @@ import com.mongodb.DBObject;
 /**
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Christian Schneider
  */
 @SuppressWarnings("deprecation")
 public class Index implements IndexDefinition {
@@ -62,6 +64,8 @@ public class Index implements IndexDefinition {
 	private boolean background = false;
 
 	private long expire = -1;
+
+	private DBObject partialFilter;
 
 	public Index() {}
 
@@ -165,6 +169,19 @@ public class Index implements IndexDefinition {
 	}
 
 	/**
+	 * @see http://docs.mongodb.com/manual/core/index-partial/
+	 * @return
+	 */
+	public Index partialFilter(String partialFilter) {
+		if(StringUtils.hasText(partialFilter)) {
+			this.partialFilter = (DBObject) JSON.parse(partialFilter);
+		} else {
+			this.partialFilter = null;
+		}
+		return this;
+	}
+
+	/**
 	 * @see http://docs.mongodb.org/manual/core/index-creation/#index-creation-duplicate-dropping
 	 * @param duplicates
 	 * @return
@@ -211,6 +228,9 @@ public class Index implements IndexDefinition {
 		}
 		if (expire >= 0) {
 			dbo.put("expireAfterSeconds", expire);
+		}
+		if (partialFilter != null) {
+			dbo.put("partialFilterExpression", partialFilter);
 		}
 
 		return dbo;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -27,6 +27,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Pollack
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Christian Schneider
  */
 public class IndexInfo {
 
@@ -37,6 +38,7 @@ public class IndexInfo {
 	private final boolean dropDuplicates;
 	private final boolean sparse;
 	private final String language;
+	private final String partialFilter;
 
 	/**
 	 * @deprecated Will be removed in 1.7. Please use {@link #IndexInfo(List, String, boolean, boolean, boolean, String)}
@@ -51,8 +53,23 @@ public class IndexInfo {
 		this(indexFields, name, unique, dropDuplicates, sparse, "");
 	}
 
+	/**
+	 * @deprecated Will be removed in 1.7. Please use {@link #IndexInfo(List, String, boolean, boolean, boolean, String)}
+	 * @param indexFields
+	 * @param name
+	 * @param unique
+	 * @param dropDuplicates
+	 * @param sparse
+	 * @param language
+	 */
+	@Deprecated
 	public IndexInfo(List<IndexField> indexFields, String name, boolean unique, boolean dropDuplicates, boolean sparse,
 			String language) {
+		this(indexFields, name, unique, dropDuplicates, sparse, "", "");
+	}
+
+	public IndexInfo(List<IndexField> indexFields, String name, boolean unique, boolean dropDuplicates, boolean sparse,
+			String language, String partialFilter) {
 
 		this.indexFields = Collections.unmodifiableList(indexFields);
 		this.name = name;
@@ -60,6 +77,7 @@ public class IndexInfo {
 		this.dropDuplicates = dropDuplicates;
 		this.sparse = sparse;
 		this.language = language;
+		this.partialFilter = partialFilter;
 	}
 
 	/**
@@ -105,6 +123,10 @@ public class IndexInfo {
 		return sparse;
 	}
 
+	public String getPartialFilter() {
+		return partialFilter;
+	}
+
 	/**
 	 * @return
 	 * @since 1.6
@@ -116,7 +138,7 @@ public class IndexInfo {
 	@Override
 	public String toString() {
 		return "IndexInfo [indexFields=" + indexFields + ", name=" + name + ", unique=" + unique + ", dropDuplicates="
-				+ dropDuplicates + ", sparse=" + sparse + ", language=" + language + "]";
+				+ dropDuplicates + ", sparse=" + sparse + ", language=" + language + ", partialFilter=" + partialFilter + "]";
 	}
 
 	@Override
@@ -130,6 +152,7 @@ public class IndexInfo {
 		result = prime * result + (sparse ? 1231 : 1237);
 		result = prime * result + (unique ? 1231 : 1237);
 		result = prime * result + ObjectUtils.nullSafeHashCode(language);
+		result = prime * result + ((partialFilter == null) ? 0 : partialFilter.hashCode());
 		return result;
 	}
 
@@ -166,6 +189,13 @@ public class IndexInfo {
 			return false;
 		}
 		if (unique != other.unique) {
+			return false;
+		}
+		if(partialFilter == null) {
+			if(other.partialFilter != null) {
+				return false;
+			}
+		} else if (!partialFilter.equals(other.partialFilter)) {
 			return false;
 		}
 		if (!ObjectUtils.nullSafeEquals(language, other.language)) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Indexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Indexed.java
@@ -30,6 +30,7 @@ import java.lang.annotation.Target;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Jordi Llach
+ * @author Christian Schneider
  */
 @Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -134,4 +135,12 @@ public @interface Indexed {
 	 * @return
 	 */
 	int expireAfterSeconds() default -1;
+
+	/**
+	 * Takes a MongoDB JSON string as filter. If set the index will be applied to documents matching the filter only.
+	 * 
+	 * @see https://docs.mongodb.com/manual/core/index-partial/
+	 * @return
+	 */
+	String partialFilter() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
@@ -396,6 +396,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 			indexDefinition.expire(index.expireAfterSeconds(), TimeUnit.SECONDS);
 		}
 
+		if (index.partialFilter() != null) {
+			indexDefinition.partialFilter(index.partialFilter());
+		}
+
 		return new IndexDefinitionHolder(dotPath, indexDefinition, collection);
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/IndexUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/IndexUnitTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.index.Index.Duplicates;
  * 
  * @author Oliver Gierke
  * @author Laurent Canet
+ * @author Christian Schneider
  */
 public class IndexUnitTests {
 
@@ -67,6 +68,17 @@ public class IndexUnitTests {
 		i.sparse().unique();
 		assertEquals("{ \"name\" : 1}", i.getIndexKeys().toString());
 		assertEquals("{ \"unique\" : true , \"sparse\" : true}", i.getIndexOptions().toString());
+	}
+
+	/**
+	 * @see DATAMONGO-1467
+	 */
+	@Test
+	public void testWithPartialFilter() {
+		Index i = new Index().on("name", Direction.ASC);
+		i.partialFilter("{ \"name\" : { \"$exists\" : true } }").unique();
+		assertEquals("{ \"name\" : 1}", i.getIndexKeys().toString());
+		assertEquals("{ \"unique\" : true , \"partialFilterExpression\" : { \"name\" : { \"$exists\" : true}}}", i.getIndexOptions().toString());
 	}
 
 	@Test


### PR DESCRIPTION
Implementing the partialFilterExpression.

Please have a look to the following points in detail:
- On the @Indexed-Annotation I used the name `partialFilter` instead of mongos name `partialFilterExpression`. I thought the word "expression" may leads into wrong assumptions regarding Springs Expression language
- I'm not able to test the change in action because with the current branch I get the following Error `Error:(5, 8) java: cannot access org.springframework.data.repository.query.QueryByExampleExecutor
  class file for org.springframework.data.repository.query.QueryByExampleExecutor not found`
