### PR TITLE
DATAMONGO-1454 - Add support for exists projection in repository query methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -28,7 +28,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.13.0.DATACMNS-875-SNAPSHOT</springdata.commons>
 		<mongo>2.14.3</mongo>
 		<mongo.osgi>2.13.0</mongo.osgi>
 	</properties>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/ExistsQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/ExistsQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,60 +21,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation to declare finder queries directly on repository methods. Both attributes allow using a placeholder
+ * Annotation to declare finder exists queries directly on repository methods. Both attributes allow using a placeholder
  * notation of {@code ?0}, {@code ?1} and so on.
- * 
- * @author Oliver Gierke
- * @author Thomas Darimont
- * @author Christoph Strobl
+ *
  * @author Mark Paluch
+ * @since 1.10
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
-@QueryAnnotation
-public @interface Query {
+@Query(exists = true)
+public @interface ExistsQuery {
 
 	/**
 	 * Takes a MongoDB JSON string to define the actual query to be executed. This one will take precedence over the
-	 * method name then.
-	 * 
-	 * @return
-	 */
-	String value() default "";
-
-	/**
-	 * Defines the fields that should be returned for the given query. Note that only these fields will make it into the
-	 * domain object returned.
-	 * 
-	 * @return
-	 */
-	String fields() default "";
-
-	/**
-	 * Returns whether the query defined should be executed as count projection.
-	 * 
-	 * @since 1.3
-	 * @return
-	 */
-	boolean count() default false;
-
-	/**
-	 * Returns whether the query defined should be executed as exists projection.
+	 * method name then. Alias for {@link Query#value}.
 	 *
-	 * @since 1.10
 	 * @return
 	 */
-	boolean exists() default false;
-
-	/**
-	 * Returns whether the query should delete matching documents.
-	 * 
-	 * @since 1.5
-	 * @return
-	 */
-	boolean delete() default false;
+	@AliasFor(annotation = Query.class)
+	String value() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -20,7 +20,9 @@ import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.query.MongoQueryExecution.CollectionExecution;
+import org.springframework.data.mongodb.repository.query.MongoQueryExecution.CountExecution;
 import org.springframework.data.mongodb.repository.query.MongoQueryExecution.DeleteExecution;
+import org.springframework.data.mongodb.repository.query.MongoQueryExecution.ExistsExecution;
 import org.springframework.data.mongodb.repository.query.MongoQueryExecution.GeoNearExecution;
 import org.springframework.data.mongodb.repository.query.MongoQueryExecution.PagedExecution;
 import org.springframework.data.mongodb.repository.query.MongoQueryExecution.PagingGeoNearExecution;
@@ -40,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public abstract class AbstractMongoQuery implements RepositoryQuery {
 
@@ -123,8 +126,12 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 			return new CollectionExecution(operations, accessor.getPageable());
 		} else if (method.isPageQuery()) {
 			return new PagedExecution(operations, accessor.getPageable());
+		} else if (isCountQuery()) {
+			return new CountExecution(operations);
+		} else if (isExistsQuery()) {
+			return new ExistsExecution(operations);
 		} else {
-			return new SingleEntityExecution(operations, isCountQuery());
+			return new SingleEntityExecution(operations);
 		}
 	}
 
@@ -163,6 +170,14 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 	 * @return
 	 */
 	protected abstract boolean isCountQuery();
+
+	/**
+	 * Returns whether the query should get an exists projection applied.
+	 *
+	 * @return
+	 * @since 1.10
+	 */
+	protected abstract boolean isExistsQuery();
 
 	/**
 	 * Return weather the query should delete matching documents.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryExecution.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryExecution.java
@@ -163,7 +163,6 @@ interface MongoQueryExecution {
 	static final class SingleEntityExecution implements MongoQueryExecution {
 
 		private final MongoOperations operations;
-		private final boolean countProjection;
 
 		/*
 		 * (non-Javadoc)
@@ -171,7 +170,50 @@ interface MongoQueryExecution {
 		 */
 		@Override
 		public Object execute(Query query, Class<?> type, String collection) {
-			return countProjection ? operations.count(query, type, collection) : operations.findOne(query, type, collection);
+			return operations.findOne(query, type, collection);
+		}
+	}
+
+	/**
+	 * {@link MongoQueryExecution} to perform a count projection.
+	 *
+	 * @author Oliver Gierke
+	 * @author Mark Paluch
+	 * @since 1.10
+	 */
+	@RequiredArgsConstructor
+	static final class CountExecution implements MongoQueryExecution {
+
+		private final MongoOperations operations;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.repository.query.AbstractMongoQuery.Execution#execute(org.springframework.data.mongodb.core.query.Query, java.lang.Class, java.lang.String)
+		 */
+		@Override
+		public Object execute(Query query, Class<?> type, String collection) {
+			return operations.count(query, type, collection);
+		}
+	}
+
+	/**
+	 * {@link MongoQueryExecution} to perform an exists projection.
+	 *
+	 * @author Mark Paluch
+	 * @since 1.10
+	 */
+	@RequiredArgsConstructor
+	static final class ExistsExecution implements MongoQueryExecution {
+
+		private final MongoOperations operations;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.repository.query.AbstractMongoQuery.Execution#execute(org.springframework.data.mongodb.core.query.Query, java.lang.Class, java.lang.String)
+		 */
+		@Override
+		public Object execute(Query query, Class<?> type, String collection) {
+			return operations.exists(query, type, collection);
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQuery.java
@@ -40,6 +40,7 @@ import com.mongodb.util.JSONParseException;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class PartTreeMongoQuery extends AbstractMongoQuery {
 
@@ -139,6 +140,15 @@ public class PartTreeMongoQuery extends AbstractMongoQuery {
 	@Override
 	protected boolean isCountQuery() {
 		return tree.isCountProjection();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.AbstractMongoQuery#isExistsQuery()
+	 */
+	@Override
+	protected boolean isExistsQuery() {
+		return tree.isExistsProjection();
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -590,6 +590,23 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	}
 
 	/**
+	 * @see DATAMONGO-1454
+	 */
+	@Test
+	public void executesDerivedExistsProjectionToBoolean() {
+		assertThat(repository.existsByFirstname("Oliver August"), is(true));
+		assertThat(repository.existsByFirstname("Hans Peter"), is(false));
+	}
+
+	/**
+	 * @see DATAMONGO-1454
+	 */
+	@Test
+	public void executesAnnotatedExistProjection() {
+		assertThat(repository.someExistQuery("Matthews"), is(true));
+	}
+
+	/**
 	 * @see DATAMONGO-701
 	 */
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -43,6 +43,7 @@ import org.springframework.data.repository.query.Param;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Fırat KÜÇÜK
+ * @author Mark Paluch
  */
 public interface PersonRepository extends MongoRepository<Person, String>, QueryDslPredicateExecutor<Person> {
 
@@ -250,6 +251,17 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	 */
 	@Query(value = "{ 'lastname' : ?0 }", count = true)
 	long someCountQuery(String lastname);
+
+	/**
+	 * @see DATAMONGO-1454
+	 */
+	boolean existsByFirstname(String firstname);
+
+	/**
+	 * @see DATAMONGO-1454
+	 */
+	@ExistsQuery(value = "{ 'lastname' : ?0 }")
+	boolean someExistQuery(String lastname);
 
 	/**
 	 * @see DATAMONGO-770

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -312,6 +312,7 @@ public class AbstractMongoQueryUnitTests {
 	private static class MongoQueryFake extends AbstractMongoQuery {
 
 		private boolean isCountQuery;
+		private boolean isExistsQuery;
 		private boolean isDeleteQuery;
 
 		public MongoQueryFake(MongoQueryMethod method, MongoOperations operations) {
@@ -326,6 +327,11 @@ public class AbstractMongoQueryUnitTests {
 		@Override
 		protected boolean isCountQuery() {
 			return isCountQuery;
+		}
+
+		@Override
+		protected boolean isExistsQuery() {
+			return false;
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
@@ -61,6 +61,7 @@ import com.mongodb.DBRef;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class StringBasedMongoQueryUnitTests {
@@ -148,7 +149,7 @@ public class StringBasedMongoQueryUnitTests {
 	public void bindsDbrefCorrectly() throws Exception {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByHavingSizeFansNotZero");
-		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] {});
+		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter);
 
 		org.springframework.data.mongodb.core.query.Query query = mongoQuery.createQuery(accessor);
 		assertThat(query.getQueryObject(), is(new BasicQuery("{ fans : { $not : { $size : 0 } } }").getQueryObject()));
@@ -178,8 +179,7 @@ public class StringBasedMongoQueryUnitTests {
 	@Test
 	public void shouldSupportFindByParameterizedCriteriaAndFields() throws Exception {
 
-		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] {
-				new BasicDBObject("firstname", "first").append("lastname", "last"), Collections.singletonMap("lastname", 1) });
+		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new BasicDBObject("firstname", "first").append("lastname", "last"), Collections.singletonMap("lastname", 1));
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByParameterizedCriteriaAndFields", DBObject.class,
 				Map.class);
 
@@ -196,7 +196,7 @@ public class StringBasedMongoQueryUnitTests {
 	@Test
 	public void shouldSupportRespectExistingQuotingInFindByTitleBeginsWithExplicitQuoting() throws Exception {
 
-		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] { "fun" });
+		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "fun");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByTitleBeginsWithExplicitQuoting", String.class);
 
 		org.springframework.data.mongodb.core.query.Query query = mongoQuery.createQuery(accessor);
@@ -210,7 +210,7 @@ public class StringBasedMongoQueryUnitTests {
 	@Test
 	public void shouldParseQueryWithParametersInExpression() throws Exception {
 
-		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] { 1, 2, 3, 4 });
+		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, 1, 2, 3, 4);
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByQueryWithParametersInExpression", int.class,
 				int.class, int.class, int.class);
 
@@ -362,6 +362,17 @@ public class StringBasedMongoQueryUnitTests {
 		assertThat(query.getQueryObject(), is(reference.getQueryObject()));
 	}
 
+	/**
+	 * @see DATAMONGO-1454
+	 */
+	@Test
+	public void shouldSupportExistsProjection() throws Exception {
+
+		StringBasedMongoQuery mongoQuery = createQueryForMethod("existsByLastname", String.class);
+
+		assertThat(mongoQuery.isExistsQuery(), is(true));
+	}
+
 	private StringBasedMongoQuery createQueryForMethod(String name, Class<?>... parameters) throws Exception {
 
 		Method method = SampleRepository.class.getMethod(name, parameters);
@@ -420,5 +431,8 @@ public class StringBasedMongoQueryUnitTests {
 
 		@Query("{'id':?#{ [0] ? { $exists :true} : [1] }, 'foo':42, 'bar': ?#{ [0] ? { $exists :false} : [1] }}")
 		List<Person> findByQueryWithExpressionAndMultipleNestedObjects(boolean param0, String param1, String param2);
+
+		@Query(value = "{ 'lastname' : ?0 }", exists = true)
+		boolean existsByLastname(String lastname);
 	}
 }


### PR DESCRIPTION
We now support exists projections for query methods in query methods for derived and string queries.

``` java
public PersonReposotiry extends Repository<Person, String> {

  boolean existsByFirstname(String firstname);

  @Query(value = "{ 'lastname' : ?0 }", exists = true)
  boolean someExistQuery(String lastname);
}
```

---

Related ticket: [DATAMONGO-1454](https://jira.spring.io/browse/DATAMONGO-1454)
Depends on: https://github.com/spring-projects/spring-data-commons/pull/171
