### PR TITLE
DATAMONGO-1406 - Propagate PersistentEntity when mapping query criteria for nested keywords.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -58,6 +58,7 @@ import com.mongodb.DBRef;
  * @author Patryk Wasik
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class QueryMapper {
 
@@ -66,7 +67,7 @@ public class QueryMapper {
 	static final ClassTypeInformation<?> NESTED_DOCUMENT = ClassTypeInformation.from(NestedDocument.class);
 
 	private enum MetaMapping {
-		FORCE, WHEN_PRESENT, IGNORE;
+		FORCE, WHEN_PRESENT, IGNORE
 	}
 
 	private final ConversionService conversionService;
@@ -316,7 +317,7 @@ public class QueryMapper {
 		}
 
 		if (isNestedKeyword(value)) {
-			return getMappedKeyword(new Keyword((DBObject) value), null);
+			return getMappedKeyword(new Keyword((DBObject) value), documentField.getPropertyEntity());
 		}
 
 		if (isAssociationConversionNecessary(documentField, value)) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -54,6 +55,7 @@ import org.springframework.data.mongodb.core.mapping.TextScore;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.test.util.BasicDbListBuilder;
 
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -68,6 +70,7 @@ import com.mongodb.QueryBuilder;
  * @author Patryk Wasik
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class QueryMapperUnitTests {
@@ -596,6 +599,28 @@ public class QueryMapperUnitTests {
 	}
 
 	/**
+	 * @see DATAMONGO-1406
+	 */
+	@Test
+	public void shouldMapQueryForNestedCustomizedPropertiesUsingConfiguredFieldNames() {
+
+		EmbeddedClass embeddedClass = new EmbeddedClass();
+		embeddedClass.customizedField = "hello";
+
+		Foo foo = new Foo();
+		foo.listOfItems = Arrays.asList(embeddedClass);
+
+		Query query = new Query(Criteria.where("listOfItems") //
+				.elemMatch(new Criteria(). //
+						andOperator(Criteria.where("customizedField").is(embeddedClass.customizedField))));
+
+		DBObject dbo = mapper.getMappedObject(query.getQueryObject(), context.getPersistentEntity(Foo.class));
+
+		assertThat(dbo, isBsonObject().containing("my_items.$elemMatch.$and",
+				new BasicDbListBuilder().add(new BasicDBObject("fancy_custom_name", embeddedClass.customizedField)).get()));
+	}
+
+	/**
 	 * @see DATAMONGO-647
 	 */
 	@Test
@@ -792,8 +817,7 @@ public class QueryMapperUnitTests {
 	}
 
 	/**
-	 * <<<<<<< HEAD
-	 * 
+	 *
 	 * @see DATAMONGO-1269
 	 */
 	@Test
@@ -859,10 +883,15 @@ public class QueryMapperUnitTests {
 	public class Foo {
 		@Id private ObjectId id;
 		EmbeddedClass embedded;
+
+		@Field("my_items")
+		List<EmbeddedClass> listOfItems;
 	}
 
 	public class EmbeddedClass {
 		public String id;
+
+		@Field("fancy_custom_name") public String customizedField;
 	}
 
 	class IdWrapper {


### PR DESCRIPTION
Previously, query mapping of nested keywords combined with nested properties did not pass the PersistentEntity. That resulted in the usage of property names as field names instead of using configuration details of `@Field`.

The QueryMapper now propagates the PersistentEntity when mapping nested keywords. The criteria mapping chain for nested keywords and properties has now access to the PersistentEntity and can use configured field names.

----

Related ticket: [DATAMONGO-1406](https://jira.spring.io/browse/DATAMONGO-1406)