### PR TITLE
DATAMONGO-1490 - Change the XML data type of boolean flags to String.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1490-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
@@ -6,4 +6,5 @@ http\://www.springframework.org/schema/data/mongo/spring-mongo-1.4.xsd=org/sprin
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.5.xsd=org/springframework/data/mongodb/config/spring-mongo-1.5.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.7.xsd=org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.8.xsd=org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
-http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo-1.10.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.xsd

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
@@ -27,7 +27,7 @@ Deprecated since 1.7 - use mongo-client instead. Defines a Mongo instance used f
 			</xsd:appinfo>
 		</xsd:annotation>
 	</xsd:element>
-	
+
 	<xsd:element name="mongo-client" type="mongoClientType">
 	  <xsd:annotation>
 		<xsd:documentation source="org.springframework.data.mongodb.core.MongoClientFactoryBean"><![CDATA[
@@ -137,13 +137,16 @@ The MongoClientURI string.]]></xsd:documentation>
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="create-query-indexes" type="xsd:boolean" default="false">
+		<xsd:attribute name="create-query-indexes" default="false">
 			<xsd:annotation>
 				<xsd:documentation>
 					Enables creation of indexes for queries that get derived from the method name
 					and thus reference domain class properties. Defaults to false.
 				</xsd:documentation>
 			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
 		</xsd:attribute>
 	</xsd:attributeGroup>
 
@@ -267,7 +270,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -337,7 +340,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 		</xsd:annotation>
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="sslSocketFactoryRef">
 	<xsd:annotation>
 			<xsd:appinfo>
@@ -360,7 +363,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			<xsd:enumeration value="MAJORITY" />
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="readPreferenceEnumeration">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="PRIMARY" />
@@ -370,23 +373,14 @@ The name of the Mongo object that determines what server to monitor. (by default
 			<xsd:enumeration value="NEAREST" />
 		</xsd:restriction>
 	</xsd:simpleType>
-	<!--  MLP
-	<xsd:attributeGroup name="writeConcern">
-		<xsd:attribute name="write-concern">
-			<xsd:simpleType>
-				<xsd:restriction base="xsd:string">
-					<xsd:enumeration value="NONE" />
-					<xsd:enumeration value="NORMAL" />
-					<xsd:enumeration value="SAFE" />
-					<xsd:enumeration value="FSYNC_SAFE" />
-					<xsd:enumeration value="REPLICA_SAFE" />
-					<xsd:enumeration value="JOURNAL_SAFE" />
-					<xsd:enumeration value="MAJORITY" />
-				</xsd:restriction>
-			</xsd:simpleType>
-		</xsd:attribute>
-	</xsd:attributeGroup>
-	-->
+
+	<xsd:simpleType name="booleanType">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="true" />
+			<xsd:enumeration value="false" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
 	<xsd:complexType name="mongoType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -416,8 +410,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -446,7 +440,7 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
@@ -466,22 +460,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -498,18 +492,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -533,20 +527,23 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
-		<xsd:attribute name="ssl" type="xsd:boolean">
+		</xsd:attribute>
+		<xsd:attribute name="ssl" default="false">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 This controls if the driver should us an SSL connection.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
 		</xsd:attribute>
 		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
 			<xsd:annotation>
@@ -556,7 +553,7 @@ The SSLSocketFactory to use for the SSL connection. If none is configured here, 
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="mongoClientType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -612,7 +609,7 @@ The comma delimited list of username:password@database entries to use for authen
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="clientOptionsType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -632,11 +629,11 @@ The MongoClient description.
 The minimum number of connections per host.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -644,36 +641,36 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes).
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-idle-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum idle time for a pooled connection.	
+The maximum idle time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-life-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum life time for a pooled connection.	
+The maximum life time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -690,7 +687,7 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="read-preference">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -700,7 +697,7 @@ The read preference.
 			<xsd:simpleType>
 				<xsd:union memberTypes="readPreferenceEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="write-concern">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -710,25 +707,25 @@ The WriteConcern that will be the default value used when asking the MongoDbFact
 			<xsd:simpleType>
 				<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This is the frequency that the driver will attempt to determine the current state of each server in the cluster. 
+This is the frequency that the driver will attempt to determine the current state of each server in the cluster.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="min-heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort. 
+In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout for connections used for the cluster heartbeat. 
+The connect timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -738,13 +735,16 @@ The connect timeout for connections used for the cluster heartbeat.
 The socket timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
-		<xsd:attribute name="ssl" type="xsd:boolean">
+		</xsd:attribute>
+		<xsd:attribute name="ssl" default="false">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 This controls if the driver should us an SSL connection.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
 		</xsd:attribute>
 		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
 			<xsd:annotation>
@@ -844,7 +844,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
@@ -137,7 +137,7 @@ The MongoClientURI string.]]></xsd:documentation>
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="create-query-indexes" type="xsd:boolean" default="false">
+		<xsd:attribute name="create-query-indexes" type="xsd:string" default="false">
 			<xsd:annotation>
 				<xsd:documentation>
 					Enables creation of indexes for queries that get derived from the method name
@@ -541,7 +541,7 @@ This controls if the driver is allowed to read from secondaries or slaves.  Defa
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>				
-		<xsd:attribute name="ssl" type="xsd:boolean">
+		<xsd:attribute name="ssl" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 This controls if the driver should us an SSL connection.  Defaults to false.
@@ -739,7 +739,7 @@ The socket timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>	
-		<xsd:attribute name="ssl" type="xsd:boolean">
+		<xsd:attribute name="ssl" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 This controls if the driver should us an SSL connection.  Defaults to false.

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
@@ -37,8 +37,8 @@ Defines a MongoClient instance used for accessing MongoDB.
 				<tool:annotation>
 					<tool:exports type="com.mongodb.MongoClient"/>
 				</tool:annotation>
-			</xsd:appinfo>	  
-	  </xsd:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
 	</xsd:element>
 
 	<xsd:element name="db-factory">
@@ -170,8 +170,8 @@ The MongoClientURI string.]]></xsd:documentation>
 				<xsd:element name="custom-converters" minOccurs="0">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
-        Top-level element that contains one or more custom converters to be used for mapping
-        domain objects to and from Mongo's DBObject]]>
+		Top-level element that contains one or more custom converters to be used for mapping
+		domain objects to and from Mongo's DBObject]]>
 						</xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
@@ -389,10 +389,10 @@ The name of the Mongo object that determines what server to monitor. (by default
 	-->
 	<xsd:complexType name="mongoType">
 		<xsd:annotation>
-	    	<xsd:documentation><![CDATA[
-Deprecated since 1.7.    	
-	    	]]></xsd:documentation>
-	    </xsd:annotation>
+			<xsd:documentation><![CDATA[
+Deprecated since 1.7.
+			]]></xsd:documentation>
+		</xsd:annotation>
 		<xsd:sequence minOccurs="0" maxOccurs="1">
 			<xsd:element name="options" type="optionsType">
 				<xsd:annotation>
@@ -451,14 +451,14 @@ The comma delimited list of host:port entries to use for replica set/pairs.
 
 	<xsd:complexType name="optionsType">
 		<xsd:annotation>
-	    	<xsd:documentation><![CDATA[
-Deprecated since 1.7.    	
-	    	]]></xsd:documentation>
-	    </xsd:annotation>
+			<xsd:documentation><![CDATA[
+Deprecated since 1.7.
+			]]></xsd:documentation>
+		</xsd:annotation>
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -559,10 +559,10 @@ The SSLSocketFactory to use for the SSL connection. If none is configured here, 
 	
 	<xsd:complexType name="mongoClientType">
 		<xsd:annotation>
-	    	<xsd:documentation><![CDATA[
-Configuration options for 'MongoClient' - @since 1.7	    	
-	    	]]></xsd:documentation>
-	    </xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClient' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
 		<xsd:sequence minOccurs="0" maxOccurs="1">
 			<xsd:element name="client-options" type="clientOptionsType">
 				<xsd:annotation>
@@ -614,11 +614,11 @@ The comma delimited list of username:password@database entries to use for authen
 	</xsd:complexType>
 	
 	<xsd:complexType name="clientOptionsType">
-	    <xsd:annotation>
-	    	<xsd:documentation><![CDATA[
-Configuration options for 'MongoClientOptions' - @since 1.7	    	
-	    	]]></xsd:documentation>
-	    </xsd:annotation>
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClientOptions' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
 		<xsd:attribute name="description" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -752,7 +752,7 @@ This controls if the driver should us an SSL connection.  Defaults to false.
 The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>									
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">
@@ -765,8 +765,8 @@ The SSLSocketFactory to use for the SSL connection. If none is configured here, 
 	<xsd:complexType name="customConverterType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
-  Element defining a custom converterr.
-      ]]></xsd:documentation>
+	Element defining a custom converter.
+	]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:group ref="beanElementGroup" minOccurs="0" maxOccurs="1"/>
 		<xsd:attribute name="ref" type="xsd:string">

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoNamespaceTests.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.authentication.UserCredentials;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.MongoClientFactoryBean;
 import org.springframework.data.mongodb.core.MongoFactoryBean;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReflectiveMongoOptionsInvokerTestUtil;
@@ -38,6 +39,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.mongodb.Mongo;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoOptions;
 import com.mongodb.WriteConcern;
 
@@ -98,6 +100,19 @@ public class MongoNamespaceTests {
 		MongoFactoryBean mfb = (MongoFactoryBean) ctx.getBean("&mongoSsl");
 
 		MongoOptions options = (MongoOptions) getField(mfb, "mongoOptions");
+		assertTrue("socketFactory should be a SSLSocketFactory", options.getSocketFactory() instanceof SSLSocketFactory);
+	}
+
+	/**
+	 * @see DATAMONGO-1490
+	 */
+	@Test
+	public void testMongoClientSingletonWithSslEnabled() {
+
+		assertTrue(ctx.containsBean("mongoClientSsl"));
+		MongoClientFactoryBean mfb = (MongoClientFactoryBean) ctx.getBean("&mongoClientSsl");
+
+		MongoClientOptions options = (MongoClientOptions) getField(mfb, "mongoClientOptions");
 		assertTrue("socketFactory should be a SSLSocketFactory", options.getSocketFactory() instanceof SSLSocketFactory);
 	}
 

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/MongoNamespaceTests-context.xml
@@ -29,8 +29,10 @@
 	
 	<mongo:db-factory dbname="database" mongo-ref="mongo"/>
 
+	<mongo:mongo-client id="mongoClientSsl">
+		<mongo:client-options ssl="${mongoSsl.ssl}" />
+	</mongo:mongo-client>
 
-	
 	<mongo:db-factory id="secondMongoDbFactory"
 					  host="localhost"
 					  port="27017"
@@ -49,7 +51,7 @@
 	<mongo:mongo id="defaultMongo" host="localhost" port="27017"/>
 
 	<mongo:mongo id="mongoSsl" host="localhost" port="27017">
-		<mongo:options ssl="true"/>
+		<mongo:options ssl="${mongoSsl.ssl}"/>
 	</mongo:mongo>
 
 	<mongo:mongo id="mongoSslWithCustomSslFactory" host="localhost" port="27017">

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/mongo.properties
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/config/mongo.properties
@@ -10,3 +10,5 @@ mongo.socketKeepAlive=true
 mongo.fsync=true
 mongo.slaveOk=true
 
+mongoSsl.ssl=true
+

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests-context.xml
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests-context.xml
@@ -2,12 +2,15 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-	<mongo:db-factory dbname="repositories"/>	
+	<context:property-placeholder
+			location="classpath:/org/springframework/data/mongodb/repository/mongo.properties"/>
+
+	<mongo:db-factory dbname="repositories"/>
 	<mongo:mapping-converter base-package="org.springframework.data.mongodb.repository"/>
 
 	<bean id="mongoTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">
@@ -15,6 +18,6 @@
 		<constructor-arg ref="mappingConverter"/>
 	</bean>
 
-	<mongo:repositories base-package="org.springframework.data.mongodb.repository" create-query-indexes="true" />
+	<mongo:repositories base-package="org.springframework.data.mongodb.repository" create-query-indexes="${mongo.create-query-indexes}" />
 
 </beans>

--- a/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/mongo.properties
+++ b/spring-data-mongodb/src/test/resources/org/springframework/data/mongodb/repository/mongo.properties
@@ -1,0 +1,1 @@
+mongo.create-query-indexes=true


### PR DESCRIPTION
We now accept String data types for boolean flags in XML configurations. Boolean data types in the XSD don't allows use of property placeholders even if the resolved value could be converted to boolean. Affected fields by this change are:

* `<mongo:repositories create-query-indexes=… />`
* `<mongo:options ssl=…/>`
* `<mongo:client-options ssl=… />`

----

Related ticket: [DATAMONGO-1490](https://jira.spring.io/browse/DATAMONGO-1490)