### PR TITLE
DATAMONGO-1480 - Add support for noCursorTimeout in Query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1480-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -93,6 +93,7 @@ import org.springframework.data.mongodb.core.mapreduce.GroupByResults;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceResults;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
@@ -2372,8 +2373,24 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 						cursorToUse = cursorToUse.addSpecial(entry.getKey(), entry.getValue());
 					}
 
-					if (query.getMeta().isNoCursorTimeout() != null && query.getMeta().isNoCursorTimeout().booleanValue()) {
-						cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_NOTIMEOUT);
+					for (Meta.CursorOption option : query.getMeta().getFlags()) {
+
+						switch (option) {
+							case EXHAUST:
+								cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_EXHAUST);
+								break;
+							case NO_TIMEOUT:
+								cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_NOTIMEOUT);
+								break;
+							case PARTIAL:
+								cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_PARTIAL);
+								break;
+							case SLAVE_OK:
+								cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_SLAVEOK);
+								break;
+							default:
+								throw new IllegalArgumentException(String.format("%s is no supported flag.", option));
+						}
 					}
 				}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -139,6 +139,7 @@ import com.mongodb.util.JSONParseException;
  * @author Christoph Strobl
  * @author Doménique Tilleuil
  * @author Niko Schmuck
+ * @author Mark Paluch
  */
 @SuppressWarnings("deprecation")
 public class MongoTemplate implements MongoOperations, ApplicationContextAware {
@@ -2249,7 +2250,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	 * @author Thomas Darimont
 	 */
 
-	static interface DbObjectCallback<T> {
+	interface DbObjectCallback<T> {
 
 		T doWith(DBObject object);
 	}
@@ -2347,22 +2348,32 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 			DBCursor cursorToUse = cursor.copy();
 
 			try {
+
 				if (query.getSkip() > 0) {
 					cursorToUse = cursorToUse.skip(query.getSkip());
 				}
+
 				if (query.getLimit() > 0) {
 					cursorToUse = cursorToUse.limit(query.getLimit());
 				}
+
 				if (query.getSortObject() != null) {
 					DBObject sortDbo = type != null ? getMappedSortObject(query, type) : query.getSortObject();
 					cursorToUse = cursorToUse.sort(sortDbo);
 				}
+
 				if (StringUtils.hasText(query.getHint())) {
 					cursorToUse = cursorToUse.hint(query.getHint());
 				}
+
 				if (query.getMeta().hasValues()) {
+
 					for (Entry<String, Object> entry : query.getMeta().values()) {
 						cursorToUse = cursorToUse.addSpecial(entry.getKey(), entry.getValue());
+					}
+
+					if (query.getMeta().isNoCursorTimeout() != null && query.getMeta().isNoCursorTimeout().booleanValue()) {
+						cursorToUse = cursorToUse.addOption(Bytes.QUERYOPTION_NOTIMEOUT);
 					}
 				}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 1.6
  */
 public class Meta {
@@ -39,12 +40,13 @@ public class Meta {
 
 		private String key;
 
-		private MetaKey(String key) {
+		MetaKey(String key) {
 			this.key = key;
 		}
 	}
 
 	private final Map<String, Object> values = new LinkedHashMap<String, Object>(2);
+	private Boolean noCursorTimeout;
 
 	/**
 	 * @return {@literal null} if not set.
@@ -121,10 +123,28 @@ public class Meta {
 	}
 
 	/**
+	 * @return {@literal null} if not set.
+	 * @since 1.10
+	 */
+	public Boolean isNoCursorTimeout() {
+		return this.noCursorTimeout;
+	}
+
+	/**
+	 * Instructs the server to avoid closing a cursor automatically after a period of inactivity.
+	 *
+	 * @param noCursorTimeout
+	 * @since 1.10
+	 */
+	public void setNoCursorTimeout(boolean noCursorTimeout) {
+		this.noCursorTimeout = noCursorTimeout;
+	}
+
+	/**
 	 * @return
 	 */
 	public boolean hasValues() {
-		return !this.values.isEmpty();
+		return !this.values.isEmpty() || this.noCursorTimeout != null;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 the original author or authors.
+ * Copyright 2010-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import com.mongodb.DBObject;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class Query {
 
@@ -333,6 +334,17 @@ public class Query {
 	public Query useSnapshot() {
 
 		meta.setSnapshot(true);
+		return this;
+	}
+
+	/**
+	 * @return
+	 * @see Meta#setNoCursorTimeout(boolean)
+	 * @since 1.10
+	 */
+	public Query noCursorTimeout() {
+
+		meta.setNoCursorTimeout(true);
 		return this;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -339,12 +339,45 @@ public class Query {
 
 	/**
 	 * @return
-	 * @see Meta#setNoCursorTimeout(boolean)
+	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#NO_TIMEOUT
 	 * @since 1.10
 	 */
 	public Query noCursorTimeout() {
 
-		meta.setNoCursorTimeout(true);
+		meta.addFlag(Meta.CursorOption.NO_TIMEOUT);
+		return this;
+	}
+
+	/**
+	 * @return
+	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#EXHAUST
+	 * @since 1.10
+	 */
+	public Query exhaust() {
+
+		meta.addFlag(Meta.CursorOption.EXHAUST);
+		return this;
+	}
+
+	/**
+	 * @return
+	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#SLAVE_OK
+	 * @since 1.10
+	 */
+	public Query slaveOk() {
+
+		meta.addFlag(Meta.CursorOption.SLAVE_OK);
+		return this;
+	}
+
+	/**
+	 * @return
+	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#PARTIAL
+	 * @since 1.10
+	 */
+	public Query partialResults() {
+
+		meta.addFlag(Meta.CursorOption.PARTIAL);
 		return this;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
@@ -76,11 +76,11 @@ public @interface Meta {
 	boolean snapshot() default false;
 
 	/**
-	 * Instructs the server to avoid closing a cursor automatically after a period of inactivity.
+	 * Set {@link org.springframework.data.mongodb.core.query.Meta.CursorOption} to be used when executing query.
 	 *
-	 * @return
+	 * @return never {@literal null}.
 	 * @since 1.10
 	 */
-	boolean noCursorTimeout() default false;
+	org.springframework.data.mongodb.core.query.Meta.CursorOption[] flags() default {};
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
@@ -75,4 +75,12 @@ public @interface Meta {
 	 */
 	boolean snapshot() default false;
 
+	/**
+	 * Instructs the server to avoid closing a cursor automatically after a period of inactivity.
+	 *
+	 * @return
+	 * @since 1.10
+	 */
+	boolean noCursorTimeout() default false;
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -248,6 +248,10 @@ public class MongoQueryMethod extends QueryMethod {
 			metaAttributes.setSnapshot(meta.snapshot());
 		}
 
+		if (meta.noCursorTimeout()) {
+			metaAttributes.setNoCursorTimeout(meta.noCursorTimeout());
+		}
+
 		return metaAttributes;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -37,6 +37,7 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -248,8 +249,11 @@ public class MongoQueryMethod extends QueryMethod {
 			metaAttributes.setSnapshot(meta.snapshot());
 		}
 
-		if (meta.noCursorTimeout()) {
-			metaAttributes.setNoCursorTimeout(meta.noCursorTimeout());
+		if (!ObjectUtils.isEmpty(meta.flags())) {
+
+			for (org.springframework.data.mongodb.core.query.Meta.CursorOption option : meta.flags()) {
+				metaAttributes.addFlag(option);
+			}
 		}
 
 		return metaAttributes;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -347,7 +347,7 @@ public class AbstractMongoQueryUnitTests {
 
 		List<Person> findByFirstname(String firstname);
 
-		@Meta(comment = "comment")
+		@Meta(comment = "comment", noCursorTimeout = true)
 		Page<Person> findByFirstname(String firstnanme, Pageable pageable);
 
 		@Meta(comment = "comment")

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -347,7 +347,7 @@ public class AbstractMongoQueryUnitTests {
 
 		List<Person> findByFirstname(String firstname);
 
-		@Meta(comment = "comment", noCursorTimeout = true)
+		@Meta(comment = "comment", flags = {org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT})
 		Page<Person> findByFirstname(String firstnanme, Pageable pageable);
 
 		@Meta(comment = "comment")

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
@@ -152,7 +152,6 @@ public class MongoQueryMethodUnitTests {
 		assertThat(method.getQueryMetaAttributes().getMaxTimeMsec(), is(100L));
 	}
 
-
 	/**
 	 * @see DATAMONGO-1403
 	 */
@@ -210,7 +209,8 @@ public class MongoQueryMethodUnitTests {
 		MongoQueryMethod method = queryMethod(PersonRepository.class, "metaWithNoCursorTimeout");
 
 		assertThat(method.hasQueryMetaAttributes(), is(true));
-		assertThat(method.getQueryMetaAttributes().isNoCursorTimeout(), is(true));
+		assertThat(method.getQueryMetaAttributes().getFlags(),
+				containsInAnyOrder(org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT));
 	}
 
 	/**
@@ -262,7 +262,7 @@ public class MongoQueryMethodUnitTests {
 		@Meta(snapshot = true)
 		List<User> metaWithSnapshotUsage();
 
-		@Meta(noCursorTimeout = true)
+		@Meta(flags = { org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT })
 		List<User> metaWithNoCursorTimeout();
 
 		/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
@@ -202,6 +202,18 @@ public class MongoQueryMethodUnitTests {
 	}
 
 	/**
+	 * @see DATAMONGO-1480
+	 */
+	@Test
+	public void createsMongoQueryMethodWithNoCursorTimeoutCorrectly() throws Exception {
+
+		MongoQueryMethod method = queryMethod(PersonRepository.class, "metaWithNoCursorTimeout");
+
+		assertThat(method.hasQueryMetaAttributes(), is(true));
+		assertThat(method.getQueryMetaAttributes().isNoCursorTimeout(), is(true));
+	}
+
+	/**
 	 * @see DATAMONGO-1266
 	 */
 	@Test
@@ -249,6 +261,9 @@ public class MongoQueryMethodUnitTests {
 
 		@Meta(snapshot = true)
 		List<User> metaWithSnapshotUsage();
+
+		@Meta(noCursorTimeout = true)
+		List<User> metaWithNoCursorTimeout();
 
 		/**
 		 * @see DATAMONGO-1266


### PR DESCRIPTION
We now allow setting noCursorTimeout for queries using `Query` and `@Meta`.

```
Query query = new Query().noCursorTimeout();
```

and

```
interface PersonRepository extends CrudRepository<Person, String> {

    @Meta(noCursorTimeout = true)
    Iterable<Person> findBy();

    @Meta(noCursorTimeout = true)
    Stream<Person> streamBy();
}
```

----

Related ticket: [DATAMONGO-1480](https://jira.spring.io/browse/DATAMONGO-1480)