### PR TITLE
DATAMONGO-1504 - Assert compatibility with MongoDB 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - PROFILE=mongo31
     - PROFILE=mongo32
     - PROFILE=mongo33
+    - PROFILE=mongo34-next
 
 # Current MongoDB version is 2.4.2 as of 2016-04, see https://github.com/travis-ci/travis-ci/issues/3694
 # apt-get starts a MongoDB instance so it's not started using before_script

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,22 @@
 		</profile>
 
 		<profile>
+
+			<id>mongo34-next</id>
+			<properties>
+				<mongo>3.4.0-SNAPSHOT</mongo>
+			</properties>
+
+			<repositories>
+				<repository>
+					<id>mongo-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</repository>
+			</repositories>
+
+		</profile>
+
+		<profile>
 			<id>release</id>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/src/main/java/org/springframework/data/mongodb/log4j/MongoLog4jAppender.java
+++ b/spring-data-mongodb-log4j/src/main/java/org/springframework/data/mongodb/log4j/MongoLog4jAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.WriteConcern;
 
 /**
@@ -37,6 +38,7 @@ import com.mongodb.WriteConcern;
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @auhtor Christoph Strobl
  */
 public class MongoLog4jAppender extends AppenderSkeleton {
 
@@ -58,8 +60,8 @@ public class MongoLog4jAppender extends AppenderSkeleton {
 	protected String collectionPattern = "%c";
 	protected PatternLayout collectionLayout = new PatternLayout(collectionPattern);
 	protected String applicationId = System.getProperty("APPLICATION_ID", null);
-	protected WriteConcern warnOrHigherWriteConcern = WriteConcern.SAFE;
-	protected WriteConcern infoOrLowerWriteConcern = WriteConcern.NORMAL;
+	protected WriteConcern warnOrHigherWriteConcern = WriteConcern.ACKNOWLEDGED;
+	protected WriteConcern infoOrLowerWriteConcern = WriteConcern.UNACKNOWLEDGED;
 	protected Mongo mongo;
 	protected DB db;
 
@@ -128,7 +130,7 @@ public class MongoLog4jAppender extends AppenderSkeleton {
 	}
 
 	protected void connectToMongo() throws UnknownHostException {
-		this.mongo = new Mongo(host, port);
+		this.mongo = new MongoClient(host, port);
 		this.db = mongo.getDB(database);
 	}
 

--- a/spring-data-mongodb-log4j/src/test/java/org/springframework/data/mongodb/log4j/MongoLog4jAppenderIntegrationTests.java
+++ b/spring-data-mongodb-log4j/src/test/java/org/springframework/data/mongodb/log4j/MongoLog4jAppenderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,37 +22,44 @@ import java.util.Calendar;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 
 /**
  * Integration tests for {@link MongoLog4jAppender}.
  * 
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class MongoLog4jAppenderIntegrationTests {
 
 	static final String NAME = MongoLog4jAppenderIntegrationTests.class.getName();
 
 	private static final Logger log = Logger.getLogger(NAME);
-	Mongo mongo;
+	MongoClient mongo;
 	DB db;
 	String collection;
 
 	@Before
 	public void setUp() throws Exception {
 
-		mongo = new Mongo("localhost", 27017);
+		mongo = new MongoClient("localhost", 27017);
 		db = mongo.getDB("logs");
 
 		Calendar now = Calendar.getInstance();
 		collection = String.valueOf(now.get(Calendar.YEAR)) + String.format("%1$02d", now.get(Calendar.MONTH) + 1);
-		db.getCollection(collection).drop();
+	}
+
+	@After
+	public void tearDown() {
+		db.getCollection(collection).remove(new BasicDBObject());
 	}
 
 	@Test
@@ -64,7 +71,6 @@ public class MongoLog4jAppenderIntegrationTests {
 		log.error("ERROR message");
 
 		DBCursor msgs = db.getCollection(collection).find();
-
 		assertThat(msgs.count(), is(4));
 	}
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1504-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2182,7 +2182,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		}
 
 		public FindCallback(DBObject query, DBObject fields) {
-			this.query = query;
+			this.query = query == null ? new BasicDBObject() : query;
 			this.fields = fields;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import com.mongodb.gridfs.GridFSInputFile;
  * @author Philipp Schneider
  * @author Thomas Darimont
  * @author Martin Baumgartner
+ * @author Christoph Strobl
  */
 public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver {
 
@@ -182,7 +183,7 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 	public List<GridFSDBFile> find(Query query) {
 
 		if (query == null) {
-			return getGridFs().find((DBObject) null);
+			return getGridFs().find(new BasicDBObject());
 		}
 
 		DBObject queryObject = getMappedQuery(query.getQueryObject());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/performance/PerformanceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/performance/PerformanceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class PerformanceTests {
 	private static final int ITERATIONS = 50;
 	private static final StopWatch watch = new StopWatch();
 	private static final Collection<String> IGNORED_WRITE_CONCERNS = Arrays.asList("MAJORITY", "REPLICAS_SAFE",
-			"FSYNC_SAFE", "FSYNCED", "JOURNAL_SAFE", "JOURNALED", "REPLICA_ACKNOWLEDGED");
+			"FSYNC_SAFE", "FSYNCED", "JOURNAL_SAFE", "JOURNALED", "REPLICA_ACKNOWLEDGED", "W2", "W3");
 	private static final int COLLECTION_SIZE = 1024 * 1024 * 256; // 256 MB
 	private static final Collection<String> COLLECTION_NAMES = Arrays.asList("template", "driver", "person");
 


### PR DESCRIPTION
We now make sure to comply to the API requirements of _mongo-java-driver 3.4_ (in current beta1) by using empty `DBObject` instead of `null`, ignoring non appropriate replication settings and cleaning up tests after execution.
