### PR TITLE
Correct query keyword 'Between', now also contains the range values.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -185,7 +185,7 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 			case LESS_THAN_EQUAL:
 				return criteria.lte(parameters.next());
 			case BETWEEN:
-				return criteria.gt(parameters.next()).lt(parameters.next());
+				return criteria.gte(parameters.next()).lte(parameters.next());
 			case IS_NOT_NULL:
 				return criteria.ne(null);
 			case IS_NULL:

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -203,8 +203,8 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	public void findsPersonInAgeRangeCorrectly() throws Exception {
 
 		List<Person> result = repository.findByAgeBetween(40, 45);
-		assertThat(result.size(), is(2));
-		assertThat(result, hasItems(dave, leroi));
+		assertThat(result.size(), is(3));
+		assertThat(result, hasItems(dave, leroi, boyd));
 	}
 
 	@Test


### PR DESCRIPTION
DATAMONGO-1506 - Different behavior in the query keyword 'Between' between the MongoDB and the JPA implementation

Fix for [DATAMONGO-1506](https://jira.spring.io/browse/DATAMONGO-1506)
