### PR TITLE
DATAMONGO-1508 - documentation for db-factory authentication-dbname a…

### DIFF
--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -387,6 +387,20 @@ You can also provide the host and port for the underlying `com.mongodb.Mongo` in
                   password="secret"/>
 ----
 
+If your mongodb authentication database differs from the target database, use the authentication-dbname attribute, as shown below.
+
+[source,xml]
+----
+<mongo:db-factory id="anotherMongoDbFactory"
+                  host="localhost"
+                  port="27017"
+                  dbname="database"
+                  username="joe"
+                  password="secret"
+				  authentication-dbname="admin"
+				  />
+----
+
 If you need to configure additional options on the `com.mongodb.Mongo` instance that is used to create a `SimpleMongoDbFactory` you can refer to an existing bean using the `mongo-ref` attribute as shown below. To show another common usage pattern, this listing shows the use of a property placeholder to parametrise the configuration and creating `MongoTemplate`.
 
 [source,xml]


### PR DESCRIPTION
It was difficult to figure out how to use a separate authentication db from the target db.  So I added an example of that to the documentation.  Please be gentle, it is my first pull request ever ;-)
John Lilley
