### PR TITLE
DATAMONGO-1509 - Write type hint as last element of an Document

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DocumentTestUtils.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DocumentTestUtils.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.bson.Document;
@@ -79,5 +80,24 @@ public abstract class DocumentTestUtils {
 		assertThat(value, is(instanceOf(type)));
 
 		return (T) value;
+	}
+
+	public static void assertTypeHint(Document document, Class<?> type) {
+		assertTypeHint(document, type.getName());
+	}
+
+	public static void assertTypeHint(Document document, String expectedTypeString) {
+
+		Iterator<String> keyIterator = document.keySet().iterator();
+		while (keyIterator.hasNext()) {
+			String key = keyIterator.next();
+			if (key.equals("_class")) {
+				assertThat((String) document.get(key), is(equalTo(expectedTypeString)));
+				assertThat(keyIterator.hasNext(), is(false));
+				return;
+			}
+		}
+
+		fail(String.format("Expected to find type info %s in %s.", document, expectedTypeString));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -44,6 +44,7 @@ import org.hamcrest.collection.IsMapContaining;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -3468,6 +3469,22 @@ public class MongoTemplateTests {
 		assertThat(document.id, is(notNullValue()));
 	}
 
+
+	/**
+	 * @see DATAMONGO-1509
+	 */
+	@Test
+	public void findsByGnericNestedListElements() {
+
+		List<Model> modelList = Arrays.<Model>asList(new ModelA("value"));
+		DocumentWithCollection dwc = new DocumentWithCollection(modelList);
+
+		template.insert(dwc);
+
+		Query query = query(where("models").is(modelList));
+		assertThat(template.findOne(query, DocumentWithCollection.class), is(equalTo(dwc)));
+	}
+
 	static class TypeWithNumbers {
 
 		@Id String id;
@@ -3547,6 +3564,7 @@ public class MongoTemplateTests {
 		@org.springframework.data.mongodb.core.mapping.DBRef(lazy = true) public Map<String, Sample> lazyDbRefAnnotatedMap;
 	}
 
+	@EqualsAndHashCode
 	static class DocumentWithCollection {
 
 		@Id String id;
@@ -3599,6 +3617,7 @@ public class MongoTemplateTests {
 		String id();
 	}
 
+	@EqualsAndHashCode
 	static class ModelA implements Model {
 
 		@Id String id;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -526,6 +526,9 @@ public class MappingMongoConverterUnitTests {
 		assertThat(converter.convertToMongoType(null), is(nullValue()));
 	}
 
+	/**
+	 * @see DATAMONGO-1509
+	 */
 	@Test
 	public void writesGenericTypeCorrectly() {
 
@@ -537,7 +540,7 @@ public class MappingMongoConverterUnitTests {
 		converter.write(type, result);
 
 		org.bson.Document content = (org.bson.Document) result.get("content");
-		assertThat(content.get("_class"), is(notNullValue()));
+		assertTypeHint(content, Address.class);
 		assertThat(content.get("city"), is(notNullValue()));
 	}
 
@@ -1272,6 +1275,7 @@ public class MappingMongoConverterUnitTests {
 
 	/**
 	 * @see DATAMONGO-523
+	 * @see DATAMONGO-1509
 	 */
 	@Test
 	public void considersTypeAliasAnnotation() {
@@ -1282,9 +1286,7 @@ public class MappingMongoConverterUnitTests {
 		org.bson.Document result = new org.bson.Document();
 		converter.write(aliased, result);
 
-		Object type = result.get("_class");
-		assertThat(type, is(notNullValue()));
-		assertThat(type.toString(), is("_"));
+		assertTypeHint(result, "_");
 	}
 
 	/**
@@ -1409,6 +1411,7 @@ public class MappingMongoConverterUnitTests {
 	/**
 	 * @see DATAMONGO-812
 	 * @see DATAMONGO-893
+	 * @see DATAMONGO-1509
 	 */
 	@Test
 	public void convertsListToBasicDBListAndRetainsTypeInformationForComplexObjects() {
@@ -1424,7 +1427,7 @@ public class MappingMongoConverterUnitTests {
 
 		List<Object> dbList = (List<Object>) result;
 		assertThat(dbList, hasSize(1));
-		assertThat(getTypedValue(getAsDocument(dbList, 0), "_class", String.class), equalTo(Address.class.getName()));
+		assertTypeHint(getAsDocument(dbList, 0), Address.class);
 	}
 
 	/**
@@ -1444,6 +1447,7 @@ public class MappingMongoConverterUnitTests {
 
 	/**
 	 * @see DATAMONGO-812
+	 * @see DATAMONGO-1509
 	 */
 	@Test
 	public void convertsArrayToBasicDBListAndRetainsTypeInformationForComplexObjects() {
@@ -1458,7 +1462,7 @@ public class MappingMongoConverterUnitTests {
 
 		List<Object> dbList = (List<Object>) result;
 		assertThat(dbList, hasSize(1));
-		assertThat(getTypedValue(getAsDocument(dbList, 0), "_class", String.class), equalTo(Address.class.getName()));
+		assertTypeHint(getAsDocument(dbList, 0), Address.class);
 	}
 
 	/**
@@ -1802,6 +1806,7 @@ public class MappingMongoConverterUnitTests {
 
 	/**
 	 * @see DATAMONGO-1001
+	 * @see DATAMONGO-1509
 	 */
 	@Test
 	public void shouldWriteCglibProxiedClassTypeInformationCorrectly() {
@@ -1814,7 +1819,7 @@ public class MappingMongoConverterUnitTests {
 		org.bson.Document document = new org.bson.Document();
 		converter.write(proxied, document);
 
-		assertThat(document.get("_class"), is((Object) GenericType.class.getName()));
+		assertTypeHint(document, GenericType.class);
 	}
 
 	/**


### PR DESCRIPTION
Always add type hint as last property of document.
This necessary to assure document equality within MongoDB in cases where the query contains full `Document` comparisons. Unfortunately this also might break existing stuff since the order of properties within a `Document` is changed with this commit.