### PR TITLE
DATAMONGO-784 - Add support for comparison aggregation operators to $group & $project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-784-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationFunctionExpressions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationFunctionExpressions.java
@@ -33,7 +33,7 @@ import com.mongodb.DBObject;
  */
 public enum AggregationFunctionExpressions {
 
-	SIZE;
+	SIZE, CMP, EQ, GT, GTE, LT, LTE, NE;
 
 	/**
 	 * Returns an {@link AggregationExpression} build from the current {@link Enum} name and the given parameters.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -617,6 +617,78 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 		}
 
 		/**
+		 * Generates a {@code $cmp} expression (compare to) that compares the value of the field to a given value or field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder cmp(Object compareValue) {
+			return project("cmp", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $eq} expression (equal) that compares the value of the field to a given value or field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder eq(Object compareValue) {
+			return project("eq", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $gt} expression (greater than) that compares the value of the field to a given value or field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder gt(Object compareValue) {
+			return project("gt", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $gte} expression (greater than equal) that compares the value of the field to a given value or
+		 * field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder gte(Object compareValue) {
+			return project("gte", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $lt} expression (less than) that compares the value of the field to a given value or field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder lt(Object compareValue) {
+			return project("lt", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $lte} expression (less than equal) that compares the value of the field to a given value or
+		 * field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder lte(Object compareValue) {
+			return project("lte", compareValue);
+		}
+
+		/**
+		 * Generates a {@code $ne} expression (not equal) that compares the value of the field to a given value or field.
+		 *
+		 * @return never {@literal null}.
+		 * @since 1.10
+		 */
+		public ProjectionOperationBuilder ne(Object compareValue) {
+			return project("ne", compareValue);
+		}
+
+		/**
 		 * Generates a {@code $slice} expression that returns a subset of the array held by the given field. <br />
 		 * If {@literal n} is positive, $slice returns up to the first n elements in the array. <br />
 		 * If {@literal n} is negative, $slice returns up to the last n elements in the array.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.mongodb.core.aggregation.AggregationFunctionExpressions.*;
 import static org.springframework.data.mongodb.core.aggregation.Fields.*;
+import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 import static org.springframework.data.mongodb.util.DBObjectUtils.*;
 
 import java.util.Arrays;
@@ -400,6 +401,90 @@ public class ProjectionOperationUnitTests {
 
 		assertThat(projected.get("renamed"),
 				is((Object) new BasicDBObject("$slice", Arrays.<Object> asList("$field", 5, 10))));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderCmpCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").cmp(10).as("cmp10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.cmp10.$cmp.[0]", "$field").containing("$project.cmp10.$cmp.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderEqCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").eq(10).as("eq10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.eq10.$eq.[0]", "$field").containing("$project.eq10.$eq.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderGtCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").gt(10).as("gt10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.gt10.$gt.[0]", "$field").containing("$project.gt10.$gt.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderGteCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").gte(10).as("gte10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.gte10.$gte.[0]", "$field").containing("$project.gte10.$gte.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderLtCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").lt(10).as("lt10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.lt10.$lt.[0]", "$field").containing("$project.lt10.$lt.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderLteCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").lte(10).as("lte10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.lte10.$lte.[0]", "$field").containing("$project.lte10.$lte.[1]", 10));
+	}
+
+	/**
+	 * @see DATAMONGO-784
+	 */
+	@Test
+	public void shouldRenderNeCorrectly() {
+
+		ProjectionOperation operation = Aggregation.project().and("field").ne(10).as("ne10");
+
+		assertThat(operation.toDBObject(Aggregation.DEFAULT_CONTEXT),
+				isBsonObject().containing("$project.ne10.$ne.[0]", "$field").containing("$project.ne10.$ne.[1]", 10));
 	}
 
 	private static DBObject exctractOperation(String field, DBObject fromProjectClause) {


### PR DESCRIPTION
We now directly support comparison aggregation operators (`$cmp`, `$eq`, `$gt`, `$gte`, `$lt`, `$lte` and `$ne`) on both `$group` and `$project` stages.