### PR TITLE
DATAMONGO-1533 - Add AggregationExpression derived from SpEL AST.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1533-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationSpELExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationSpELExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import com.mongodb.DBObject;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AggregationExpression} that renders a MongoDB Aggregation Framework expression from the AST of a
+ * <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/html/expressions.html">SpEL
+ * expression</a>. <br />
+ * <br />
+ * <strong>Samples:</strong> <br />
+ * <code>
+ * <pre>
+ * // { $and: [ { $gt: [ "$qty", 100 ] }, { $lt: [ "$qty", 250 ] } ] }
+ * expressionOf("qty > 100 && qty < 250);
+ *
+ * // { $cond : { if : { $gte : [ "$a", 42 ]}, then : "answer", else : "no-answer" } }
+ * expressionOf("cond(a >= 42, 'answer', 'no-answer')");
+ * </pre>
+ * </code>
+ * 
+ * @author Christoph Strobl
+ * @see SpelExpressionTransformer
+ * @since 1.10
+ */
+public class AggregationSpELExpression implements AggregationExpression {
+
+	private static final SpelExpressionTransformer TRANSFORMER = new SpelExpressionTransformer();
+	private final String rawExpression;
+	private final Object[] parameters;
+
+	private AggregationSpELExpression(String rawExpression, Object[] parameters) {
+
+		this.rawExpression = rawExpression;
+		this.parameters = parameters;
+	}
+
+	/**
+	 * Creates new {@link AggregationSpELExpression} for the given {@literal expressionString} and {@literal parameters}.
+	 *
+	 * @param expression must not be {@literal null}.
+	 * @param parameters can be empty.
+	 * @return
+	 */
+	public static AggregationSpELExpression expressionOf(String expressionString, Object... parameters) {
+
+		Assert.notNull(expressionString, "ExpressionString must not be null!");
+		return new AggregationSpELExpression(expressionString, parameters);
+	}
+
+	@Override
+	public DBObject toDbObject(AggregationOperationContext context) {
+		return (DBObject) TRANSFORMER.transform(rawExpression, context, parameters);
+	}
+}


### PR DESCRIPTION
We added an `AggregationExpression` that renders a MongoDB Aggregation Framework expression from the AST of a SpEL expression. This allows usage with various stages (eg. `$project`, `$group`) throughout the aggregation support.

```java
  // { $and: [ { $gt: [ "$qty", 100 ] }, { $lt: [ "$qty", 250 ] } ] }
  expressionOf("qty > 100 && qty < 250");

  // { $cond : { if : { $gte : [ "$a", 42 ]}, then : "answer", else : "no-answer" } }
  expressionOf("cond(a >= 42, 'answer', 'no-answer')");
```