### PR TITLE
DATAMONGO-1467 - Add support for MongoDB 3.2 partialFilterExpression for index creation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1467-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -557,7 +557,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	}
 
 	public IndexOperations indexOps(Class<?> entityClass) {
-		return new DefaultIndexOperations(this, determineCollectionName(entityClass));
+		return new DefaultIndexOperations(this, determineCollectionName(entityClass), entityClass);
 	}
 
 	public BulkOperations bulkOps(BulkMode bulkMode, String collectionName) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeospatialIndex.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/GeospatialIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class GeospatialIndex implements IndexDefinition {
 	private GeoSpatialIndexType type = GeoSpatialIndexType.GEO_2D;
 	private Double bucketSize = 1.0;
 	private String additionalField;
+	private IndexFilter filter;
 
 	/**
 	 * Creates a new {@link GeospatialIndex} for the given field.
@@ -119,6 +120,22 @@ public class GeospatialIndex implements IndexDefinition {
 		return this;
 	}
 
+
+	/**
+	 * Only index the documents in a collection that meet a specified {@link IndexFilter filter expression}.
+	 *
+	 * @param filter can be {@literal null}.
+	 * @return
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/core/index-partial/">https://docs.mongodb.com/manual/core/index-partial/</a>
+	 * @since 1.10
+	 */
+	public GeospatialIndex partial(IndexFilter filter) {
+
+		this.filter = filter;
+		return this;
+	}
+
 	public DBObject getIndexKeys() {
 
 		DBObject dbo = new BasicDBObject();
@@ -184,6 +201,10 @@ public class GeospatialIndex implements IndexDefinition {
 					dbo.put("bucketSize", bucketSize);
 				}
 				break;
+		}
+
+		if (filter != null) {
+			dbo.put("partialFilterExpression", filter.getFilterObject());
 		}
 
 		return dbo;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 the original author or authors.
+ * Copyright 2010-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,8 @@ public class Index implements IndexDefinition {
 	private boolean background = false;
 
 	private long expire = -1;
+
+	private IndexFilter filter;
 
 	public Index() {}
 
@@ -176,6 +178,21 @@ public class Index implements IndexDefinition {
 		return unique();
 	}
 
+	/**
+	 * Only index the documents in a collection that meet a specified {@link IndexFilter filter expression}.
+	 *
+	 * @param filter can be {@literal null}.
+	 * @return
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/core/index-partial/">https://docs.mongodb.com/manual/core/index-partial/</a>
+	 * @since 1.10
+	 */
+	public Index partial(IndexFilter filter) {
+
+		this.filter = filter;
+		return this;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.index.IndexDefinition#getIndexKeys()
@@ -213,6 +230,9 @@ public class Index implements IndexDefinition {
 			dbo.put("expireAfterSeconds", expire);
 		}
 
+		if (filter != null) {
+			dbo.put("partialFilterExpression", filter.getFilterObject());
+		}
 		return dbo;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexFilter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import com.mongodb.DBObject;
+
+/**
+ * Use {@link IndexFilter} to create the partial filter expression used when creating
+ * <a href="https://docs.mongodb.com/manual/core/index-partial/">Partial Indexes</a>.
+ *
+ * @author Christoph Strobl
+ * @since 1.10
+ */
+public interface IndexFilter {
+
+	/**
+	 * Get the raw (unmapped) filter expression.
+	 *
+	 * @return
+	 */
+	DBObject getFilterObject();
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,15 @@
  */
 package org.springframework.data.mongodb.core.index;
 
+import static org.springframework.data.domain.Sort.Direction.*;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.mongodb.DBObject;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -30,6 +34,10 @@ import org.springframework.util.ObjectUtils;
  */
 public class IndexInfo {
 
+	private static final Double ONE = Double.valueOf(1);
+	private static final Double MINUS_ONE = Double.valueOf(-1);
+	private static final Collection<String> TWO_D_IDENTIFIERS = Arrays.asList("2d", "2dsphere");
+
 	private final List<IndexField> indexFields;
 
 	private final String name;
@@ -37,6 +45,7 @@ public class IndexInfo {
 	private final boolean dropDuplicates;
 	private final boolean sparse;
 	private final String language;
+	private String partialFilterExpression;
 
 	/**
 	 * @deprecated Will be removed in 1.7. Please use {@link #IndexInfo(List, String, boolean, boolean, boolean, String)}
@@ -60,6 +69,61 @@ public class IndexInfo {
 		this.dropDuplicates = dropDuplicates;
 		this.sparse = sparse;
 		this.language = language;
+	}
+
+	/**
+	 * Creates new {@link IndexInfo} parsing required properties from the given {@literal sourceDocument}.
+	 *
+	 * @param sourceDocument
+	 * @return
+	 * @since 1.10
+	 */
+	public static IndexInfo indexInfoOf(DBObject sourceDocument) {
+
+		DBObject keyDbObject = (DBObject) sourceDocument.get("key");
+		int numberOfElements = keyDbObject.keySet().size();
+
+		List<IndexField> indexFields = new ArrayList<IndexField>(numberOfElements);
+
+		for (String key : keyDbObject.keySet()) {
+
+			Object value = keyDbObject.get(key);
+
+			if (TWO_D_IDENTIFIERS.contains(value)) {
+				indexFields.add(IndexField.geo(key));
+			} else if ("text".equals(value)) {
+
+				DBObject weights = (DBObject) sourceDocument.get("weights");
+				for (String fieldName : weights.keySet()) {
+					indexFields.add(IndexField.text(fieldName, Float.valueOf(weights.get(fieldName).toString())));
+				}
+
+			} else {
+
+				Double keyValue = new Double(value.toString());
+
+				if (ONE.equals(keyValue)) {
+					indexFields.add(IndexField.create(key, ASC));
+				} else if (MINUS_ONE.equals(keyValue)) {
+					indexFields.add(IndexField.create(key, DESC));
+				}
+			}
+		}
+
+		String name = sourceDocument.get("name").toString();
+
+		boolean unique = sourceDocument.containsField("unique") ? (Boolean) sourceDocument.get("unique") : false;
+		boolean dropDuplicates = sourceDocument.containsField("dropDups") ? (Boolean) sourceDocument.get("dropDups")
+				: false;
+		boolean sparse = sourceDocument.containsField("sparse") ? (Boolean) sourceDocument.get("sparse") : false;
+		String language = sourceDocument.containsField("default_language") ? (String) sourceDocument.get("default_language")
+				: "";
+		String partialFilter = sourceDocument.containsField("partialFilterExpression")
+				? sourceDocument.get("partialFilterExpression").toString() : "";
+
+		IndexInfo info = new IndexInfo(indexFields, name, unique, dropDuplicates, sparse, language);
+		info.partialFilterExpression = partialFilter;
+		return info;
 	}
 
 	/**
@@ -113,10 +177,19 @@ public class IndexInfo {
 		return language;
 	}
 
+	/**
+	 * @return
+	 * @since 1.0
+	 */
+	public String getPartialFilterExpression() {
+		return partialFilterExpression;
+	}
+
 	@Override
 	public String toString() {
 		return "IndexInfo [indexFields=" + indexFields + ", name=" + name + ", unique=" + unique + ", dropDuplicates="
-				+ dropDuplicates + ", sparse=" + sparse + ", language=" + language + "]";
+				+ dropDuplicates + ", sparse=" + sparse + ", language=" + language + ", partialFilterExpression="
+				+ partialFilterExpression + "]";
 	}
 
 	@Override
@@ -130,6 +203,7 @@ public class IndexInfo {
 		result = prime * result + (sparse ? 1231 : 1237);
 		result = prime * result + (unique ? 1231 : 1237);
 		result = prime * result + ObjectUtils.nullSafeHashCode(language);
+		result = prime * result + ObjectUtils.nullSafeHashCode(partialFilterExpression);
 		return result;
 	}
 
@@ -169,6 +243,9 @@ public class IndexInfo {
 			return false;
 		}
 		if (!ObjectUtils.nullSafeEquals(language, other.language)) {
+			return false;
+		}
+		if (!ObjectUtils.nullSafeEquals(partialFilterExpression, other.partialFilterExpression)) {
 			return false;
 		}
 		return true;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/PartialIndexFilter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/PartialIndexFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.util.Assert;
+
+import com.mongodb.DBObject;
+
+/**
+ * {@link IndexFilter} implementation for usage with plain {@link DBObject} as well as {@link CriteriaDefinition} filter
+ * expressions.
+ *
+ * @author Christoph Strobl
+ * @since 1.10
+ */
+public class PartialIndexFilter implements IndexFilter {
+
+	private final Object filterExpression;
+
+	private PartialIndexFilter(Object filterExpression) {
+
+		Assert.notNull(filterExpression, "FilterExpression must not be null!");
+		this.filterExpression = filterExpression;
+	}
+
+	/**
+	 * Create new {@link PartialIndexFilter} for given {@link DBObject filter expression}.
+	 *
+	 * @param where must not be {@literal null}.
+	 * @return
+	 */
+	public static PartialIndexFilter filter(DBObject where) {
+		return new PartialIndexFilter(where);
+	}
+
+	/**
+	 * Create new {@link PartialIndexFilter} for given {@link CriteriaDefinition filter expression}.
+	 *
+	 * @param where must not be {@literal null}.
+	 * @return
+	 */
+	public static PartialIndexFilter filter(CriteriaDefinition where) {
+		return new PartialIndexFilter(where);
+	}
+
+	public DBObject getFilterObject() {
+
+		if (filterExpression instanceof DBObject) {
+			return (DBObject) filterExpression;
+		}
+
+		if (filterExpression instanceof CriteriaDefinition) {
+			return ((CriteriaDefinition) filterExpression).getCriteriaObject();
+		}
+
+		throw new IllegalArgumentException(
+				String.format("Unknown type %s used as filter expression.", filterExpression.getClass()));
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class TextIndexDefinition implements IndexDefinition {
 	private Set<TextIndexedFieldSpec> fieldSpecs;
 	private String defaultLanguage;
 	private String languageOverride;
+	private IndexFilter filter;
 
 	TextIndexDefinition() {
 		fieldSpecs = new LinkedHashSet<TextIndexedFieldSpec>();
@@ -127,6 +128,10 @@ public class TextIndexDefinition implements IndexDefinition {
 		}
 		if (StringUtils.hasText(languageOverride)) {
 			options.put("language_override", languageOverride);
+		}
+
+		if (filter != null) {
+			options.put("partialFilterExpression", filter.getFilterObject());
 		}
 
 		return options;
@@ -288,8 +293,8 @@ public class TextIndexDefinition implements IndexDefinition {
 		public TextIndexDefinitionBuilder onField(String fieldname, Float weight) {
 
 			if (this.instance.fieldSpecs.contains(ALL_FIELDS)) {
-				throw new InvalidDataAccessApiUsageException(String.format("Cannot add %s to field spec for all fields.",
-						fieldname));
+				throw new InvalidDataAccessApiUsageException(
+						String.format("Cannot add %s to field spec for all fields.", fieldname));
 			}
 
 			this.instance.fieldSpecs.add(new TextIndexedFieldSpec(fieldname, weight));
@@ -318,12 +323,27 @@ public class TextIndexDefinition implements IndexDefinition {
 		public TextIndexDefinitionBuilder withLanguageOverride(String fieldname) {
 
 			if (StringUtils.hasText(this.instance.languageOverride)) {
-				throw new InvalidDataAccessApiUsageException(String.format(
-						"Cannot set language override on %s as it is already defined on %s.", fieldname,
-						this.instance.languageOverride));
+				throw new InvalidDataAccessApiUsageException(
+						String.format("Cannot set language override on %s as it is already defined on %s.", fieldname,
+								this.instance.languageOverride));
 			}
 
 			this.instance.languageOverride = fieldname;
+			return this;
+		}
+
+		/**
+		 * Only index the documents that meet the specified {@link IndexFilter filter expression}.
+		 *
+		 * @param filter can be {@literal null}.
+		 * @return
+		 * @see <a href=
+		 *      "https://docs.mongodb.com/manual/core/index-partial/">https://docs.mongodb.com/manual/core/index-partial/</a>
+		 * @since 1.10
+		 */
+		public TextIndexDefinitionBuilder partial(IndexFilter filter) {
+
+			this.instance.filter = filter;
 			return this;
 		}
 


### PR DESCRIPTION
We now support `partialFilterExpression` via `partial`. This allows to create partial indexes that only index the documents in a collection that meet a specified filter expression.

```java
new Index().named("idx").on("k3y", ASC).partial(filter(where("age").gte(10)))
```
The filter expression can be set via a plain `DBObject` or a `CriteriaDefinition` and is mapped against the associated domain type.

---

Relates to: #380