### PR TITLE
DATAMONGO-1588 - Fix derived finder not accepting subclass of parameter type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.0.BUILD-SNAPSHOT</version>
+			<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.0.BUILD-SNAPSHOT</version>
+		<version>1.10.0.DATAMONGO-1588-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.data.repository.query.parser.Part.IgnoreCaseType;
 import org.springframework.data.repository.query.parser.Part.Type;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Custom query creator to create Mongo criterias.
@@ -369,8 +370,10 @@ class MongoQueryCreator extends AbstractQueryCreator<Query, Criteria> {
 	 */
 	@SuppressWarnings("unchecked")
 	private <T> T nextAs(Iterator<Object> iterator, Class<T> type) {
+
 		Object parameter = iterator.next();
-		if (parameter.getClass().isAssignableFrom(type)) {
+
+		if (ClassUtils.isAssignable(type, parameter.getClass())) {
 			return (T) parameter;
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -51,6 +51,7 @@ import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.repository.Person.Sex;
 import org.springframework.data.mongodb.repository.SampleEvaluationContextExtension.SampleSecurityContextHolder;
@@ -265,6 +266,18 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	@Test
 	public void findsPeopleByLocationNear() {
 		Point point = new Point(-73.99171, 40.738868);
+		dave.setLocation(point);
+		repository.save(dave);
+
+		List<Person> result = repository.findByLocationNear(point);
+		assertThat(result.size(), is(1));
+		assertThat(result, hasItem(dave));
+	}
+
+	@Test // DATAMONGO-1588
+	public void findsPeopleByLocationNearUsingGeoJsonType() {
+
+		GeoJsonPoint point = new GeoJsonPoint(-73.99171, 40.738868);
 		dave.setLocation(point);
 		repository.save(dave);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -44,6 +44,8 @@ import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.geo.GeoJsonLineString;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
 import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -604,6 +606,29 @@ public class MongoQueryCreatorUnitTests {
 		assertThat(query.getQueryObject(), is(query(where("username").not().regex(".*")).getQueryObject()));
 	}
 
+	@Test // DATAMONGO-1588
+	public void queryShouldAcceptSubclassOfDeclaredArgument() {
+
+		PartTree tree = new PartTree("findByLocationNear", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter, new GeoJsonPoint(-74.044502D, 40.689247D));
+
+		Query query = new MongoQueryCreator(tree, accessor, context).createQuery();
+		assertThat(query.getQueryObject().containsField("location"), is(true));
+	}
+
+	@Test // DATAMONGO-1588
+	public void queryShouldThrowExceptionWhenArgumentDoesNotMatchDeclaration() {
+
+		expection.expect(IllegalArgumentException.class);
+		expection.expectMessage("Expected parameter type of " + Point.class);
+
+		PartTree tree = new PartTree("findByLocationNear", User.class);
+		ConvertingParameterAccessor accessor = getAccessor(converter,
+				new GeoJsonLineString(new Point(-74.044502D, 40.689247D), new Point(-73.997330D, 40.730824D)));
+
+		new MongoQueryCreator(tree, accessor, context).createQuery();
+	}
+
 	interface PersonRepository extends Repository<Person, Long> {
 
 		List<Person> findByLocationNearAndFirstname(Point location, Distance maxDistance, String firstname);
@@ -622,6 +647,8 @@ public class MongoQueryCreatorUnitTests {
 		Address address;
 
 		Address2dSphere address2dSphere;
+
+		Point location;
 	}
 
 	static class Address {


### PR DESCRIPTION
We now allow using sub types as arguments for derived queries. This makes it possible to use eg. a `GeoJsonPoint` for querying while the declared property type in the domain object remains a regular (legacy) `Point`.