### PR TITLE
DATAMONGO-1600 - Make GraphLookupOperationBuilder public.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.11.0.BUILD-SNAPSHOT</version>
+			<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1600-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GraphLookupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GraphLookupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,7 +332,7 @@ public class GraphLookupOperation implements InheritsFieldsAggregationOperation 
 	/**
 	 * @author Mark Paluch
 	 */
-	static final class GraphLookupOperationBuilder {
+	public static final class GraphLookupOperationBuilder {
 
 		private final String from;
 		private final List<Object> startWith;


### PR DESCRIPTION
Make `GraphLookupOperationBuilder` public so it can be used in types outside the aggregation package.

---

Related ticket: [DATAMONGO-1600](https://jira.spring.io/browse/DATAMONGO-1600)