### PR TITLE
DATAMONGO-1619 - Use ReactiveQueryByExampleExecutor in ReactiveMongoRepository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -28,9 +28,9 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
-		<mongo>3.4.2</mongo>
-		<mongo.reactivestreams>1.3.0</mongo.reactivestreams>
+        <springdata.commons>2.0.0.DATACMNS-995-SNAPSHOT</springdata.commons>
+        <mongo>3.4.2</mongo>
+        <mongo.reactivestreams>1.3.0</mongo.reactivestreams>
 	</properties>
 
 	<developers>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1619-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/ReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/ReactiveMongoRepository.java
@@ -22,6 +22,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 /**
@@ -31,7 +32,7 @@ import org.springframework.data.repository.reactive.ReactiveSortingRepository;
  * @since 2.0
  */
 @NoRepositoryBean
-public interface ReactiveMongoRepository<T, ID> extends ReactiveSortingRepository<T, ID> {
+public interface ReactiveMongoRepository<T, ID> extends ReactiveSortingRepository<T, ID>, ReactiveQueryByExampleExecutor<T> {
 
 	/**
 	 * Inserts the given entity. Assumes the instance to be new to be able to apply insertion optimizations. Use the

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -78,6 +78,19 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ReactiveQueryByExampleExecutor#findOne(org.springframework.data.domain.Example)
+	 */
+	@Override
+	public <S extends T> Mono<S> findOne(Example<S> example) {
+
+		Assert.notNull(example, "Sample must not be null!");
+
+		Query q = new Query(new Criteria().alike(example));
+		return mongoOperations.findOne(q, example.getProbeType(), entityInformation.getCollectionName());
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#existsById(java.lang.Object)
 	 */
 	@Override
@@ -103,6 +116,23 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ReactiveQueryByExampleExecutor#exists(org.springframework.data.domain.Example)
+	 */
+	@Override
+	public <S extends T> Mono<Boolean> exists(Example<S> example) {
+
+		Assert.notNull(example, "Sample must not be null!");
+
+		Query q = new Query(new Criteria().alike(example));
+		return mongoOperations.exists(q, example.getProbeType(), entityInformation.getCollectionName());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.reactive.ReactiveSortingRepository#findAll()
+	 */
 	@Override
 	public Flux<T> findAll() {
 		return findAll(new Query());
@@ -170,8 +200,22 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#count()
 	 */
+	@Override
 	public Mono<Long> count() {
 		return mongoOperations.count(new Query(), entityInformation.getCollectionName());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ReactiveQueryByExampleExecutor#count(org.springframework.data.domain.Example)
+	 */
+	@Override
+	public <S extends T> Mono<Long> count(Example<S> example) {
+
+		Assert.notNull(example, "Sample must not be null!");
+
+		Query q = new Query(new Criteria().alike(example));
+		return mongoOperations.count(q, example.getProbeType(), entityInformation.getCollectionName());
 	}
 
 	/*
@@ -315,32 +359,9 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#deleteAll()
 	 */
+	@Override
 	public Mono<Void> deleteAll() {
 		return mongoOperations.remove(new Query(), entityInformation.getCollectionName()).then(Mono.empty());
-	}
-
-	public <S extends T> Mono<Boolean> exists(Example<S> example) {
-
-		Assert.notNull(example, "Sample must not be null!");
-
-		Query q = new Query(new Criteria().alike(example));
-		return mongoOperations.exists(q, example.getProbeType(), entityInformation.getCollectionName());
-	}
-
-	public <S extends T> Mono<S> findOne(Example<S> example) {
-
-		Assert.notNull(example, "Sample must not be null!");
-
-		Query q = new Query(new Criteria().alike(example));
-		return mongoOperations.findOne(q, example.getProbeType(), entityInformation.getCollectionName());
-	}
-
-	public <S extends T> Mono<Long> count(Example<S> example) {
-
-		Assert.notNull(example, "Sample must not be null!");
-
-		Query q = new Query(new Criteria().alike(example));
-		return mongoOperations.count(q, example.getProbeType(), entityInformation.getCollectionName());
 	}
 
 	private Query getIdQuery(Object id) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SimpleReactiveMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SimpleReactiveMongoRepositoryTests.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Sort;
@@ -49,9 +50,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ClassUtils;
 
 /**
- * Test for {@link ReactiveMongoRepository}.
+ * Tests for {@link ReactiveMongoRepository}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:reactive-infrastructure.xml")
@@ -401,6 +403,15 @@ public class SimpleReactiveMongoRepositoryTests implements BeanClassLoaderAware,
 		Example<ReactivePerson> example = Example.of(new ReactivePerson("foo", "bar", -1));
 
 		StepVerifier.create(repository.exists(example)).expectNext(false).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void findOneShouldEmitIncorrectResultSizeDataAccessExceptionWhenMoreThanOneElementFound() {
+
+		Example<ReactivePerson> example = Example.of(new ReactivePerson(null, "Matthews", -1),
+				matching().withIgnorePaths("age"));
+
+		StepVerifier.create(repository.findOne(example)).expectError(IncorrectResultSizeDataAccessException.class);
 	}
 
 	interface ReactivePersonRepostitory extends ReactiveMongoRepository<ReactivePerson, String> {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SimpleReactiveMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/SimpleReactiveMongoRepositoryTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.repository;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.data.domain.ExampleMatcher.*;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,6 +36,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
@@ -351,6 +353,54 @@ public class SimpleReactiveMongoRepositoryTests implements BeanClassLoaderAware,
 		StepVerifier.create(repository.findById(boyd.id)).verifyComplete();
 
 		StepVerifier.create(repository.findByLastname("Matthews")).expectNext(oliver).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void findOneByExampleShouldReturnObject() {
+
+		Example<ReactivePerson> example = Example.of(dave);
+
+		StepVerifier.create(repository.findOne(example)).expectNext(dave).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void findAllByExampleShouldReturnObjects() {
+
+		Example<ReactivePerson> example = Example.of(dave, matching().withIgnorePaths("id", "age", "firstname"));
+
+		StepVerifier.create(repository.findAll(example)).expectNextCount(2).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void findAllByExampleAndSortShouldReturnObjects() {
+
+		Example<ReactivePerson> example = Example.of(dave, matching().withIgnorePaths("id", "age", "firstname"));
+
+		StepVerifier.create(repository.findAll(example, Sort.by("firstname"))).expectNext(dave, oliver).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void countByExampleShouldCountObjects() {
+
+		Example<ReactivePerson> example = Example.of(dave, matching().withIgnorePaths("id", "age", "firstname"));
+
+		StepVerifier.create(repository.count(example)).expectNext(2L).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void existsByExampleShouldReturnExisting() {
+
+		Example<ReactivePerson> example = Example.of(dave, matching().withIgnorePaths("id", "age", "firstname"));
+
+		StepVerifier.create(repository.exists(example)).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1619
+	public void existsByExampleShouldReturnNonExisting() {
+
+		Example<ReactivePerson> example = Example.of(new ReactivePerson("foo", "bar", -1));
+
+		StepVerifier.create(repository.exists(example)).expectNext(false).verifyComplete();
 	}
 
 	interface ReactivePersonRepostitory extends ReactiveMongoRepository<ReactivePerson, String> {


### PR DESCRIPTION
Add `ReactiveQueryByExampleExecutor` to `ReactiveMongoRepository` to declare reactive support for Query-by-Example. 

Extend tests. Add `@Override` and override JavaDocs.

---

Related ticket: [DATAMONGO-1619](https://jira.spring.io/browse/DATAMONGO-1619)
Depends on: https://github.com/spring-projects/spring-data-commons/pull/197