### PR TITLE
DATAMONGO-1421 - Fix serialization in error message causing error itself.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.11.0.BUILD-SNAPSHOT</version>
+			<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1421-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class Query {
 		} else {
 			throw new InvalidMongoDbApiUsageException(
 					"Due to limitations of the com.mongodb.BasicDBObject, " + "you can't add a second '" + key + "' criteria. "
-							+ "Query already contains '" + existing.getCriteriaObject() + "'.");
+							+ "Query already contains '" + serializeToJsonSafely(existing.getCriteriaObject()) + "'.");
 		}
 
 		return this;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
@@ -33,11 +33,12 @@ import org.springframework.data.mongodb.core.SpecialDoc;
 
 /**
  * Unit tests for {@link Query}.
- * 
+ *
  * @author Thomas Risberg
  * @author Oliver Gierke
  * @author Patryk Wasik
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class QueryTests {
 
@@ -203,5 +204,21 @@ public class QueryTests {
 		assertThat(query.getRestrictedTypes(), is(notNullValue()));
 		assertThat(query.getRestrictedTypes().size(), is(1));
 		assertThat(query.getRestrictedTypes(), hasItems(Arrays.asList(SpecialDoc.class).toArray(new Class<?>[0])));
+	}
+
+	@Test // DATAMONGO-1421
+	public void addCriteriaForSamePropertyMultipleTimesShouldThrowAndSafelySerializeErrorMessage() {
+
+		exception.expect(InvalidMongoDbApiUsageException.class);
+		exception.expectMessage("second 'value' criteria");
+		exception.expectMessage("already contains '{ \"value\" : { $java : VAL_1 } }'");
+
+		Query query = new Query();
+		query.addCriteria(where("value").is(EnumType.VAL_1));
+		query.addCriteria(where("value").is(EnumType.VAL_2));
+	}
+
+	enum EnumType {
+		VAL_1, VAL_2
 	}
 }


### PR DESCRIPTION
We now make sure to safely serialize the criteria object used for creating the error message when raising an `InvalidMongoDbApiUsageException` in cases where `addCriteria` is used to add multiple entries for the same property.