### PR TITLE
DATAMONGO-1620 - Add server-selection-timeout to XML MongoClientOptions config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.11.0.BUILD-SNAPSHOT</version>
+			<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1620-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,6 +129,7 @@ abstract class MongoParsingUtils {
 		setPropertyValue(clientOptionsDefBuilder, optionsElement, "heartbeat-socket-timeout", "heartbeatSocketTimeout");
 		setPropertyValue(clientOptionsDefBuilder, optionsElement, "ssl", "ssl");
 		setPropertyReference(clientOptionsDefBuilder, optionsElement, "ssl-socket-factory-ref", "sslSocketFactory");
+		setPropertyValue(clientOptionsDefBuilder, optionsElement, "server-selection-timeout", "serverSelectionTimeout");
 
 		mongoClientBuilder.addPropertyValue("mongoClientOptions", clientOptionsDefBuilder.getBeanDefinition());
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.java
@@ -32,7 +32,7 @@ import com.mongodb.WriteConcern;
 
 /**
  * A factory bean for construction of a {@link MongoClientOptions} instance.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @since 1.7
@@ -64,14 +64,14 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	private int heartbeatConnectTimeout = DEFAULT_MONGO_OPTIONS.getHeartbeatConnectTimeout();
 	private int heartbeatSocketTimeout = DEFAULT_MONGO_OPTIONS.getHeartbeatSocketTimeout();
 	private String requiredReplicaSetName = DEFAULT_MONGO_OPTIONS.getRequiredReplicaSetName();
-	private int serverSelectionTimeout = -1;
+	private int serverSelectionTimeout = Integer.MIN_VALUE;
 
 	private boolean ssl;
 	private SSLSocketFactory sslSocketFactory;
 
 	/**
 	 * Set the {@link MongoClient} description.
-	 * 
+	 *
 	 * @param description
 	 */
 	public void setDescription(String description) {
@@ -80,7 +80,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the minimum number of connections per host.
-	 * 
+	 *
 	 * @param minConnectionsPerHost
 	 */
 	public void setMinConnectionsPerHost(int minConnectionsPerHost) {
@@ -90,7 +90,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	/**
 	 * Set the number of connections allowed per host. Will block if run out. Default is 10. System property
 	 * {@code MONGO.POOLSIZE} can override
-	 * 
+	 *
 	 * @param connectionsPerHost
 	 */
 	public void setConnectionsPerHost(int connectionsPerHost) {
@@ -101,7 +101,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	 * Set the multiplier for connectionsPerHost for # of threads that can block. Default is 5. If connectionsPerHost is
 	 * 10, and threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an
 	 * exception will be thrown.
-	 * 
+	 *
 	 * @param threadsAllowedToBlockForConnectionMultiplier
 	 */
 	public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
@@ -110,7 +110,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
-	 * 
+	 *
 	 * @param maxWaitTime
 	 */
 	public void setMaxWaitTime(int maxWaitTime) {
@@ -119,7 +119,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * The maximum idle time for a pooled connection.
-	 * 
+	 *
 	 * @param maxConnectionIdleTime
 	 */
 	public void setMaxConnectionIdleTime(int maxConnectionIdleTime) {
@@ -128,7 +128,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the maximum life time for a pooled connection.
-	 * 
+	 *
 	 * @param maxConnectionLifeTime
 	 */
 	public void setMaxConnectionLifeTime(int maxConnectionLifeTime) {
@@ -137,7 +137,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the connect timeout in milliseconds. 0 is default and infinite.
-	 * 
+	 *
 	 * @param connectTimeout
 	 */
 	public void setConnectTimeout(int connectTimeout) {
@@ -146,7 +146,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the socket timeout. 0 is default and infinite.
-	 * 
+	 *
 	 * @param socketTimeout
 	 */
 	public void setSocketTimeout(int socketTimeout) {
@@ -155,7 +155,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
-	 * 
+	 *
 	 * @param socketKeepAlive
 	 */
 	public void setSocketKeepAlive(boolean socketKeepAlive) {
@@ -164,7 +164,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the {@link ReadPreference}.
-	 * 
+	 *
 	 * @param readPreference
 	 */
 	public void setReadPreference(ReadPreference readPreference) {
@@ -174,7 +174,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	/**
 	 * Set the {@link WriteConcern} that will be the default value used when asking the {@link MongoDbFactory} for a DB
 	 * object.
-	 * 
+	 *
 	 * @param writeConcern
 	 */
 	public void setWriteConcern(WriteConcern writeConcern) {
@@ -190,7 +190,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the frequency that the driver will attempt to determine the current state of each server in the cluster.
-	 * 
+	 *
 	 * @param heartbeatFrequency
 	 */
 	public void setHeartbeatFrequency(int heartbeatFrequency) {
@@ -200,7 +200,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	/**
 	 * In the event that the driver has to frequently re-check a server's availability, it will wait at least this long
 	 * since the previous check to avoid wasted effort.
-	 * 
+	 *
 	 * @param minHeartbeatFrequency
 	 */
 	public void setMinHeartbeatFrequency(int minHeartbeatFrequency) {
@@ -209,7 +209,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the connect timeout for connections used for the cluster heartbeat.
-	 * 
+	 *
 	 * @param heartbeatConnectTimeout
 	 */
 	public void setHeartbeatConnectTimeout(int heartbeatConnectTimeout) {
@@ -218,7 +218,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the socket timeout for connections used for the cluster heartbeat.
-	 * 
+	 *
 	 * @param heartbeatSocketTimeout
 	 */
 	public void setHeartbeatSocketTimeout(int heartbeatSocketTimeout) {
@@ -227,7 +227,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Configures the name of the replica set.
-	 * 
+	 *
 	 * @param requiredReplicaSetName
 	 */
 	public void setRequiredReplicaSetName(String requiredReplicaSetName) {
@@ -236,7 +236,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * This controls if the driver should us an SSL connection. Defaults to |@literal false}.
-	 * 
+	 *
 	 * @param ssl
 	 */
 	public void setSsl(boolean ssl) {
@@ -246,7 +246,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 	/**
 	 * Set the {@link SSLSocketFactory} to use for the {@literal SSL} connection. If none is configured here,
 	 * {@link SSLSocketFactory#getDefault()} will be used.
-	 * 
+	 *
 	 * @param sslSocketFactory
 	 */
 	public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
@@ -255,7 +255,8 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	/**
 	 * Set the {@literal server selection timeout} in msec for a 3.x MongoDB Java driver. If not set the default value of
-	 * 30 sec will be used.
+	 * 30 sec will be used. A value of 0 means that it will timeout immediately if no server is available. A negative
+	 * value means to wait indefinitely.
 	 *
 	 * @param serverSelectionTimeout in msec.
 	 */
@@ -275,7 +276,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 		MongoClientOptions.Builder builder = MongoClientOptions.builder();
 
-		if (MongoClientVersion.isMongo3Driver() && serverSelectionTimeout > 0) {
+		if (MongoClientVersion.isMongo3Driver() && serverSelectionTimeout != Integer.MIN_VALUE) {
 			new DirectFieldAccessor(builder).setPropertyValue("serverSelectionTimeout", serverSelectionTimeout);
 		}
 

--- a/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
@@ -7,4 +7,5 @@ http\://www.springframework.org/schema/data/mongo/spring-mongo-1.5.xsd=org/sprin
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.7.xsd=org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.8.xsd=org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.10.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
-http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo-1.10.2.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
@@ -1,0 +1,901 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="http://www.springframework.org/schema/data/mongo"
+						xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+						xmlns:beans="http://www.springframework.org/schema/beans"
+						xmlns:tool="http://www.springframework.org/schema/tool"
+						xmlns:context="http://www.springframework.org/schema/context"
+						xmlns:repository="http://www.springframework.org/schema/data/repository"
+						targetNamespace="http://www.springframework.org/schema/data/mongo"
+						elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/context" />
+	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
+				schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+
+	<xsd:element name="mongo" type="mongoType">
+		<xsd:annotation>
+			<xsd:documentation source="org.springframework.data.mongodb.core.MongoFactoryBean"><![CDATA[
+Deprecated since 1.7 - use mongo-client instead. Defines a Mongo instance used for accessing MongoDB.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.mongodb.Mongo"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="mongo-client" type="mongoClientType">
+	  <xsd:annotation>
+		<xsd:documentation source="org.springframework.data.mongodb.core.MongoClientFactoryBean"><![CDATA[
+Defines a MongoClient instance used for accessing MongoDB.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.mongodb.MongoClient"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="db-factory">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongo instance. If not configured a default com.mongodb.Mongo instance will be created.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="dbname" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the database to connect to. Default is 'db'.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="authentication-dbname" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Deprecated since 1.7 - Please use MongoClient internal authentication. The name of the authentication database to connect to. Default is 'db'.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The port to connect to MongoDB server. Default is 27017
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Deprecated since 1.7 - Please use MongoClient internal authentication. The username to use when connecting to a MongoDB server.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Deprecated since 1.7 - Please use MongoClient internal authentication. The password to use when connecting to a MongoDB server.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="uri" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Deprecated since 1.8 - Please use client-uri instead. The Mongo URI string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="client-uri" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The MongoClientURI string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="mongo-repository-attributes">
+		<xsd:attribute name="mongo-template-ref" type="mongoTemplateRef" default="mongoTemplate">
+			<xsd:annotation>
+				<xsd:documentation>
+					The reference to a MongoTemplate. Will default to 'mongoTemplate'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="create-query-indexes" default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Enables creation of indexes for queries that get derived from the method name
+					and thus reference domain class properties. Defaults to false.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:element name="repositories">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="repository:repositories">
+					<xsd:attributeGroup ref="mongo-repository-attributes"/>
+					<xsd:attributeGroup ref="repository:repository-attributes"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mapping-converter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[Defines a MongoConverter for getting rich mapping functionality.]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:exports type="org.springframework.data.mongodb.core.convert.MappingMongoConverter" />
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="custom-converters" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+		Top-level element that contains one or more custom converters to be used for mapping
+		domain objects to and from Mongo's DBObject]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="converter" type="customConverterType" minOccurs="0" maxOccurs="unbounded"/>
+						</xsd:sequence>
+						<xsd:attribute name="base-package" type="xsd:string" />
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MappingMongoConverter instance (by default "mappingConverter").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="base-package" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The base package in which to scan for entities annotated with @Document
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="type-mapper-ref" type="typeMapperRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a MongoTypeMapper to be used by this MappingMongoConverter.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mapping.model.MappingContext">
+						The reference to a MappingContext. Will default to 'mappingContext'.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="disable-validation" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener">
+						Disables JSR-303 validation on MongoDB documents before they are saved. By default it is set to false.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="abbreviate-field-names" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.CamelCaseAbbreviatingFieldNamingStrategy">
+						Enables abbreviating the field names for domain class properties to the
+						first character of their camel case names, e.g. fooBar -> fb. Defaults to false.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="field-naming-strategy-ref" type="fieldNamingStrategyRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.FieldNamingStrategy">
+						The reference to a FieldNamingStrategy.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="jmx">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a JMX Model MBeans for monitoring a MongoDB server'.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the Mongo object that determines what server to monitor. (by default "mongo").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="auditing">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.data.mongodb.core.mapping.event.AuditingEventListener" />
+					<tool:exports type="org.springframework.data.auditing.IsNewAwareAuditingHandler" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="repository:auditing-attributes" />
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="typeMapperRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoTypeMapper"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mappingContextRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mapping.model.MappingContext"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="fieldNamingStrategyRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.mapping.FieldNamingStrategy"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoTemplateRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.MongoTemplate"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.MongoFactoryBean"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="sslSocketFactoryRef">
+	<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="javax.net.ssl.SSLSocketFactory"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="writeConcernEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="NONE" />
+			<xsd:enumeration value="NORMAL" />
+			<xsd:enumeration value="SAFE" />
+			<xsd:enumeration value="FSYNC_SAFE" />
+			<xsd:enumeration value="REPLICAS_SAFE" />
+			<xsd:enumeration value="JOURNAL_SAFE" />
+			<xsd:enumeration value="MAJORITY" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="readPreferenceEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="PRIMARY" />
+			<xsd:enumeration value="PRIMARY_PREFERRED" />
+			<xsd:enumeration value="SECONDARY" />
+			<xsd:enumeration value="SECONDARY_PREFERRED" />
+			<xsd:enumeration value="NEAREST" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="booleanType">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="true" />
+			<xsd:enumeration value="false" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="mongoType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Deprecated since 1.7.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence minOccurs="0" maxOccurs="1">
+			<xsd:element name="options" type="optionsType">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The Mongo driver options
+							]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation>
+							<tool:exports type="com.mongodb.MongoOptions"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		<!-- MLP
+		<xsd:attributeGroup ref="writeConcern" />
+		-->
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongo").]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="port" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The port to connect to MongoDB server.  Default is 27017
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="host" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replica-set" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of host:port entries to use for replica set/pairs.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="optionsType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Deprecated since 1.7.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="threads-allowed-to-block-for-connection-multiplier" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-wait-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout in milliseconds. 0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout.  0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-keep-alive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-connect-retry" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls whether or not on a connect, the system retries automatically.  Default is false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-number" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This specifies the number of servers to wait for on the write operation, and exception raising behavior.  The 'w' option to the getlasterror command.  Defaults to 0.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls timeout for write operations in milliseconds.  The 'wtimeout' option to the getlasterror command.  Defaults to 0 (indefinite).  Greater than zero is number of milliseconds to wait.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="write-fsync" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="slave-ok" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ssl" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver should us an SSL connection.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="mongoClientType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClient' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence minOccurs="0" maxOccurs="1">
+			<xsd:element name="client-options" type="clientOptionsType">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The Mongo driver options
+							]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation>
+							<tool:exports type="com.mongodb.MongoClientOptions"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoClient").]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="port" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The port to connect to MongoDB server.  Default is 27017
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="host" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replica-set" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of host:port entries to use for replica set/pairs.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="credentials" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of username:password@database entries to use for authentication. Appending ?uri.authMechanism allows to specify the authentication challenge mechanism. If the credential you're trying to pass contains a comma itself, quote it with single quotes: '…'.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="clientOptionsType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClientOptions' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="description" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The MongoClient description.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The minimum number of connections per host.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="threads-allowed-to-block-for-connection-multiplier" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-wait-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes).
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-connection-idle-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum idle time for a pooled connection.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-connection-life-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum life time for a pooled connection.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout in milliseconds. 0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout.  0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-keep-alive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="server-selection-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The server selection timeout in milliseconds, which defines how long the driver will wait for server selection to succeed before throwing an exception. Default is 30 seconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="read-preference">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The read preference.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="readPreferenceEnumeration xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="write-concern">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-frequency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This is the frequency that the driver will attempt to determine the current state of each server in the cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-heartbeat-frequency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout for connections used for the cluster heartbeat.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout for connections used for the cluster heartbeat.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ssl" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver should us an SSL connection.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:group name="beanElementGroup">
+		<xsd:choice>
+			<xsd:element ref="beans:bean"/>
+			<xsd:element ref="beans:ref"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:complexType name="customConverterType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Element defining a custom converter.
+	]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="beanElementGroup" minOccurs="0" maxOccurs="1"/>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					A reference to a custom converter.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref"/>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:simpleType name="converterRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongoconverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string"
+				use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="gridFsTemplate">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the mongo definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a Mongoconverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="bucket" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The GridFs bucket string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoClientParserIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoClientParserIntegrationTests.java
@@ -39,7 +39,7 @@ import com.mongodb.WriteConcern;
 
 /**
  * Integration tests for {@link MongoClientParser}.
- * 
+ *
  * @author Christoph Strobl
  */
 public class MongoClientParserIntegrationTests {
@@ -118,7 +118,7 @@ public class MongoClientParserIntegrationTests {
 	}
 
 	@Test // DATAMONGO-1620
-	public void createsMongoClinetWithServerSelectionTimeoutCorrectly() {
+	public void createsMongoClientWithServerSelectionTimeoutCorrectly() {
 
 		assumeThat(MongoClientVersion.isMongo3Driver(), is(true));
 

--- a/spring-data-mongodb/src/test/resources/namespace/mongoClient-bean.xml
+++ b/spring-data-mongodb/src/test/resources/namespace/mongoClient-bean.xml
@@ -15,4 +15,9 @@
 	
 	<mongo:mongo-client />
 
+	<!-- DATAMONGO-1620 -->
+	<mongo:mongo-client id="mongo-client-with-server-selection-timeout">
+		<mongo:client-options server-selection-timeout="100" />
+	</mongo:mongo-client>
+
 </beans>


### PR DESCRIPTION
This change allows in combination with a MongoDB Java Driver `3.x` setting the `serverSelectionTimeout` on `MongoClientOptions` via the  `server-selection-timeout` XML attribute.

The attribute is ignored when set using a `2.x` MongoDB driver. 

This change should be ported to  `1.10.x` (the namespace xsd (1.10.2) is already set up for it).
For `2.x` the `server-selection-timeout` should be added leaving out the reflection fluff required in `MongoClientOptionsFactoryBean` for`1.x`.