### PR TITLE
DATAMONGO-1645 - Safely serialize JSON output for log message in LoggingEventListener.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.11.0.BUILD-SNAPSHOT</version>
+			<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.11.0.BUILD-SNAPSHOT</version>
+		<version>1.11.0.DATAMONGO-1645-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.mongodb.core.mapping.event;
 
+import static org.springframework.data.mongodb.core.query.SerializationUtils.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -25,6 +27,7 @@ import org.springframework.context.ApplicationListener;
  * @author Jon Brisbin
  * @author Martin Baumgartner
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 
@@ -45,7 +48,7 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onBeforeSave(BeforeSaveEvent<Object> event) {
-		LOGGER.info("onBeforeSave: {}, {}", event.getSource(), event.getDBObject());
+		LOGGER.info("onBeforeSave: {}, {}", event.getSource(), serializeToJsonSafely(event.getDBObject()));
 	}
 
 	/* 
@@ -54,7 +57,7 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onAfterSave(AfterSaveEvent<Object> event) {
-		LOGGER.info("onAfterSave: {}, {}", event.getSource(), event.getDBObject());
+		LOGGER.info("onAfterSave: {}, {}", event.getSource(), serializeToJsonSafely(event.getDBObject()));
 	}
 
 	/* 
@@ -63,7 +66,7 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onAfterLoad(AfterLoadEvent<Object> event) {
-		LOGGER.info("onAfterLoad: {}", event.getDBObject());
+		LOGGER.info("onAfterLoad: {}", serializeToJsonSafely(event.getDBObject()));
 	}
 
 	/* 
@@ -72,7 +75,7 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onAfterConvert(AfterConvertEvent<Object> event) {
-		LOGGER.info("onAfterConvert: {}, {}", event.getDBObject(), event.getSource());
+		LOGGER.info("onAfterConvert: {}, {}", serializeToJsonSafely(event.getDBObject()), event.getSource());
 	}
 
 	/* 
@@ -81,7 +84,7 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onAfterDelete(AfterDeleteEvent<Object> event) {
-		LOGGER.info("onAfterDelete: {}", event.getDBObject());
+		LOGGER.info("onAfterDelete: {}", serializeToJsonSafely(event.getDBObject()));
 	}
 
 	/* 
@@ -90,6 +93,6 @@ public class LoggingEventListener extends AbstractMongoEventListener<Object> {
 	 */
 	@Override
 	public void onBeforeDelete(BeforeDeleteEvent<Object> event) {
-		LOGGER.info("onBeforeDelete: {}", event.getDBObject());
+		LOGGER.info("onBeforeDelete: {}", serializeToJsonSafely(event.getDBObject()));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import static org.hamcrest.core.StringStartsWith.*;
+import static org.junit.Assert.*;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.BasicDBObject;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LoggingEventListenerTests {
+
+	LoggingEventListener listener;
+	ListAppender<ILoggingEvent> appender;
+
+	@Before
+	public void setUp() {
+
+		// set log level for LoggingEventListener to "info" and set up an appender capturing events.
+		ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
+				.getLogger(LoggingEventListener.class);
+		logger.setLevel(Level.toLevel("info"));
+
+		appender = new ListAppender();
+		logger.addAppender(appender);
+		appender.start();
+
+		listener = new LoggingEventListener();
+	}
+
+	@Test // DATAMONGO-1645
+	public void shouldSerializeAfterConvertEventCorrectly() {
+
+		listener.onAfterConvert(new AfterConvertEvent<Object>(new BasicDBObject("foo", new Foo()), this, "collection"));
+
+		assertThat(appender.list.get(0).getFormattedMessage(), startsWith("onAfterConvert: { \"foo\""));
+	}
+
+	@Test // DATAMONGO-1645
+	public void shouldSerializeBeforeSaveEventEventCorrectly() {
+
+		listener.onBeforeSave(new BeforeSaveEvent<Object>(new Foo(), new BasicDBObject("foo", new Foo()), "collection"));
+
+		assertThat(appender.list.get(0).getFormattedMessage(),
+				startsWith("onBeforeSave: org.springframework.data.mongodb.core."));
+	}
+
+	@Test // DATAMONGO-1645
+	public void shouldSerializeAfterSaveEventEventCorrectly() {
+
+		listener.onAfterSave(new AfterSaveEvent<Object>(new Foo(), new BasicDBObject("foo", new Foo()), "collection"));
+
+		assertThat(appender.list.get(0).getFormattedMessage(),
+				startsWith("onAfterSave: org.springframework.data.mongodb.core."));
+	}
+
+	@Test // DATAMONGO-1645
+	public void shouldSerializeBeforeDeleteEventEventCorrectly() {
+
+		listener
+				.onBeforeDelete(new BeforeDeleteEvent<Object>(new BasicDBObject("foo", new Foo()), Object.class, "collection"));
+
+		assertThat(appender.list.get(0).getFormattedMessage(), startsWith("onBeforeDelete: { \"foo\""));
+	}
+
+	@Test // DATAMONGO-1645
+	public void shouldSerializeAfterDeleteEventEventCorrectly() {
+
+		listener
+				.onAfterDelete(new AfterDeleteEvent<Object>(new BasicDBObject("foo", new Foo()), Object.class, "collection"));
+
+		assertThat(appender.list.get(0).getFormattedMessage(), startsWith("onAfterDelete: { \"foo\""));
+	}
+
+	static class Foo {
+
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
@@ -22,6 +22,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -29,26 +30,40 @@ import org.slf4j.LoggerFactory;
 import com.mongodb.BasicDBObject;
 
 /**
+ * Tests for {@link LoggingEventListener}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LoggingEventListenerTests {
 
 	LoggingEventListener listener;
-	ListAppender<ILoggingEvent> appender;
+	ch.qos.logback.classic.Logger logger;
+	ListAppender<ILoggingEvent> appender = new ListAppender<ILoggingEvent>();
 
 	@Before
 	public void setUp() {
 
 		// set log level for LoggingEventListener to "info" and set up an appender capturing events.
-		ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
-				.getLogger(LoggingEventListener.class);
-		logger.setLevel(Level.toLevel("info"));
+		logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LoggingEventListener.class);
+		logger.setLevel(Level.INFO);
 
-		appender = new ListAppender();
 		logger.addAppender(appender);
 		appender.start();
 
 		listener = new LoggingEventListener();
+	}
+
+	@After
+	public void tearDown() {
+
+		// cleanup
+		if (logger != null) {
+			logger.detachAppender(appender);
+			logger.setLevel(null);
+		}
+
+		appender.stop();
 	}
 
 	@Test // DATAMONGO-1645
@@ -98,5 +113,4 @@ public class LoggingEventListenerTests {
 	static class Foo {
 
 	}
-
 }


### PR DESCRIPTION
We now make sure to safely serialize JSON output for mapped documents. This prevents the logger from rendering false exception messages to log appender.