### PR TITLE
DATAMONGO-1325 Add support for $sample to aggregation.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -53,6 +53,7 @@ import com.mongodb.DBObject;
  * @author Alessio Fachechi
  * @author Christoph Strobl
  * @author Nikolay Bogdanov
+ * @author Gustavo de Geus
  * @since 1.3
  */
 public class Aggregation {
@@ -387,7 +388,7 @@ public class Aggregation {
 	/**
 	 * Creates a new {@link SampleOperation} to selects the specified number of documents from its input randomly.
 	 *
-	 * @param maxElements must not be less than zero.
+	 * @param sampleSize must not be less than zero.
 	 * @return
 	 */
 	public static SampleOperation sample(long sampleSize) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -385,6 +385,16 @@ public class Aggregation {
 	}
 
 	/**
+	 * Creates a new {@link SampleOperation} to selects the specified number of documents from its input randomly.
+	 *
+	 * @param maxElements must not be less than zero.
+	 * @return
+	 */
+	public static SampleOperation sample(long sampleSize) {
+		return new SampleOperation(sampleSize);
+	}
+	
+	/**
 	 * Creates a new {@link MatchOperation} using the given {@link Criteria}.
 	 *
 	 * @param criteria must not be {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/SampleOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/SampleOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import org.springframework.util.Assert;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Encapsulates the {@code $sample}-operation.
+ * <p>
+ * We recommend to use the static factory method {@link Aggregation#sample(long)} instead of creating instances of this
+ * class directly.
+ * 
+ * @author Gustavo de Geus
+ * @since 2.0
+ * @see <a href="https://docs.mongodb.com/master/reference/operator/aggregation/sample/">MongoDB Aggregation Framework: $sample</a>
+ */
+public class SampleOperation implements AggregationOperation {
+
+	private final long sampleSize;
+
+	/**
+	 * @param sampleSize Number of documents to consider.
+	 */
+	public SampleOperation(long sampleSize) {
+
+		Assert.isTrue(sampleSize > 0, "Sample size must be greater than zero!");
+		this.sampleSize = sampleSize;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperation#toDBObject(org.springframework.data.mongodb.core.aggregation.AggregationOperationContext)
+	 */
+	@Override
+	public DBObject toDBObject(AggregationOperationContext context) {
+		return new BasicDBObject("$sample", new BasicDBObject("size", this.sampleSize));
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/SampleOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/SampleOperation.java
@@ -35,7 +35,7 @@ public class SampleOperation implements AggregationOperation {
 	private final long sampleSize;
 
 	/**
-	 * @param sampleSize Number of documents to consider.
+	 * @param sampleSize number of documents to be randomly selected from its input.
 	 */
 	public SampleOperation(long sampleSize) {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SampleOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SampleOperationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SampleOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SampleOperationUnitTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Unit tests for {@link SampleOperation}.
+ * 
+ * @author Gustavo de Geus
+ */
+public class SampleOperationUnitTests {
+
+	private static final String SIZE = "size";
+	private static final String OP = "$sample";
+
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsNegativeSample() {
+		new SampleOperation(-1L);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsZeroSample() {
+		new SampleOperation(0L);
+	}
+	
+	@Test
+	public void rendersSampleOperation() {
+		long sampleSize = 5L;
+		SampleOperation sampleOperation = Aggregation.sample(sampleSize);
+		DBObject sampleOperationDbObject = sampleOperation.toDBObject(Aggregation.DEFAULT_CONTEXT);
+		assertNotNull(sampleOperationDbObject.get(OP));
+		assertThat(sampleOperationDbObject.get(OP), is(instanceOf(BasicDBObject.class)));
+		BasicDBObject sampleSizeDbObject = (BasicDBObject) sampleOperationDbObject.get(OP);
+		assertEquals(sampleSize, sampleSizeDbObject.get(SIZE));
+	}
+}


### PR DESCRIPTION
Added [$sample](https://docs.mongodb.com/master/reference/operator/aggregation/sample/) aggregation operator.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
