### PR TITLE
DATAMONGO-1666 - Consider collection type in bulk DBRef fetching.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1666-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -31,6 +31,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -55,7 +56,6 @@ import org.springframework.data.mapping.model.SpELContext;
 import org.springframework.data.mapping.model.SpELExpressionEvaluator;
 import org.springframework.data.mapping.model.SpELExpressionParameterValueProvider;
 import org.springframework.data.mongodb.MongoDbFactory;
-import org.springframework.data.mongodb.core.convert.MongoConverters.ObjectIdToBigIntegerConverter;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
@@ -241,10 +241,9 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		}
 		// Retrieve persistent entity info
 
-		Document target = bson instanceof BasicDBObject ? new Document((BasicDBObject)bson) : (Document) bson;
+		Document target = bson instanceof BasicDBObject ? new Document((BasicDBObject) bson) : (Document) bson;
 
-		return read((MongoPersistentEntity<S>) mappingContext.getRequiredPersistentEntity(typeToUse), target,
-				path);
+		return read((MongoPersistentEntity<S>) mappingContext.getRequiredPersistentEntity(typeToUse), target, path);
 	}
 
 	private ParameterValueProvider<MongoPersistentProperty> getParameterProvider(MongoPersistentEntity<?> entity,
@@ -870,7 +869,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			}
 
 			return dbRefResolver.createDbRef(property == null ? null : property.getDBRef(), entity,
-					idMapper.convertId(id instanceof Optional ? (Optional)id : Optional.ofNullable(id)).orElse(null));
+					idMapper.convertId(id instanceof Optional ? (Optional) id : Optional.ofNullable(id)).orElse(null));
 
 		}).orElseThrow(() -> new MappingException("No id property found on class " + entity.getType()));
 	}
@@ -913,7 +912,10 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		}
 
 		if (!DBRef.class.equals(rawComponentType) && isCollectionOfDbRefWhereBulkFetchIsPossible(sourceValue)) {
-			return bulkReadAndConvertDBRefs((List<DBRef>) (List) (sourceValue), componentType, path, rawComponentType);
+
+			List<Object> objects = bulkReadAndConvertDBRefs((List<DBRef>) sourceValue, componentType, path,
+					rawComponentType);
+			return getPotentiallyConvertedSimpleRead(objects, targetType.getType());
 		}
 
 		for (Object dbObjItem : sourceValue) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -40,7 +41,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.annotation.AccessType;
 import org.springframework.data.annotation.AccessType.Type;
 import org.springframework.data.annotation.Id;
@@ -95,7 +95,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		person.id = "foo";
 
 		DBRef dbRef = converter.toDBRef(person, null);
-		assertThat(dbRef.getId(), is((Object) "foo"));
+		assertThat(dbRef.getId(), is("foo"));
 		assertThat(dbRef.getCollectionName(), is("person"));
 	}
 
@@ -127,7 +127,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		MapDBRefVal val = new MapDBRefVal();
 		val.id = BigInteger.ONE;
 
-		Map<String, MapDBRefVal> mapVal = new HashMap<String, MapDBRefVal>();
+		Map<String, MapDBRefVal> mapVal = new HashMap<>();
 		mapVal.put("test", val);
 
 		mapDBRef.map = mapVal;
@@ -156,7 +156,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		person.id = "foo";
 
 		DBRef dbRef = converter.toDBRef(person, property);
-		assertThat(dbRef.getId(), is((Object) "foo"));
+		assertThat(dbRef.getId(), is("foo"));
 		assertThat(dbRef.getCollectionName(), is("person"));
 	}
 
@@ -166,11 +166,11 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
-		lazyDbRefs.dbRefToInterface = new LinkedList<LazyDbRefTarget>(Arrays.asList(new LazyDbRefTarget("1")));
+		lazyDbRefs.dbRefToInterface = new LinkedList<>(Collections.singletonList(new LazyDbRefTarget("1")));
 		converterSpy.write(lazyDbRefs, document);
 
 		ClassWithLazyDbRefs result = converterSpy.read(ClassWithLazyDbRefs.class, document);
@@ -187,12 +187,11 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
-		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<LazyDbRefTarget>(
-				Arrays.asList(new LazyDbRefTarget(id, value)));
+		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<>(Collections.singletonList(new LazyDbRefTarget(id, value)));
 		converterSpy.write(lazyDbRefs, document);
 
 		ClassWithLazyDbRefs result = converterSpy.read(ClassWithLazyDbRefs.class, document);
@@ -209,7 +208,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
@@ -230,12 +229,11 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
-		lazyDbRefs.dbRefToConcreteTypeWithPersistenceConstructor = new LazyDbRefTargetWithPeristenceConstructor((Object) id,
-				(Object) value);
+		lazyDbRefs.dbRefToConcreteTypeWithPersistenceConstructor = new LazyDbRefTargetWithPeristenceConstructor(id, value);
 		converterSpy.write(lazyDbRefs, document);
 
 		ClassWithLazyDbRefs result = converterSpy.read(ClassWithLazyDbRefs.class, document);
@@ -252,12 +250,12 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
 		lazyDbRefs.dbRefToConcreteTypeWithPersistenceConstructorWithoutDefaultConstructor = new LazyDbRefTargetWithPeristenceConstructorWithoutDefaultConstructor(
-				(Object) id, (Object) value);
+				id, value);
 		converterSpy.write(lazyDbRefs, document);
 
 		ClassWithLazyDbRefs result = converterSpy.read(ClassWithLazyDbRefs.class, document);
@@ -274,7 +272,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		SerializableClassWithLazyDbRefs lazyDbRefs = new SerializableClassWithLazyDbRefs();
@@ -296,7 +294,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		WithObjectMethodOverrideLazyDbRefs lazyDbRefs = new WithObjectMethodOverrideLazyDbRefs();
@@ -317,7 +315,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		WithObjectMethodOverrideLazyDbRefs lazyDbRefs = new WithObjectMethodOverrideLazyDbRefs();
@@ -393,7 +391,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		String id = "42";
 		String value = "bubu";
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef((DBRef) any());
+		doReturn(new Document("_id", id).append("value", value)).when(converterSpy).readRef(any());
 
 		Document document = new Document();
 		WithObjectMethodOverrideLazyDbRefs lazyDbRefs = new WithObjectMethodOverrideLazyDbRefs();
@@ -537,11 +535,11 @@ public class DbRefMappingMongoConverterUnitTests {
 		MappingMongoConverter converterSpy = spy(converter);
 		doReturn(
 				Arrays.asList(new Document("_id", id1).append("value", value), new Document("_id", id2).append("value", value)))
-						.when(converterSpy).bulkReadRefs(anyListOf(DBRef.class));
+						.when(converterSpy).bulkReadRefs(anyList());
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
-		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<LazyDbRefTarget>(
+		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<>(
 				Arrays.asList(new LazyDbRefTarget(id1, value), new LazyDbRefTarget(id2, value)));
 		converterSpy.write(lazyDbRefs, document);
 
@@ -565,7 +563,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		MappingMongoConverter converterSpy = spy(converter);
 		doReturn(
 				Arrays.asList(new Document("_id", id1).append("value", value), new Document("_id", id2).append("value", value)))
-						.when(converterSpy).bulkReadRefs(any());
+						.when(converterSpy).bulkReadRefs(anyList());
 
 		Document document = new Document("dbRefToInterface",
 				Arrays.asList(new DBRef("lazyDbRefTarget", "1"), new DBRef("lazyDbRefTarget", "2")));
@@ -590,7 +588,7 @@ public class DbRefMappingMongoConverterUnitTests {
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
-		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<LazyDbRefTarget>(
+		lazyDbRefs.dbRefToConcreteCollection = new ArrayList<>(
 				Arrays.asList(new LazyDbRefTarget(id1, value), new SerializableLazyDbRefTarget(id2, value)));
 		converterSpy.write(lazyDbRefs, document);
 
@@ -602,7 +600,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		assertThat(result.dbRefToConcreteCollection.get(1).getId(), is(id2));
 
 		verify(converterSpy, times(2)).readRef(Mockito.any(DBRef.class));
-		verify(converterSpy, never()).bulkReadRefs(anyListOf(DBRef.class));
+		verify(converterSpy, never()).bulkReadRefs(anyList());
 	}
 
 	@Test // DATAMONGO-1194
@@ -616,11 +614,11 @@ public class DbRefMappingMongoConverterUnitTests {
 
 		MappingMongoConverter converterSpy = spy(converter);
 		doReturn(Arrays.asList(new Document("_id", val1.id), new Document("_id", val2.id))).when(converterSpy)
-				.bulkReadRefs(anyListOf(DBRef.class));
+				.bulkReadRefs(anyList());
 
 		Document document = new Document();
 		MapDBRef mapDBRef = new MapDBRef();
-		mapDBRef.map = new LinkedHashMap<String, MapDBRefVal>();
+		mapDBRef.map = new LinkedHashMap<>();
 		mapDBRef.map.put("one", val1);
 		mapDBRef.map.put("two", val2);
 
@@ -633,7 +631,7 @@ public class DbRefMappingMongoConverterUnitTests {
 		// assertProxyIsResolved(result.map, true);
 		assertThat(result.map.get("two").id, is(val2.id));
 
-		verify(converterSpy, times(1)).bulkReadRefs(anyListOf(DBRef.class));
+		verify(converterSpy, times(1)).bulkReadRefs(anyList());
 		verify(converterSpy, never()).readRef(Mockito.any(DBRef.class));
 	}
 
@@ -648,11 +646,11 @@ public class DbRefMappingMongoConverterUnitTests {
 
 		MappingMongoConverter converterSpy = spy(converter);
 		doReturn(Arrays.asList(new Document("_id", val1.id), new Document("_id", val2.id))).when(converterSpy)
-				.bulkReadRefs(anyListOf(DBRef.class));
+				.bulkReadRefs(anyList());
 
 		Document document = new Document();
 		MapDBRef mapDBRef = new MapDBRef();
-		mapDBRef.lazyMap = new LinkedHashMap<String, MapDBRefVal>();
+		mapDBRef.lazyMap = new LinkedHashMap<>();
 		mapDBRef.lazyMap.put("one", val1);
 		mapDBRef.lazyMap.put("two", val2);
 
@@ -665,8 +663,8 @@ public class DbRefMappingMongoConverterUnitTests {
 		assertProxyIsResolved(result.lazyMap, true);
 		assertThat(result.lazyMap.get("two").id, is(val2.id));
 
-		verify(converterSpy, times(1)).bulkReadRefs(anyListOf(DBRef.class));
-		verify(converterSpy, never()).readRef(Mockito.any(DBRef.class));
+		verify(converterSpy, times(1)).bulkReadRefs(anyList());
+		verify(converterSpy, never()).readRef(any());
 	}
 
 	private Object transport(Object result) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/DbRefMappingMongoConverterUnitTests.java
@@ -29,19 +29,18 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import com.mongodb.BasicDBObject;
-import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.data.annotation.AccessType;
 import org.springframework.data.annotation.AccessType.Type;
 import org.springframework.data.annotation.Id;
@@ -65,7 +64,7 @@ import com.mongodb.client.MongoDatabase;
 
 /**
  * Unit tests for {@link DbRefMappingMongoConverter}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
@@ -485,7 +484,8 @@ public class DbRefMappingMongoConverterUnitTests {
 		ClassWithLazyDbRefs result = converter.read(ClassWithLazyDbRefs.class, object);
 
 		PersistentPropertyAccessor accessor = propertyEntity.getPropertyAccessor(result.dbRefToConcreteType);
-		MongoPersistentProperty idProperty = mappingContext.getRequiredPersistentEntity(LazyDbRefTarget.class).getIdProperty().get();
+		MongoPersistentProperty idProperty = mappingContext.getRequiredPersistentEntity(LazyDbRefTarget.class)
+				.getIdProperty().get();
 
 		assertThat(accessor.getProperty(idProperty), is(notNullValue()));
 		assertProxyIsResolved(result.dbRefToConcreteType, false);
@@ -512,7 +512,8 @@ public class DbRefMappingMongoConverterUnitTests {
 	@Test // DATAMONGO-1076
 	public void shouldNotTriggerResolvingOfLazyLoadedProxyWhenFinalizeMethodIsInvoked() throws Exception {
 
-		MongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(WithObjectMethodOverrideLazyDbRefs.class);
+		MongoPersistentEntity<?> entity = mappingContext
+				.getRequiredPersistentEntity(WithObjectMethodOverrideLazyDbRefs.class);
 		MongoPersistentProperty property = entity.getRequiredPersistentProperty("dbRefToPlainObject");
 
 		String idValue = new ObjectId().toString();
@@ -534,8 +535,9 @@ public class DbRefMappingMongoConverterUnitTests {
 		String value = "val";
 
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(Arrays.asList(new Document("_id", id1).append("value", value),
-				new Document("_id", id2).append("value", value))).when(converterSpy).bulkReadRefs(anyListOf(DBRef.class));
+		doReturn(
+				Arrays.asList(new Document("_id", id1).append("value", value), new Document("_id", id2).append("value", value)))
+						.when(converterSpy).bulkReadRefs(anyListOf(DBRef.class));
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
@@ -553,6 +555,28 @@ public class DbRefMappingMongoConverterUnitTests {
 		verify(converterSpy, never()).readRef(Mockito.any(DBRef.class));
 	}
 
+	@Test // DATAMONGO-1666
+	public void shouldBulkFetchSetOfReferencesForConstructorCreation() {
+
+		String id1 = "1";
+		String id2 = "2";
+		String value = "val";
+
+		MappingMongoConverter converterSpy = spy(converter);
+		doReturn(
+				Arrays.asList(new Document("_id", id1).append("value", value), new Document("_id", id2).append("value", value)))
+						.when(converterSpy).bulkReadRefs(any());
+
+		Document document = new Document("dbRefToInterface",
+				Arrays.asList(new DBRef("lazyDbRefTarget", "1"), new DBRef("lazyDbRefTarget", "2")));
+
+		ClassWithDbRefSetConstructor result = converterSpy.read(ClassWithDbRefSetConstructor.class, document);
+
+		assertThat(result.dbRefToInterface, is(instanceOf(Set.class)));
+
+		verify(converterSpy, never()).readRef(Mockito.any(DBRef.class));
+	}
+
 	@Test // DATAMONGO-1194
 	public void shouldFallbackToOneByOneFetchingWhenElementsInListOfReferencesPointToDifferentCollections() {
 
@@ -561,9 +585,8 @@ public class DbRefMappingMongoConverterUnitTests {
 		String value = "val";
 
 		MappingMongoConverter converterSpy = spy(converter);
-		doReturn(new Document("_id", id1).append("value", value))
-				.doReturn(new Document("_id", id2).append("value", value)).when(converterSpy)
-				.readRef(Mockito.any(DBRef.class));
+		doReturn(new Document("_id", id1).append("value", value)).doReturn(new Document("_id", id2).append("value", value))
+				.when(converterSpy).readRef(Mockito.any(DBRef.class));
 
 		Document document = new Document();
 		ClassWithLazyDbRefs lazyDbRefs = new ClassWithLazyDbRefs();
@@ -678,6 +701,15 @@ public class DbRefMappingMongoConverterUnitTests {
 				lazy = true) LazyDbRefTargetWithPeristenceConstructorWithoutDefaultConstructor dbRefToConcreteTypeWithPersistenceConstructorWithoutDefaultConstructor;
 	}
 
+	static class ClassWithDbRefSetConstructor {
+
+		final @org.springframework.data.mongodb.core.mapping.DBRef Set<LazyDbRefTarget> dbRefToInterface;
+
+		public ClassWithDbRefSetConstructor(Set<LazyDbRefTarget> dbRefToInterface) {
+			this.dbRefToInterface = dbRefToInterface;
+		}
+	}
+
 	static class SerializableClassWithLazyDbRefs implements Serializable {
 
 		private static final long serialVersionUID = 1L;
@@ -785,7 +817,7 @@ public class DbRefMappingMongoConverterUnitTests {
 			super(id, value);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see java.lang.Object#toString()
 		 */


### PR DESCRIPTION
We now consider the property's collection type after bulk-fetching DBRefs before returning the actual result value. The issue got only visible if bulk fetching is possible and constructor creation is used. Setting the property value on through an property accessor works fine because the property accessor checks all values for assignability and potentially converts values to their target type. That's different for constructor creation.

---

Related ticket: [DATAMONGO-1666](https://jira.spring.io/browse/DATAMONGO-1666).