### PR TITLE
DATAMONGO-1518 - Add support for Collation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1518-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/Collation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/Collation.java
@@ -1,0 +1,754 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+
+import com.mongodb.client.model.Collation.Builder;
+import com.mongodb.client.model.CollationAlternate;
+import com.mongodb.client.model.CollationCaseFirst;
+import com.mongodb.client.model.CollationMaxVariable;
+import com.mongodb.client.model.CollationStrength;
+
+/**
+ * Central abstraction for MongoDB collation support. <br />
+ * Allows fluent creation of a collation {@link Document} that can be used for creating collections & indexes as well as
+ * querying data.
+ * <p />
+ * <strong>NOTE:</strong> Please keep in mind that queries will only make use of an index with collation settings if the
+ * query itself specifies the same collation.
+ *
+ * @author Christoph Strobl
+ * @since 2.0
+ * @see <a href="https://docs.mongodb.com/manual/reference/collation/">MongoDB Reference - Collation</a>
+ */
+public class Collation {
+
+	private static final Collation DEFAULT = of("simple");
+
+	private final ICULocale locale;
+
+	private Optional<ICUComparisonLevel> strength = Optional.empty();
+	private Optional<Boolean> numericOrdering = Optional.empty();
+	private Optional<Alternate> alternate = Optional.empty();
+	private Optional<Boolean> backwards = Optional.empty();
+	private Optional<Boolean> normalization = Optional.empty();
+	private Optional<String> version = Optional.empty();
+
+	private Collation(ICULocale locale) {
+
+		Assert.notNull(locale, "ICULocale must not be null!");
+		this.locale = locale;
+	}
+
+	/**
+	 * Create new {@link Collation} using simple binary comparison.
+	 *
+	 * @return
+	 * @see #binary()
+	 */
+	public static Collation simple() {
+		return binary();
+	}
+
+	/**
+	 * Create new {@link Collation} using simple binary comparison.
+	 *
+	 * @return
+	 */
+	public static Collation binary() {
+		return DEFAULT;
+	}
+
+	/**
+	 * Create new {@link Collation} with locale set to {{@link java.util.Locale#getLanguage()}} and
+	 * {@link java.util.Locale#getVariant()}.
+	 *
+	 * @param locale must not be {@literal null}.
+	 * @return
+	 */
+	public static Collation of(Locale locale) {
+
+		Assert.notNull(locale, "Locale must not be null!");
+		return of(ICULocale.of(locale.getLanguage()).variant(locale.getVariant()));
+	}
+
+	/**
+	 * Create new {@link Collation} with locale set to the given ICU language.
+	 *
+	 * @param language must not be {@literal null}.
+	 * @return
+	 */
+	public static Collation of(String language) {
+		return of(ICULocale.of(language));
+	}
+
+	/**
+	 * Create new {@link Collation} with locale set to the given {@link ICULocale}.
+	 *
+	 * @param locale must not be {@literal null}.
+	 * @return
+	 */
+	public static Collation of(ICULocale locale) {
+		return new Collation(locale);
+	}
+
+	/**
+	 * Create new {@link Collation} from values in {@link Document}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/collation/#collation-document">MongoDB Reference -
+	 *      Collation Document</a>
+	 */
+	public static Collation from(Document source) {
+
+		Assert.notNull(source, "Source must not be null!");
+
+		Collation collation = Collation.of(source.getString("locale"));
+		if (source.containsKey("strength")) {
+			collation = collation.strength(source.getInteger("strength"));
+		}
+		if (source.containsKey("caseLevel")) {
+			collation = collation.caseLevel(source.getBoolean("caseLevel"));
+		}
+		if (source.containsKey("caseFirst")) {
+			collation = collation.caseFirst(source.getString("caseFirst"));
+		}
+		if (source.containsKey("numericOrdering")) {
+			collation = collation.numericOrdering(source.getBoolean("numericOrdering"));
+		}
+		if (source.containsKey("alternate")) {
+			collation = collation.alternate(source.getString("alternate"));
+		}
+		if (source.containsKey("maxVariable")) {
+			collation = collation.maxVariable(source.getString("maxVariable"));
+		}
+		if (source.containsKey("backwards")) {
+			collation = collation.backwards(source.getBoolean("backwards"));
+		}
+		if (source.containsKey("normalization")) {
+			collation = collation.normalization(source.getBoolean("normalization"));
+		}
+		if (source.containsKey("version")) {
+			collation.version = Optional.of(source.get("version").toString());
+		}
+		return collation;
+	}
+
+	/**
+	 * Set the level of comparison to perform.
+	 *
+	 * @param strength must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation strength(Integer strength) {
+
+		ICUComparisonLevel current = this.strength.orElseGet(() -> new ICUComparisonLevel(strength, null, null));
+		return strength(new ICUComparisonLevel(strength, current.caseFirst.orElse(null), current.caseLevel.orElse(null)));
+	}
+
+	/**
+	 * Set the level of comparison to perform.
+	 *
+	 * @param comparisonLevel must not be {@literal null}.
+	 * @return new {@link Collation}
+	 */
+	public Collation strength(ICUComparisonLevel comparisonLevel) {
+
+		Collation newInstance = copy();
+		newInstance.strength = Optional.ofNullable(comparisonLevel);
+		return newInstance;
+	}
+
+	/**
+	 * Set {@code caseLevel} comarison. <br />
+	 *
+	 * @param caseLevel must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation caseLevel(Boolean caseLevel) {
+
+		ICUComparisonLevel strengthValue = strength.orElseGet(() -> ICUComparisonLevel.primary());
+		return strength(new ICUComparisonLevel(strengthValue.level, strengthValue.caseFirst.orElse(null), caseLevel));
+	}
+
+	/**
+	 * Set the flag that determines sort order of case differences during tertiary level comparisons.
+	 *
+	 * @param caseFirst must not be {@literal null}.
+	 * @return
+	 */
+	public Collation caseFirst(String caseFirst) {
+		return caseFirst(new ICUCaseFirst(caseFirst));
+	}
+
+	/**
+	 * Set the flag that determines sort order of case differences during tertiary level comparisons.
+	 *
+	 * @param caseFirst must not be {@literal null}.
+	 * @return
+	 */
+	public Collation caseFirst(ICUCaseFirst sort) {
+
+		ICUComparisonLevel strengthValue = strength.orElseGet(() -> ICUComparisonLevel.tertiary());
+		return strength(new ICUComparisonLevel(strengthValue.level, sort, strengthValue.caseLevel.orElse(null)));
+	}
+
+	/**
+	 * Treat numeric strings as numbers for comparison.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation numericOrderingEnabled() {
+		return numericOrdering(true);
+	}
+
+	/**
+	 * Treat numeric strings as string for comparison.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation numericOrderingDisabled() {
+		return numericOrdering(false);
+	}
+
+	/**
+	 * Set the flag that determines whether to compare numeric strings as numbers or as strings.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation numericOrdering(Boolean flag) {
+
+		Collation newInstance = copy();
+		newInstance.numericOrdering = Optional.ofNullable(flag);
+		return newInstance;
+	}
+
+	/**
+	 * Set the Field that determines whether collation should consider whitespace and punctuation as base characters for
+	 * purposes of comparison.
+	 *
+	 * @param alternate must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation alternate(String alternate) {
+
+		Alternate instance = this.alternate.orElseGet(() -> new Alternate(alternate, null));
+		return alternate(new Alternate(alternate, instance.maxVariable.orElse(null)));
+	}
+
+	/**
+	 * Set the Field that determines whether collation should consider whitespace and punctuation as base characters for
+	 * purposes of comparison.
+	 *
+	 * @param alternate must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation alternate(Alternate alternate) {
+
+		Collation newInstance = copy();
+		newInstance.alternate = Optional.ofNullable(alternate);
+		return newInstance;
+	}
+
+	/**
+	 * Sort string with diacritics sort from back of the string.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation backwardDiacriticSort() {
+		return backwards(true);
+	}
+
+	/**
+	 * Do not sort string with diacritics sort from back of the string.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation forwardDiacriticSort() {
+		return backwards(false);
+	}
+
+	/**
+	 * Set the flag that determines whether strings with diacritics sort from back of the string.
+	 *
+	 * @param backwards must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation backwards(Boolean backwards) {
+
+		Collation newInstance = copy();
+		newInstance.backwards = Optional.ofNullable(backwards);
+		return newInstance;
+	}
+
+	/**
+	 * Enable text normalization.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation normalizationEnabled() {
+		return normalization(true);
+	}
+
+	/**
+	 * Disable text normalization.
+	 *
+	 * @return new {@link Collation}.
+	 */
+	public Collation normalizationDisabled() {
+		return normalization(false);
+	}
+
+	/**
+	 * Set the flag that determines whether to check if text require normalization and to perform normalization.
+	 *
+	 * @param normalization must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation normalization(Boolean normalization) {
+
+		Collation newInstance = copy();
+		newInstance.normalization = Optional.ofNullable(normalization);
+		return newInstance;
+	}
+
+	/**
+	 * Set the field that determines up to which characters are considered ignorable when alternate is {@code shifted}.
+	 *
+	 * @param maxVariable must not be {@literal null}.
+	 * @return new {@link Collation}.
+	 */
+	public Collation maxVariable(String maxVariable) {
+
+		Alternate alternateValue = alternate.orElseGet(() -> Alternate.shifted());
+		return alternate(new AlternateWithMaxVariable(alternateValue.alternate, maxVariable));
+	}
+
+	/**
+	 * Get the {@link Document} representation of the {@link Collation}.
+	 *
+	 * @return
+	 */
+	public Document toDocument() {
+		return map(toMongoDocumentConverter());
+	}
+
+	/**
+	 * Get the {@link com.mongodb.client.model.Collation} representation of the {@link Collation}.
+	 *
+	 * @return
+	 */
+	public com.mongodb.client.model.Collation toMongoCollation() {
+		return map(toMongoCollationConverter());
+	}
+
+	public <R> R map(Converter<? super Collation, ? extends R> mapper) {
+		return mapper.convert(this);
+	}
+
+	@Override
+	public String toString() {
+		return toDocument().toJson();
+	}
+
+	private Collation copy() {
+
+		Collation collation = new Collation(locale);
+		collation.strength = this.strength;
+		collation.normalization = this.normalization;
+		collation.numericOrdering = this.numericOrdering;
+		collation.alternate = this.alternate;
+		collation.backwards = this.backwards;
+		return collation;
+	}
+
+	/**
+	 * Abstraction for the ICU Comparison Levels.
+	 *
+	 * @since 2.0
+	 */
+	public static class ICUComparisonLevel {
+
+		protected final Integer level;
+		private final Optional<ICUCaseFirst> caseFirst;
+		private final Optional<Boolean> caseLevel;
+
+		private ICUComparisonLevel(Integer level, ICUCaseFirst caseFirst, Boolean caseLevel) {
+
+			this.level = level;
+			this.caseFirst = Optional.ofNullable(caseFirst);
+			this.caseLevel = Optional.ofNullable(caseLevel);
+		}
+
+		/**
+		 * Primary level of comparison. Collation performs comparisons of the base characters only, ignoring other
+		 * differences such as diacritics and case. <br />
+		 * The {@code caseLevel} can be set via {@link ComparisonLevelWithCase#caseLevel(Boolean)}.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}.
+		 */
+		public static PrimaryICUComparisonLevel primary() {
+			return new PrimaryICUComparisonLevel(1, null);
+		}
+
+		/**
+		 * Scondary level of comparison. Collation performs comparisons up to secondary differences, such as
+		 * diacritics.<br />
+		 * The {@code caseLevel} can be set via {@link ComparisonLevelWithCase#caseLevel(Boolean)}.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}.
+		 */
+		public static SecondaryICUComparisonLevel secondary() {
+			return new SecondaryICUComparisonLevel(2, null);
+		}
+
+		/**
+		 * Tertiary level of comparison. Collation performs comparisons up to tertiary differences, such as case and letter
+		 * variants. <br />
+		 * The {@code caseLevel} cannot be set for {@link ICUComparisonLevel} above {@code secondary}.
+		 *
+		 * @return new {@link ICUComparisonLevel}.
+		 */
+		public static TertiaryICUComparisonLevel tertiary() {
+			return new TertiaryICUComparisonLevel(3, null);
+		}
+
+		/**
+		 * Quaternary Level. Limited for specific use case to consider punctuation. <br />
+		 * The {@code caseLevel} cannot be set for {@link ICUComparisonLevel} above {@code secondary}.
+		 *
+		 * @return new {@link ICUComparisonLevel}.
+		 */
+		public static ICUComparisonLevel quaternary() {
+			return new ICUComparisonLevel(4, null, null);
+		}
+
+		/**
+		 * Identical Level. Limited for specific use case of tie breaker. <br />
+		 * The {@code caseLevel} cannot be set for {@link ICUComparisonLevel} above {@code secondary}.
+		 *
+		 * @return new {@link ICUComparisonLevel}.
+		 */
+		public static ICUComparisonLevel identical() {
+			return new ICUComparisonLevel(5, null, null);
+		}
+	}
+
+	public static class TertiaryICUComparisonLevel extends ICUComparisonLevel {
+
+		private TertiaryICUComparisonLevel(Integer level, ICUCaseFirst caseFirst) {
+			super(level, caseFirst, null);
+		}
+
+		/**
+		 * Set the flag that determines sort order of case differences.
+		 *
+		 * @param caseFirstSort must not be {@literal null}.
+		 * @return
+		 */
+		public TertiaryICUComparisonLevel caseFirst(ICUCaseFirst caseFirst) {
+
+			Assert.notNull(caseFirst, "CaseFirst must not be null!");
+			return new TertiaryICUComparisonLevel(level, caseFirst);
+		}
+	}
+
+	public static class PrimaryICUComparisonLevel extends ICUComparisonLevel {
+
+		private PrimaryICUComparisonLevel(Integer level, Boolean caseLevel) {
+			super(level, null, caseLevel);
+		}
+
+		/**
+		 * Include case comparison.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}
+		 */
+		public PrimaryICUComparisonLevel includeCase() {
+			return caseLevel(Boolean.TRUE);
+		}
+
+		/**
+		 * Exclude case comparison.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}
+		 */
+		public PrimaryICUComparisonLevel excludeCase() {
+			return caseLevel(Boolean.FALSE);
+		}
+
+		PrimaryICUComparisonLevel caseLevel(Boolean caseLevel) {
+			return new PrimaryICUComparisonLevel(level, caseLevel);
+		}
+	}
+
+	public static class SecondaryICUComparisonLevel extends ICUComparisonLevel {
+
+		private SecondaryICUComparisonLevel(Integer level, Boolean caseLevel) {
+			super(level, null, caseLevel);
+		}
+
+		/**
+		 * Include case comparison.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}
+		 */
+		public SecondaryICUComparisonLevel includeCase() {
+			return caseLevel(Boolean.TRUE);
+		}
+
+		/**
+		 * Exclude case comparison.
+		 *
+		 * @return new {@link ComparisonLevelWithCase}
+		 */
+		public SecondaryICUComparisonLevel excludeCase() {
+			return caseLevel(Boolean.FALSE);
+		}
+
+		SecondaryICUComparisonLevel caseLevel(Boolean caseLevel) {
+			return new SecondaryICUComparisonLevel(level, caseLevel);
+		}
+	}
+
+	/**
+	 * @since 2.0
+	 */
+	public static class ICUCaseFirst {
+
+		private final String state;
+
+		private ICUCaseFirst(String state) {
+			this.state = state;
+		}
+
+		/**
+		 * Sort uppercase before lowercase.
+		 *
+		 * @return new {@link ICUCaseFirst}.
+		 */
+		public static ICUCaseFirst upper() {
+			return new ICUCaseFirst("upper");
+		}
+
+		/**
+		 * Sort lowercase before uppercase.
+		 *
+		 * @return new {@link ICUCaseFirst}.
+		 */
+		public static ICUCaseFirst lower() {
+			return new ICUCaseFirst("lower");
+		}
+
+		/**
+		 * Use the default.
+		 *
+		 * @return new {@link ICUCaseFirst}.
+		 */
+		public static ICUCaseFirst off() {
+			return new ICUCaseFirst("off");
+		}
+	}
+
+	/**
+	 * @since 2.0
+	 */
+	public static class Alternate {
+
+		protected final String alternate;
+		protected Optional<String> maxVariable;
+
+		private Alternate(String alternate, String maxVariable) {
+			this.alternate = alternate;
+			this.maxVariable = Optional.ofNullable(maxVariable);
+		}
+
+		/**
+		 * Consider Whitespace and punctuation as base characters.
+		 *
+		 * @return new {@link Alternate}.
+		 */
+		public static Alternate nonIgnorable() {
+			return new Alternate("non-ignorable", null);
+		}
+
+		/**
+		 * Whitespace and punctuation are <strong>not</strong> considered base characters and are only distinguished at
+		 * strength. <br />
+		 * <strong>NOTE:</strong> Only works for {@link ICUComparisonLevel} above {@link ICUComparisonLevel#tertiary()}.
+		 *
+		 * @return new {@link AlternateWithMaxVariable}.
+		 */
+		public static AlternateWithMaxVariable shifted() {
+			return new AlternateWithMaxVariable("shifted", null);
+		}
+	}
+
+	/**
+	 * @since 2.0
+	 */
+	public static class AlternateWithMaxVariable extends Alternate {
+
+		private AlternateWithMaxVariable(String alternate, String maxVariable) {
+			super(alternate, maxVariable);
+		}
+
+		/**
+		 * Consider both whitespaces and punctuation as ignorable.
+		 *
+		 * @return new {@link AlternateWithMaxVariable}.
+		 */
+		public AlternateWithMaxVariable punct() {
+			return new AlternateWithMaxVariable(alternate, "punct");
+		}
+
+		/**
+		 * Only consider whitespaces as ignorable.
+		 *
+		 * @return new {@link AlternateWithMaxVariable}.
+		 */
+		public AlternateWithMaxVariable space() {
+			return new AlternateWithMaxVariable(alternate, "space");
+		}
+
+	}
+
+	/**
+	 * ICU locale abstraction for usage with MongoDB {@link Collation}.
+	 *
+	 * @since 2.0
+	 * @see <a href="http://site.icu-project.org">ICU - International Components for Unicode</a>
+	 */
+	public static class ICULocale {
+
+		private final String language;
+		private final Optional<String> variant;
+
+		private ICULocale(String language, String variant) {
+			this.language = language;
+			this.variant = Optional.ofNullable(variant);
+		}
+
+		/**
+		 * Create new {@link ICULocale} for given language.
+		 *
+		 * @param language must not be {@literal null}.
+		 * @return
+		 */
+		public static ICULocale of(String language) {
+
+			Assert.notNull(language, "Code must not be null!");
+			return new ICULocale(language, null);
+		}
+
+		/**
+		 * Define language variant.
+		 *
+		 * @param variant must not be {@literal null}.
+		 * @return new {@link ICULocale}.
+		 */
+		public ICULocale variant(String variant) {
+
+			Assert.notNull(variant, "Variant must not be null!");
+			return new ICULocale(language, variant);
+		}
+
+		/**
+		 * Get the string representation.
+		 *
+		 * @return
+		 */
+		public String asString() {
+
+			StringBuilder sb = new StringBuilder(language);
+			variant.ifPresent(val -> {
+
+				if (!val.isEmpty()) {
+					sb.append("@collation=").append(val);
+				}
+			});
+			return sb.toString();
+		}
+	}
+
+	private static Converter<Collation, Document> toMongoDocumentConverter() {
+
+		return source -> {
+
+			Document document = new Document();
+			document.append("locale", source.locale.asString());
+
+			source.strength.ifPresent(val -> {
+
+				document.append("strength", val.level);
+
+				val.caseLevel.ifPresent(cl -> document.append("caseLevel", cl));
+				val.caseFirst.ifPresent(cl -> document.append("caseFirst", cl.state));
+			});
+
+			source.numericOrdering.ifPresent(val -> document.append("numericOrdering", val));
+			source.alternate.ifPresent(val -> {
+
+				document.append("alternate", val.alternate);
+				val.maxVariable.ifPresent(maxVariable -> document.append("maxVariable", maxVariable));
+			});
+
+			source.backwards.ifPresent(val -> document.append("backwards", val));
+			source.normalization.ifPresent(val -> document.append("normalization", val));
+			source.version.ifPresent(val -> document.append("version", val));
+
+			return document;
+		};
+	}
+
+	private static Converter<Collation, com.mongodb.client.model.Collation> toMongoCollationConverter() {
+
+		return source -> {
+
+			Builder builder = com.mongodb.client.model.Collation.builder();
+
+			builder.locale(source.locale.asString());
+
+			source.strength.ifPresent(val -> {
+
+				builder.collationStrength(CollationStrength.fromInt(val.level));
+
+				val.caseLevel.ifPresent(cl -> builder.caseLevel(cl));
+				val.caseFirst.ifPresent(cl -> builder.collationCaseFirst(CollationCaseFirst.fromString(cl.state)));
+			});
+
+			source.numericOrdering.ifPresent(val -> builder.numericOrdering(val));
+			source.alternate.ifPresent(val -> {
+
+				builder.collationAlternate(CollationAlternate.fromString(val.alternate));
+				val.maxVariable
+						.ifPresent(maxVariable -> builder.collationMaxVariable(CollationMaxVariable.fromString(maxVariable)));
+			});
+
+			source.backwards.ifPresent(val -> builder.backwards(val));
+			source.normalization.ifPresent(val -> builder.normalization(val));
+
+			return builder.build();
+		};
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,22 @@
  */
 package org.springframework.data.mongodb.core;
 
+import java.util.Optional;
+
+import org.springframework.util.Assert;
+
 /**
  * Provides a simple wrapper to encapsulate the variety of settings you can use when creating a collection.
- * 
+ *
  * @author Thomas Risberg
+ * @author Christoph Strobl
  */
 public class CollectionOptions {
 
 	private Integer maxDocuments;
-
 	private Integer size;
-
 	private Boolean capped;
+	private Collation collation;
 
 	/**
 	 * Constructs a new <code>CollectionOptions</code> instance.
@@ -37,10 +41,83 @@ public class CollectionOptions {
 	 *          false otherwise.
 	 */
 	public CollectionOptions(Integer size, Integer maxDocuments, Boolean capped) {
-		super();
+
 		this.maxDocuments = maxDocuments;
 		this.size = size;
 		this.capped = capped;
+	}
+
+	private CollectionOptions() {}
+
+	/**
+	 * Create new {@link CollectionOptions} by just providing the {@link Collation} to use.
+	 *
+	 * @param collation must not be {@literal null}.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public static CollectionOptions just(Collation collation) {
+
+		Assert.notNull(collation, "Collation must not be null!");
+
+		CollectionOptions options = new CollectionOptions();
+		options.setCollation(collation);
+		return options;
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and capped set to {@literal true}.
+	 *
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public CollectionOptions capped() {
+
+		CollectionOptions options = new CollectionOptions(size, maxDocuments, true);
+		options.setCollation(collation);
+		return options;
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and {@code maxDocuments} set to given value.
+	 *
+	 * @param maxDocuments can be {@literal null}.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public CollectionOptions maxDocuments(Integer maxDocuments) {
+
+		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
+		options.setCollation(collation);
+		return options;
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and {@code size} set to given value.
+	 *
+	 * @param size can be {@literal null}.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public CollectionOptions size(Integer size) {
+
+		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
+		options.setCollation(collation);
+		return options;
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and {@code collation} set to given value.
+	 *
+	 * @param collation can be {@literal null}.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public CollectionOptions collation(Collation collation) {
+
+		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
+		options.setCollation(collation);
+		return options;
 	}
 
 	public Integer getMaxDocuments() {
@@ -67,4 +144,23 @@ public class CollectionOptions {
 		this.capped = capped;
 	}
 
+	/**
+	 * Set {@link Collation} options.
+	 *
+	 * @param collation
+	 * @since 2.0
+	 */
+	public void setCollation(Collation collation) {
+		this.collation = collation;
+	}
+
+	/**
+	 * Get the {@link Collation} settings.
+	 *
+	 * @return
+	 * @since 2.0
+	 */
+	public Optional<Collation> getCollation() {
+		return Optional.ofNullable(collation);
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -24,27 +24,33 @@ import org.springframework.util.Assert;
  *
  * @author Thomas Risberg
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class CollectionOptions {
 
 	private Integer maxDocuments;
 	private Integer size;
 	private Boolean capped;
-	private Collation collation;
+	private Optional<Collation> collation;
 
 	/**
 	 * Constructs a new <code>CollectionOptions</code> instance.
-	 * 
-	 * @param size the collection size in bytes, this data space is preallocated
+	 *
+	 * @param size the collection size in bytes, this data space is preallocated.
 	 * @param maxDocuments the maximum number of documents in the collection.
 	 * @param capped true to created a "capped" collection (fixed size with auto-FIFO behavior based on insertion order),
 	 *          false otherwise.
 	 */
 	public CollectionOptions(Integer size, Integer maxDocuments, Boolean capped) {
+		this(size, maxDocuments, capped, Optional.empty());
+	}
+
+	private CollectionOptions(Integer size, Integer maxDocuments, Boolean capped, Optional<Collation> collation) {
 
 		this.maxDocuments = maxDocuments;
 		this.size = size;
 		this.capped = capped;
+		this.collation = collation;
 	}
 
 	private CollectionOptions() {}
@@ -66,16 +72,24 @@ public class CollectionOptions {
 	}
 
 	/**
-	 * Create new {@link CollectionOptions} with already given settings and capped set to {@literal true}.
+	 * Create new empty {@link CollectionOptions}.
 	 *
 	 * @return new {@link CollectionOptions}.
 	 * @since 2.0
 	 */
-	public CollectionOptions capped() {
+	public static CollectionOptions empty() {
+		return new CollectionOptions();
+	}
 
-		CollectionOptions options = new CollectionOptions(size, maxDocuments, true);
-		options.setCollation(collation);
-		return options;
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and capped set to {@literal true}.
+	 *
+	 * @param size the collection size in bytes, this data space is preallocated.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.0
+	 */
+	public CollectionOptions capped(int size) {
+		return new CollectionOptions(size, maxDocuments, true, collation);
 	}
 
 	/**
@@ -86,10 +100,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions maxDocuments(Integer maxDocuments) {
-
-		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
-		options.setCollation(collation);
-		return options;
+		return new CollectionOptions(size, maxDocuments, capped, collation);
 	}
 
 	/**
@@ -99,11 +110,8 @@ public class CollectionOptions {
 	 * @return new {@link CollectionOptions}.
 	 * @since 2.0
 	 */
-	public CollectionOptions size(Integer size) {
-
-		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
-		options.setCollation(collation);
-		return options;
+	public CollectionOptions size(int size) {
+		return new CollectionOptions(size, maxDocuments, capped, collation);
 	}
 
 	/**
@@ -114,10 +122,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions collation(Collation collation) {
-
-		CollectionOptions options = new CollectionOptions(size, maxDocuments, capped);
-		options.setCollation(collation);
-		return options;
+		return new CollectionOptions(size, maxDocuments, capped, Optional.ofNullable(collation));
 	}
 
 	public Integer getMaxDocuments() {
@@ -151,7 +156,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public void setCollation(Collation collation) {
-		this.collation = collation;
+		this.collation = Optional.ofNullable(collation);
 	}
 
 	/**
@@ -161,6 +166,6 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public Optional<Collation> getCollation() {
-		return Optional.ofNullable(collation);
+		return collation;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
@@ -24,15 +24,15 @@ import java.util.Optional;
  */
 public class FindAndModifyOptions {
 
-	boolean returnNew;
-	boolean upsert;
-	boolean remove;
+	private boolean returnNew;
+	private boolean upsert;
+	private boolean remove;
 
 	private Collation collation;
 
 	/**
 	 * Static factory method to create a FindAndModifyOptions instance
-	 * 
+	 *
 	 * @return a new instance
 	 */
 	public static FindAndModifyOptions options() {
@@ -46,9 +46,8 @@ public class FindAndModifyOptions {
 	 */
 	public static FindAndModifyOptions of(FindAndModifyOptions source) {
 
-
 		FindAndModifyOptions options = new FindAndModifyOptions();
-		if(source == null) {
+		if (source == null) {
 			return options;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,20 @@
  */
 package org.springframework.data.mongodb.core;
 
+import java.util.Optional;
+
+/**
+ * @author Mark Pollak
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ */
 public class FindAndModifyOptions {
 
 	boolean returnNew;
-
 	boolean upsert;
-
 	boolean remove;
+
+	private Collation collation;
 
 	/**
 	 * Static factory method to create a FindAndModifyOptions instance
@@ -30,6 +37,27 @@ public class FindAndModifyOptions {
 	 */
 	public static FindAndModifyOptions options() {
 		return new FindAndModifyOptions();
+	}
+
+	/**
+	 * @param options
+	 * @return
+	 * @since 2.0
+	 */
+	public static FindAndModifyOptions of(FindAndModifyOptions source) {
+
+
+		FindAndModifyOptions options = new FindAndModifyOptions();
+		if(source == null) {
+			return options;
+		}
+
+		options.returnNew = source.returnNew;
+		options.upsert = source.upsert;
+		options.remove = source.remove;
+		options.collation = source.collation;
+
+		return options;
 	}
 
 	public FindAndModifyOptions returnNew(boolean returnNew) {
@@ -47,6 +75,19 @@ public class FindAndModifyOptions {
 		return this;
 	}
 
+	/**
+	 * Define the {@link Collation} specifying language-specific rules for string comparison.
+	 *
+	 * @param collation
+	 * @return
+	 * @since 2.0
+	 */
+	public FindAndModifyOptions collation(Collation collation) {
+
+		this.collation = collation;
+		return this;
+	}
+
 	public boolean isReturnNew() {
 		return returnNew;
 	}
@@ -57,6 +98,16 @@ public class FindAndModifyOptions {
 
 	public boolean isRemove() {
 		return remove;
+	}
+
+	/**
+	 * Get the {@link Collation} specifying language-specific rules for string comparison.
+	 *
+	 * @return
+	 * @since 2.0
+	 */
+	public Optional<Collation> getCollation() {
+		return Optional.ofNullable(collation);
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/IndexConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/IndexConverters.java
@@ -25,10 +25,6 @@ import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.util.ObjectUtils;
 
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.CollationAlternate;
-import com.mongodb.client.model.CollationCaseFirst;
-import com.mongodb.client.model.CollationMaxVariable;
-import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.IndexOptions;
 
 /**
@@ -129,39 +125,11 @@ abstract class IndexConverters {
 			return null;
 		}
 
-		com.mongodb.client.model.Collation.Builder collationBuilder = Collation.builder();
-
-		collationBuilder.locale(source.getString("locale"));
-		if (source.containsKey("caseLevel")) {
-			collationBuilder.caseLevel(source.getBoolean("caseLevel"));
-		}
-		if (source.containsKey("caseFirst")) {
-			collationBuilder.collationCaseFirst(CollationCaseFirst.fromString(source.getString("caseFirst")));
-		}
-		if (source.containsKey("strength")) {
-			collationBuilder.collationStrength(CollationStrength.fromInt(source.getInteger("strength")));
-		}
-		if (source.containsKey("numericOrdering")) {
-			collationBuilder.numericOrdering(source.getBoolean("numericOrdering"));
-		}
-		if (source.containsKey("alternate")) {
-			collationBuilder.collationAlternate(CollationAlternate.fromString(source.getString("alternate")));
-		}
-		if (source.containsKey("maxVariable")) {
-			collationBuilder.collationMaxVariable(CollationMaxVariable.fromString(source.getString("maxVariable")));
-		}
-		if (source.containsKey("backwards")) {
-			collationBuilder.backwards(source.getBoolean("backwards"));
-		}
-		if (source.containsKey("normalization")) {
-			collationBuilder.normalization(source.getBoolean("normalization"));
-		}
-
-		return collationBuilder.build();
+		return org.springframework.data.mongodb.core.Collation.from(source).toMongoCollation();
 	}
 
 	private static Converter<Document, IndexInfo> getDocumentIndexInfoConverter() {
-		return ix -> IndexInfo.indexInfoOf(ix);
+		return IndexInfo::indexInfoOf;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationUtils.java
@@ -22,7 +22,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.util.Assert;
 
 /**
- * Utility methods for aggregation ooperation implementations.
+ * Utility methods for aggregation operation implementations.
  * 
  * @author Oliver Gierke
  */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Index.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @SuppressWarnings("deprecation")
 public class Index implements IndexDefinition {
@@ -39,21 +40,13 @@ public class Index implements IndexDefinition {
 	}
 
 	private final Map<String, Direction> fieldSpec = new LinkedHashMap<String, Direction>();
-
 	private String name;
-
 	private boolean unique = false;
-
 	private boolean dropDuplicates = false;
-
 	private boolean sparse = false;
-
 	private boolean background = false;
-
 	private long expire = -1;
-
 	private Optional<IndexFilter> filter = Optional.empty();
-
 	private Optional<Collation> collation = Optional.empty();
 
 	public Index() {}
@@ -98,7 +91,7 @@ public class Index implements IndexDefinition {
 
 	/**
 	 * Build the index in background (non blocking).
-	 * 
+	 *
 	 * @return
 	 * @since 1.5
 	 */
@@ -110,7 +103,7 @@ public class Index implements IndexDefinition {
 
 	/**
 	 * Specifies TTL in seconds.
-	 * 
+	 *
 	 * @param value
 	 * @return
 	 * @since 1.5
@@ -121,7 +114,7 @@ public class Index implements IndexDefinition {
 
 	/**
 	 * Specifies TTL with given {@link TimeUnit}.
-	 * 
+	 *
 	 * @param value
 	 * @param unit
 	 * @return

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.bson.Document;
 import org.springframework.util.Assert;
@@ -46,9 +47,9 @@ public class IndexInfo {
 	private final boolean sparse;
 	private final String language;
 	private String partialFilterExpression;
+	private Document collation;
 
-	public IndexInfo(List<IndexField> indexFields, String name, boolean unique, boolean sparse,
-			String language) {
+	public IndexInfo(List<IndexField> indexFields, String name, boolean unique, boolean sparse, String language) {
 
 		this.indexFields = Collections.unmodifiableList(indexFields);
 		this.name = name;
@@ -106,10 +107,11 @@ public class IndexInfo {
 		String language = sourceDocument.containsKey("default_language") ? (String) sourceDocument.get("default_language")
 				: "";
 		String partialFilter = sourceDocument.containsKey("partialFilterExpression")
-				? ((Document)sourceDocument.get("partialFilterExpression")).toJson() : "";
+				? ((Document) sourceDocument.get("partialFilterExpression")).toJson() : "";
 
 		IndexInfo info = new IndexInfo(indexFields, name, unique, sparse, language);
 		info.partialFilterExpression = partialFilter;
+		info.collation = sourceDocument.get("collation", Document.class);
 		return info;
 	}
 
@@ -169,10 +171,21 @@ public class IndexInfo {
 		return partialFilterExpression;
 	}
 
+	/**
+	 * Get collation information.
+	 *
+	 * @return
+	 * @since 2.0
+	 */
+	public Optional<Document> getCollation() {
+		return Optional.ofNullable(collation);
+	}
+
 	@Override
 	public String toString() {
-		return "IndexInfo [indexFields=" + indexFields + ", name=" + name + ", unique=" + unique + ", sparse=" + sparse + ", language=" + language + ", partialFilterExpression="
-				+ partialFilterExpression + "]";
+		return "IndexInfo [indexFields=" + indexFields + ", name=" + name + ", unique=" + unique + ", sparse=" + sparse
+				+ ", language=" + language + ", partialFilterExpression=" + partialFilterExpression + ", collation=" + collation
+				+ "]";
 	}
 
 	@Override
@@ -186,6 +199,7 @@ public class IndexInfo {
 		result = prime * result + (unique ? 1231 : 1237);
 		result = prime * result + ObjectUtils.nullSafeHashCode(language);
 		result = prime * result + ObjectUtils.nullSafeHashCode(partialFilterExpression);
+		result = prime * result + ObjectUtils.nullSafeHashCode(collation);
 		return result;
 	}
 
@@ -225,6 +239,10 @@ public class IndexInfo {
 			return false;
 		}
 		if (!ObjectUtils.nullSafeEquals(partialFilterExpression, other.partialFilterExpression)) {
+			return false;
+		}
+
+		if (!ObjectUtils.nullSafeEquals(collation, collation)) {
 			return false;
 		}
 		return true;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupBy.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupBy.java
@@ -24,7 +24,7 @@ import org.springframework.data.mongodb.core.Collation;
  * Collects the parameters required to perform a group operation on a collection. The query condition and the input
  * collection are specified on the group method as method arguments to be consistent with other operations, e.g.
  * map-reduce.
- * 
+ *
  * @author Mark Pollack
  * @author Christoph Strobl
  */
@@ -33,7 +33,7 @@ public class GroupBy {
 	private Document initialDocument;
 	private String reduce;
 
-	private Optional<Document> dboKeys = Optional.empty();
+	private Optional<Document> keys = Optional.empty();
 	private Optional<String> keyFunction = Optional.empty();
 	private Optional<String> initial = Optional.empty();
 	private Optional<String> finalize = Optional.empty();
@@ -46,7 +46,7 @@ public class GroupBy {
 			document.put(key, 1);
 		}
 
-		dboKeys = Optional.of(document);
+		this.keys = Optional.of(document);
 	}
 
 	// NOTE GroupByCommand does not handle keyfunction.
@@ -58,7 +58,7 @@ public class GroupBy {
 			keyFunction = Optional.ofNullable(key);
 		} else {
 			document.put(key, 1);
-			dboKeys = Optional.of(document);
+			keys = Optional.of(document);
 		}
 	}
 
@@ -152,7 +152,7 @@ public class GroupBy {
 
 		Document document = new Document();
 
-		dboKeys.ifPresent(val -> document.append("key", val));
+		keys.ifPresent(val -> document.append("key", val));
 		keyFunction.ifPresent(val -> document.append("$keyf", val));
 
 		document.put("$reduce", reduce);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
@@ -17,8 +17,10 @@ package org.springframework.data.mongodb.core.mapreduce;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.bson.Document;
+import org.springframework.data.mongodb.core.Collation;
 
 import com.mongodb.MapReduceCommand;
 
@@ -31,23 +33,17 @@ public class MapReduceOptions {
 
 	private String outputCollection;
 
-	private String outputDatabase;
-
-	private Boolean outputSharded;
-
+	private Optional<String> outputDatabase = Optional.empty();
 	private MapReduceCommand.OutputType outputType = MapReduceCommand.OutputType.REPLACE;
-
-	private String finalizeFunction;
-
 	private Map<String, Object> scopeVariables = new HashMap<String, Object>();
-
+	private Map<String, Object> extraOptions = new HashMap<String, Object>();
 	private Boolean jsMode;
-
-	private Boolean verbose = true;
-
+	private Boolean verbose = Boolean.TRUE;
 	private Integer limit;
 
-	private Map<String, Object> extraOptions = new HashMap<String, Object>();
+	private Optional<Boolean> outputSharded = Optional.empty();
+	private Optional<String> finalizeFunction = Optional.empty();
+	private Optional<Collation> collation = Optional.empty();
 
 	/**
 	 * Static factory method to create a MapReduceOptions instance
@@ -79,6 +75,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputCollection(String collectionName) {
+
 		this.outputCollection = collectionName;
 		return this;
 	}
@@ -91,7 +88,8 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputDatabase(String outputDatabase) {
-		this.outputDatabase = outputDatabase;
+
+		this.outputDatabase = Optional.ofNullable(outputDatabase);
 		return this;
 	}
 
@@ -103,6 +101,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputTypeInline() {
+
 		this.outputType = MapReduceCommand.OutputType.INLINE;
 		return this;
 	}
@@ -114,6 +113,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputTypeMerge() {
+
 		this.outputType = MapReduceCommand.OutputType.MERGE;
 		return this;
 	}
@@ -137,6 +137,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputTypeReplace() {
+
 		this.outputType = MapReduceCommand.OutputType.REPLACE;
 		return this;
 	}
@@ -149,7 +150,8 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions outputSharded(boolean outputShared) {
-		this.outputSharded = outputShared;
+
+		this.outputSharded = Optional.of(outputShared);
 		return this;
 	}
 
@@ -160,7 +162,8 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions finalizeFunction(String finalizeFunction) {
-		this.finalizeFunction = finalizeFunction;
+
+		this.finalizeFunction = Optional.ofNullable(finalizeFunction);
 		return this;
 	}
 
@@ -172,6 +175,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions scopeVariables(Map<String, Object> scopeVariables) {
+
 		this.scopeVariables = scopeVariables;
 		return this;
 	}
@@ -184,6 +188,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions javaScriptMode(boolean javaScriptMode) {
+
 		this.jsMode = javaScriptMode;
 		return this;
 	}
@@ -194,6 +199,7 @@ public class MapReduceOptions {
 	 * @return MapReduceOptions so that methods can be chained in a fluent API style
 	 */
 	public MapReduceOptions verbose(boolean verbose) {
+
 		this.verbose = verbose;
 		return this;
 	}
@@ -210,7 +216,21 @@ public class MapReduceOptions {
 	 */
 	@Deprecated
 	public MapReduceOptions extraOption(String key, Object value) {
+
 		extraOptions.put(key, value);
+		return this;
+	}
+
+	/**
+	 * Define the Collation specifying language-specific rules for string comparison.
+	 *
+	 * @param collation can be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public MapReduceOptions collation(Collation collation) {
+
+		this.collation = Optional.ofNullable(collation);
 		return this;
 	}
 
@@ -223,7 +243,7 @@ public class MapReduceOptions {
 		return extraOptions;
 	}
 
-	public String getFinalizeFunction() {
+	public Optional<String> getFinalizeFunction() {
 		return this.finalizeFunction;
 	}
 
@@ -235,11 +255,11 @@ public class MapReduceOptions {
 		return this.outputCollection;
 	}
 
-	public String getOutputDatabase() {
+	public Optional<String> getOutputDatabase() {
 		return this.outputDatabase;
 	}
 
-	public Boolean getOutputSharded() {
+	public Optional<Boolean> getOutputSharded() {
 		return this.outputSharded;
 	}
 
@@ -260,7 +280,18 @@ public class MapReduceOptions {
 		return limit;
 	}
 
+	/**
+	 * Get the Collation specifying language-specific rules for string comparison.
+	 *
+	 * @return
+	 * @since 2.0
+	 */
+	public Optional<Collation> getCollation() {
+		return collation;
+	}
+
 	public Document getOptionsObject() {
+
 		Document cmd = new Document();
 
 		if (verbose != null) {
@@ -269,9 +300,7 @@ public class MapReduceOptions {
 
 		cmd.put("out", createOutObject());
 
-		if (finalizeFunction != null) {
-			cmd.put("finalize", finalizeFunction);
-		}
+		finalizeFunction.ifPresent(val -> cmd.append("finalize", val));
 
 		if (scopeVariables != null) {
 			cmd.put("scope", scopeVariables);
@@ -285,10 +314,13 @@ public class MapReduceOptions {
 			cmd.putAll(extraOptions);
 		}
 
+		getCollation().ifPresent(val -> cmd.append("collation", val.toDocument()));
+
 		return cmd;
 	}
 
 	protected Document createOutObject() {
+
 		Document out = new Document();
 
 		switch (outputType) {
@@ -306,13 +338,8 @@ public class MapReduceOptions {
 				break;
 		}
 
-		if (outputDatabase != null) {
-			out.put("db", outputDatabase);
-		}
-
-		if (outputSharded != null) {
-			out.put("sharded", outputSharded);
-		}
+		outputDatabase.ifPresent(val -> out.append("db", val));
+		outputSharded.ifPresent(val -> out.append("sharded", val));
 
 		return out;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -404,7 +404,9 @@ public final class NearQuery {
 		Document document = new Document();
 
 		if (query != null) {
+
 			document.put("query", query.getQueryObject());
+			query.getCollation().ifPresent(collation -> document.append("collation", collation.toDocument()));
 		}
 
 		if (maxDistance != null) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollationUnitTests.java
@@ -17,15 +17,18 @@ package org.springframework.data.mongodb.core;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Locale;
+
 import org.bson.Document;
 import org.junit.Test;
 import org.springframework.data.mongodb.core.Collation.Alternate;
-import org.springframework.data.mongodb.core.Collation.ICUCaseFirst;
-import org.springframework.data.mongodb.core.Collation.ICUComparisonLevel;
-import org.springframework.data.mongodb.core.Collation.ICULocale;
+import org.springframework.data.mongodb.core.Collation.CaseFirst;
+import org.springframework.data.mongodb.core.Collation.CollationLocale;
+import org.springframework.data.mongodb.core.Collation.ComparisonLevel;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class CollationUnitTests {
 
@@ -59,7 +62,8 @@ public class CollationUnitTests {
 
 	@Test // DATAMONGO-1518
 	public void localeWithVariant() {
-		assertThat(Collation.of(ICULocale.of("de_AT").variant("phonebook")).toDocument()).isEqualTo(LOCALE_WITH_VARIANT);
+		assertThat(Collation.of(CollationLocale.of("de_AT").variant("phonebook")).toDocument())
+				.isEqualTo(LOCALE_WITH_VARIANT);
 	}
 
 	@Test // DATAMONGO-1518
@@ -68,14 +72,15 @@ public class CollationUnitTests {
 	}
 
 	@Test // DATAMONGO-1518
-	public void lcaleFromJavaUtilLocale() {
-		assertThat(Collation.of(java.util.Locale.US).toDocument()).isEqualTo(new Document().append("locale", "en"));
+	public void localeFromJavaUtilLocale() {
+
+		assertThat(Collation.of(java.util.Locale.US).toDocument()).isEqualTo(new Document().append("locale", "en_US"));
+		assertThat(Collation.of(Locale.ENGLISH).toDocument()).isEqualTo(new Document().append("locale", "en"));
 	}
 
 	@Test // DATAMONGO-1518
 	public void withStrenghPrimary() {
-		assertThat(Collation.of("en_US").strength(ICUComparisonLevel.primary()).toDocument())
-				.isEqualTo(WITH_STRENGTH_PRIMARY);
+		assertThat(Collation.of("en_US").strength(ComparisonLevel.primary()).toDocument()).isEqualTo(WITH_STRENGTH_PRIMARY);
 	}
 
 	@Test // DATAMONGO-1518
@@ -86,7 +91,7 @@ public class CollationUnitTests {
 	@Test // DATAMONGO-1518
 	public void withStrenghPrimaryAndIncludeCase() {
 
-		assertThat(Collation.of("en_US").strength(ICUComparisonLevel.primary().includeCase()).toDocument())
+		assertThat(Collation.of("en_US").strength(ComparisonLevel.primary().includeCase()).toDocument())
 				.isEqualTo(WITH_STRENGTH_PRIMARY_INCLUDE_CASE);
 	}
 
@@ -129,7 +134,7 @@ public class CollationUnitTests {
 
 	@Test // DATAMONGO-1518
 	public void withCaseFirst() {
-		assertThat(Collation.of("en_US").caseFirst(ICUCaseFirst.upper()).toDocument()).isEqualTo(WITH_CASE_FIRST_UPPER);
+		assertThat(Collation.of("en_US").caseFirst(CaseFirst.upper()).toDocument()).isEqualTo(WITH_CASE_FIRST_UPPER);
 	}
 
 	@Test // DATAMONGO-1518
@@ -164,8 +169,8 @@ public class CollationUnitTests {
 	@Test // DATAMONGO-1518
 	public void allTheThings() {
 
-		assertThat(Collation.of(ICULocale.of("de_AT").variant("phonebook"))
-				.strength(ICUComparisonLevel.primary().includeCase()).normalizationEnabled().backwardDiacriticSort()
+		assertThat(Collation.of(CollationLocale.of("de_AT").variant("phonebook"))
+				.strength(ComparisonLevel.primary().includeCase()).normalizationEnabled().backwardDiacriticSort()
 				.numericOrderingEnabled().alternate(Alternate.shifted().punct()).toDocument()).isEqualTo(ALL_THE_THINGS);
 	}
 
@@ -176,7 +181,7 @@ public class CollationUnitTests {
 
 	@Test // DATAMONGO-1518
 	public void justTheDefault() {
-		assertThat(Collation.binary().toDocument()).isEqualTo(BINARY_COMPARISON);
+		assertThat(Collation.simple().toDocument()).isEqualTo(BINARY_COMPARISON);
 	}
 
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollationUnitTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.bson.Document;
+import org.junit.Test;
+import org.springframework.data.mongodb.core.Collation.Alternate;
+import org.springframework.data.mongodb.core.Collation.ICUCaseFirst;
+import org.springframework.data.mongodb.core.Collation.ICUComparisonLevel;
+import org.springframework.data.mongodb.core.Collation.ICULocale;
+
+/**
+ * @author Christoph Strobl
+ */
+public class CollationUnitTests {
+
+	static final Document BINARY_COMPARISON = new Document().append("locale", "simple");
+	static final Document JUST_LOCALE = new Document().append("locale", "en_US");
+	static final Document LOCALE_WITH_VARIANT = new Document().append("locale", "de_AT@collation=phonebook");
+	static final Document WITH_STRENGTH_PRIMARY = new Document(JUST_LOCALE).append("strength", 1);
+	static final Document WITH_STRENGTH_PRIMARY_INCLUDE_CASE = new Document(WITH_STRENGTH_PRIMARY).append("caseLevel",
+			true);
+	static final Document WITH_NORMALIZATION = new Document(JUST_LOCALE).append("normalization", true);
+	static final Document WITH_BACKWARDS = new Document(JUST_LOCALE).append("backwards", true);
+	static final Document WITH_NUMERIC_ORDERING = new Document(JUST_LOCALE).append("numericOrdering", true);
+	static final Document WITH_CASE_FIRST_UPPER = new Document(JUST_LOCALE).append("strength", 3).append("caseFirst",
+			"upper");
+	static final Document WITH_ALTERNATE_SHIFTED = new Document(JUST_LOCALE).append("alternate", "shifted");
+	static final Document WITH_ALTERNATE_SHIFTED_MAX_VARIABLE_PUNCT = new Document(WITH_ALTERNATE_SHIFTED)
+			.append("maxVariable", "punct");
+	static final Document ALL_THE_THINGS = new Document(LOCALE_WITH_VARIANT).append("strength", 1)
+			.append("caseLevel", true).append("backwards", true).append("numericOrdering", true)
+			.append("alternate", "shifted").append("maxVariable", "punct").append("normalization", true);
+
+	@Test // DATAMONGO-1518
+	public void justLocale() {
+		assertThat(Collation.of("en_US").toDocument()).isEqualTo(JUST_LOCALE);
+	}
+
+	@Test // DATAMONGO-1518
+	public void justLocaleFromDocument() {
+		assertThat(Collation.from(JUST_LOCALE).toDocument()).isEqualTo(JUST_LOCALE);
+	}
+
+	@Test // DATAMONGO-1518
+	public void localeWithVariant() {
+		assertThat(Collation.of(ICULocale.of("de_AT").variant("phonebook")).toDocument()).isEqualTo(LOCALE_WITH_VARIANT);
+	}
+
+	@Test // DATAMONGO-1518
+	public void localeWithVariantFromDocument() {
+		assertThat(Collation.from(LOCALE_WITH_VARIANT).toDocument()).isEqualTo(LOCALE_WITH_VARIANT);
+	}
+
+	@Test // DATAMONGO-1518
+	public void lcaleFromJavaUtilLocale() {
+		assertThat(Collation.of(java.util.Locale.US).toDocument()).isEqualTo(new Document().append("locale", "en"));
+	}
+
+	@Test // DATAMONGO-1518
+	public void withStrenghPrimary() {
+		assertThat(Collation.of("en_US").strength(ICUComparisonLevel.primary()).toDocument())
+				.isEqualTo(WITH_STRENGTH_PRIMARY);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withStrenghPrimaryFromDocument() {
+		assertThat(Collation.from(WITH_STRENGTH_PRIMARY).toDocument()).isEqualTo(WITH_STRENGTH_PRIMARY);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withStrenghPrimaryAndIncludeCase() {
+
+		assertThat(Collation.of("en_US").strength(ICUComparisonLevel.primary().includeCase()).toDocument())
+				.isEqualTo(WITH_STRENGTH_PRIMARY_INCLUDE_CASE);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withStrenghPrimaryAndIncludeCaseFromDocument() {
+
+		assertThat(Collation.from(WITH_STRENGTH_PRIMARY_INCLUDE_CASE).toDocument())
+				.isEqualTo(WITH_STRENGTH_PRIMARY_INCLUDE_CASE);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withNormalization() {
+		assertThat(Collation.of("en_US").normalization(true).toDocument()).isEqualTo(WITH_NORMALIZATION);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withNormalizationFromDocument() {
+		assertThat(Collation.from(WITH_NORMALIZATION).toDocument()).isEqualTo(WITH_NORMALIZATION);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withBackwards() {
+		assertThat(Collation.of("en_US").backwards(true).toDocument()).isEqualTo(WITH_BACKWARDS);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withBackwardsFromDocument() {
+		assertThat(Collation.from(WITH_BACKWARDS).toDocument()).isEqualTo(WITH_BACKWARDS);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withNumericOrdering() {
+		assertThat(Collation.of("en_US").numericOrdering(true).toDocument()).isEqualTo(WITH_NUMERIC_ORDERING);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withNumericOrderingFromDocument() {
+		assertThat(Collation.from(WITH_NUMERIC_ORDERING).toDocument()).isEqualTo(WITH_NUMERIC_ORDERING);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withCaseFirst() {
+		assertThat(Collation.of("en_US").caseFirst(ICUCaseFirst.upper()).toDocument()).isEqualTo(WITH_CASE_FIRST_UPPER);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withCaseFirstFromDocument() {
+		assertThat(Collation.from(WITH_CASE_FIRST_UPPER).toDocument()).isEqualTo(WITH_CASE_FIRST_UPPER);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withAlternate() {
+		assertThat(Collation.of("en_US").alternate(Alternate.shifted()).toDocument()).isEqualTo(WITH_ALTERNATE_SHIFTED);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withAlternateFromDocument() {
+		assertThat(Collation.from(WITH_ALTERNATE_SHIFTED).toDocument()).isEqualTo(WITH_ALTERNATE_SHIFTED);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withAlternateAndMaxVariable() {
+
+		assertThat(Collation.of("en_US").alternate(Alternate.shifted().punct()).toDocument())
+				.isEqualTo(WITH_ALTERNATE_SHIFTED_MAX_VARIABLE_PUNCT);
+	}
+
+	@Test // DATAMONGO-1518
+	public void withAlternateAndMaxVariableFromDocument() {
+
+		assertThat(Collation.from(WITH_ALTERNATE_SHIFTED_MAX_VARIABLE_PUNCT).toDocument())
+				.isEqualTo(WITH_ALTERNATE_SHIFTED_MAX_VARIABLE_PUNCT);
+	}
+
+	@Test // DATAMONGO-1518
+	public void allTheThings() {
+
+		assertThat(Collation.of(ICULocale.of("de_AT").variant("phonebook"))
+				.strength(ICUComparisonLevel.primary().includeCase()).normalizationEnabled().backwardDiacriticSort()
+				.numericOrderingEnabled().alternate(Alternate.shifted().punct()).toDocument()).isEqualTo(ALL_THE_THINGS);
+	}
+
+	@Test // DATAMONGO-1518
+	public void allTheThingsFromDocument() {
+		assertThat(Collation.from(ALL_THE_THINGS).toDocument()).isEqualTo(ALL_THE_THINGS);
+	}
+
+	@Test // DATAMONGO-1518
+	public void justTheDefault() {
+		assertThat(Collation.binary().toDocument()).isEqualTo(BINARY_COMPARISON);
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+
+import java.util.List;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Update;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.DeleteManyModel;
+import com.mongodb.client.model.UpdateManyModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.WriteModel;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultBulkOperationsUnitTests {
+
+	@Mock MongoTemplate template;
+	@Mock MongoCollection collection;
+
+	DefaultBulkOperations ops;
+
+	@Before
+	public void setUp() {
+
+		when(template.getCollection(anyString())).thenReturn(collection);
+		ops = new DefaultBulkOperations(template, BulkMode.ORDERED, "collection-1", SomeDomainType.class);
+	}
+
+	@Test // DATAMONGO-1518
+	public void updateOneShouldUseCollationWhenPresent() {
+
+		ops.updateOne(new BasicQuery("{}").collation(Collation.of("de")), new Update().set("lastName", "targaryen"))
+				.execute();
+
+		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
+
+		verify(collection).bulkWrite(captor.capture(), any());
+
+		assertThat(captor.getValue().get(0)).isInstanceOf(UpdateOneModel.class);
+		assertThat(((UpdateOneModel) captor.getValue().get(0)).getOptions().getCollation())
+				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
+	}
+
+	@Test // DATAMONGO-1518
+	public void updateMayShouldUseCollationWhenPresent() {
+
+		ops.updateMulti(new BasicQuery("{}").collation(Collation.of("de")), new Update().set("lastName", "targaryen"))
+				.execute();
+
+		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
+
+		verify(collection).bulkWrite(captor.capture(), any());
+
+		assertThat(captor.getValue().get(0)).isInstanceOf(UpdateManyModel.class);
+		assertThat(((UpdateManyModel) captor.getValue().get(0)).getOptions().getCollation())
+				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
+	}
+
+	@Test // DATAMONGO-1518
+	public void removeShouldUseCollationWhenPresent() {
+
+		ops.remove(new BasicQuery("{}").collation(Collation.of("de"))).execute();
+
+		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
+
+		verify(collection).bulkWrite(captor.capture(), any());
+
+		assertThat(captor.getValue().get(0)).isInstanceOf(DeleteManyModel.class);
+		assertThat(((DeleteManyModel) captor.getValue().get(0)).getOptions().getCollation())
+				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
+	}
+
+	class SomeDomainType {
+
+		@Id String id;
+		Gender gender;
+		@Field("first_name") String firstName;
+		@Field String lastName;
+	}
+
+	enum Gender {
+		M, F
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.mongodb.core.Collation.ICUCaseFirst;
+import org.springframework.data.mongodb.core.Collation.CaseFirst;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
@@ -45,6 +45,7 @@ import com.mongodb.client.MongoCollection;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:infrastructure.xml")
@@ -154,7 +155,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR), is(true));
 
 		IndexDefinition id = new Index().named("with-collation").on("xyz", Direction.ASC)
-				.collation(Collation.of("de_AT").caseFirst(ICUCaseFirst.off()));
+				.collation(Collation.of("de_AT").caseFirst(CaseFirst.off()));
 
 		new DefaultIndexOperations(template.getMongoDbFactory(),
 				this.template.getCollectionName(DefaultIndexOperationsIntegrationTestsSample.class),

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assume.*;
+
+import reactor.test.StepVerifier;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.config.AbstractReactiveMongoConfiguration;
+import org.springframework.data.mongodb.core.Collation.ICUCaseFirst;
+import org.springframework.data.mongodb.core.DefaultIndexOperationsIntegrationTests.DefaultIndexOperationsIntegrationTestsSample;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.util.Version;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class DefaultReactiveIndexOperationsTests {
+
+	@Configuration
+	static class Config extends AbstractReactiveMongoConfiguration {
+
+		@Override
+		public MongoClient mongoClient() {
+			return MongoClients.create();
+		}
+
+		@Override
+		protected String getDatabaseName() {
+			return "index-ops-tests";
+		}
+	}
+
+	private static final Version THREE_DOT_FOUR = new Version(3, 4);
+	private static Version mongoVersion;
+
+	@Autowired ReactiveMongoTemplate template;
+
+	MongoCollection<Document> collection;
+	DefaultReactiveIndexOperations indexOps;
+
+	@Before
+	public void setUp() {
+
+		queryMongoVersionIfNecessary();
+		String collectionName = this.template.getCollectionName(DefaultIndexOperationsIntegrationTestsSample.class);
+
+		this.collection = this.template.getMongoDatabase().getCollection(collectionName, Document.class);
+		this.collection.dropIndexes();
+		this.indexOps = new DefaultReactiveIndexOperations(template, collectionName);
+	}
+
+	private void queryMongoVersionIfNecessary() {
+
+		if (mongoVersion == null) {
+			Document result = template.executeCommand("{ buildInfo: 1 }").block();
+			mongoVersion = Version.parse(result.get("version").toString());
+		}
+	}
+
+	@Test // DATAMONGO-1518
+	public void shouldCreateIndexWithCollationCorrectly() {
+
+		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR), is(true));
+
+		IndexDefinition id = new Index().named("with-collation").on("xyz", Direction.ASC)
+				.collation(Collation.of("de_AT").caseFirst(ICUCaseFirst.off()));
+
+		indexOps.ensureIndex(id).subscribe();
+
+		Document expected = new Document("locale", "de_AT") //
+				.append("caseLevel", false) //
+				.append("caseFirst", "off") //
+				.append("strength", 3) //
+				.append("numericOrdering", false) //
+				.append("alternate", "non-ignorable") //
+				.append("maxVariable", "punct") //
+				.append("normalization", false) //
+				.append("backwards", false);
+
+		StepVerifier.create(indexOps.getIndexInfo().filter(val -> val.getName().equals("with-collation")))
+				.consumeNextWith(indexInfo -> {
+
+					assertThat(indexInfo.getCollation()).isPresent();
+
+					// version is set by MongoDB server - we remove it to avoid errors when upgrading server version.
+					Document result = indexInfo.getCollation().get();
+					result.remove("version");
+
+					assertThat(result).isEqualTo(expected);
+				}) //
+				.verifyComplete();
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.config.AbstractReactiveMongoConfiguration;
-import org.springframework.data.mongodb.core.Collation.ICUCaseFirst;
+import org.springframework.data.mongodb.core.Collation.CaseFirst;
 import org.springframework.data.mongodb.core.DefaultIndexOperationsIntegrationTests.DefaultIndexOperationsIntegrationTestsSample;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
@@ -43,6 +43,7 @@ import com.mongodb.reactivestreams.client.MongoCollection;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -95,7 +96,7 @@ public class DefaultReactiveIndexOperationsTests {
 		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR), is(true));
 
 		IndexDefinition id = new Index().named("with-collation").on("xyz", Direction.ASC)
-				.collation(Collation.of("de_AT").caseFirst(ICUCaseFirst.off()));
+				.collation(Collation.of("de_AT").caseFirst(CaseFirst.off()));
 
 		indexOps.ensureIndex(id).subscribe();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.bson.Document;
 import org.junit.Before;
@@ -28,8 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.core.Collation.Alternate;
-import org.springframework.data.mongodb.core.Collation.ICUComparisonLevel;
-import org.springframework.data.mongodb.core.Collation.ICULocale;
+import org.springframework.data.mongodb.core.Collation.ComparisonLevel;
 import org.springframework.data.mongodb.test.util.MongoVersionRule;
 import org.springframework.data.util.Version;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -38,6 +38,7 @@ import com.mongodb.MongoClient;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 public class MongoTemplateCollationTests {
@@ -79,7 +80,7 @@ public class MongoTemplateCollationTests {
 	public void createCollectionWithCollationHavingLocaleVariant() {
 
 		template.createCollection(COLLECTION_NAME,
-				CollectionOptions.just(Collation.of(ICULocale.of("de_AT").variant("phonebook"))));
+				CollectionOptions.just(Collation.of(new Locale("de", "AT", "phonebook"))));
 
 		Document collation = getCollationInfo(COLLECTION_NAME);
 		assertThat(collation.get("locale")).isEqualTo("de_AT@collation=phonebook");
@@ -89,7 +90,7 @@ public class MongoTemplateCollationTests {
 	public void createCollectionWithCollationHavingStrength() {
 
 		template.createCollection(COLLECTION_NAME,
-				CollectionOptions.just(Collation.of("en_US").strength(ICUComparisonLevel.primary().includeCase())));
+				CollectionOptions.just(Collation.of("en_US").strength(ComparisonLevel.primary().includeCase())));
 
 		Document collation = getCollationInfo(COLLECTION_NAME);
 		assertThat(collation.get("strength")).isEqualTo(1);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.core.Collation.Alternate;
+import org.springframework.data.mongodb.core.Collation.ICUComparisonLevel;
+import org.springframework.data.mongodb.core.Collation.ICULocale;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
+import org.springframework.data.util.Version;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MongoTemplateCollationTests {
+
+	public static @ClassRule MongoVersionRule REQUIRES_AT_LEAST_3_4_0 = MongoVersionRule.atLeast(Version.parse("3.4.0"));
+	public static final String COLLECTION_NAME = "collation-1";
+
+	@Configuration
+	static class Config extends AbstractMongoConfiguration {
+
+		@Override
+		public MongoClient mongoClient() {
+			return new MongoClient();
+		}
+
+		@Override
+		protected String getDatabaseName() {
+			return "collation-tests";
+		}
+	}
+
+	@Autowired MongoTemplate template;
+
+	@Before
+	public void setUp() {
+		template.dropCollection(COLLECTION_NAME);
+	}
+
+	@Test // DATAMONGO-1518
+	public void createCollectionWithCollation() {
+
+		template.createCollection(COLLECTION_NAME, CollectionOptions.just(Collation.of("en_US")));
+
+		Document collation = getCollationInfo(COLLECTION_NAME);
+		assertThat(collation.get("locale")).isEqualTo("en_US");
+	}
+
+	@Test // DATAMONGO-1518
+	public void createCollectionWithCollationHavingLocaleVariant() {
+
+		template.createCollection(COLLECTION_NAME,
+				CollectionOptions.just(Collation.of(ICULocale.of("de_AT").variant("phonebook"))));
+
+		Document collation = getCollationInfo(COLLECTION_NAME);
+		assertThat(collation.get("locale")).isEqualTo("de_AT@collation=phonebook");
+	}
+
+	@Test // DATAMONGO-1518
+	public void createCollectionWithCollationHavingStrength() {
+
+		template.createCollection(COLLECTION_NAME,
+				CollectionOptions.just(Collation.of("en_US").strength(ICUComparisonLevel.primary().includeCase())));
+
+		Document collation = getCollationInfo(COLLECTION_NAME);
+		assertThat(collation.get("strength")).isEqualTo(1);
+		assertThat(collation.get("caseLevel")).isEqualTo(true);
+	}
+
+	@Test // DATAMONGO-1518
+	public void createCollectionWithCollationHavingBackwardsAndNumericOrdering() {
+
+		template.createCollection(COLLECTION_NAME,
+				CollectionOptions.just(Collation.of("en_US").backwardDiacriticSort().numericOrderingEnabled()));
+
+		Document collation = getCollationInfo(COLLECTION_NAME);
+		assertThat(collation.get("backwards")).isEqualTo(true);
+		assertThat(collation.get("numericOrdering")).isEqualTo(true);
+	}
+
+	@Test // DATAMONGO-1518
+	public void createCollationWithCollationHavingAlternate() {
+
+		template.createCollection(COLLECTION_NAME,
+				CollectionOptions.just(Collation.of("en_US").alternate(Alternate.shifted().punct())));
+
+		Document collation = getCollationInfo(COLLECTION_NAME);
+		assertThat(collation.get("alternate")).isEqualTo("shifted");
+		assertThat(collation.get("maxVariable")).isEqualTo("punct");
+	}
+
+	private Document getCollationInfo(String collectionName) {
+		return getCollectionInfo(collectionName).get("options", Document.class).get("collation", Document.class);
+	}
+
+	private Document getCollectionInfo(String collectionName) {
+
+		return template.execute(db -> {
+
+			Document result = db.runCommand(
+					new Document().append("listCollections", 1).append("filter", new Document("name", collectionName)));
+			return (Document) result.get("cursor", Document.class).get("firstBatch", List.class).get(0);
+		});
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate.QueryCursorPreparer;
+import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -59,6 +60,7 @@ public class QueryCursorPreparerUnitTests {
 		when(factory.getExceptionTranslator()).thenReturn(exceptionTranslatorMock);
 		when(cursor.modifiers(any(Document.class))).thenReturn(cursor);
 		when(cursor.noCursorTimeout(anyBoolean())).thenReturn(cursor);
+		when(cursor.collation(any())).thenReturn(cursor);
 	}
 
 	@Test // DATAMONGO-185
@@ -132,7 +134,6 @@ public class QueryCursorPreparerUnitTests {
 		assertThat(captor.getValue(), equalTo(new Document("$snapshot", true)));
 	}
 
-
 	@Test // DATAMONGO-1480
 	public void appliesNoCursorTimeoutCorrectly() {
 
@@ -141,6 +142,14 @@ public class QueryCursorPreparerUnitTests {
 		prepare(query);
 
 		verify(cursor).noCursorTimeout(eq(true));
+	}
+
+	@Test // DATAMONGO-1518
+	public void appliesCollationCorrectly() {
+
+		prepare(new BasicQuery("{}").collation(Collation.of("fr")));
+
+		verify(cursor).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
 	}
 
 	private FindIterable<Document> prepare(Query query) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -13,36 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.mongodb.core;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 
+import org.bson.Document;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Publisher;
+import org.springframework.data.mongodb.core.MongoTemplateUnitTests.AutogenerateableId;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate.NoOpDbRefResolver;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.NearQuery;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.reactivestreams.client.FindPublisher;
 import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 
 /**
  * Unit tests for {@link ReactiveMongoTemplate}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ReactiveMongoTemplateUnitTests {
 
 	ReactiveMongoTemplate template;
 
 	@Mock SimpleReactiveMongoDatabaseFactory factory;
 	@Mock MongoClient mongoClient;
+	@Mock MongoDatabase db;
+	@Mock MongoCollection collection;
+	@Mock FindPublisher findPublisher;
+	@Mock Publisher runCommandPublisher;
 
 	MongoExceptionTranslator exceptionTranslator = new MongoExceptionTranslator();
 	MappingMongoConverter converter;
@@ -52,10 +76,21 @@ public class ReactiveMongoTemplateUnitTests {
 	public void setUp() {
 
 		when(factory.getExceptionTranslator()).thenReturn(exceptionTranslator);
+		when(factory.getMongoDatabase()).thenReturn(db);
+		when(db.getCollection(any())).thenReturn(collection);
+		when(db.getCollection(any(), any())).thenReturn(collection);
+		when(db.runCommand(any(), any(Class.class))).thenReturn(runCommandPublisher);
+		when(collection.find()).thenReturn(findPublisher);
+		when(collection.find(Mockito.any(Document.class))).thenReturn(findPublisher);
+		when(findPublisher.projection(any())).thenReturn(findPublisher);
+		when(findPublisher.limit(anyInt())).thenReturn(findPublisher);
+		when(findPublisher.collation(any())).thenReturn(findPublisher);
+		when(findPublisher.first()).thenReturn(findPublisher);
 
 		this.mappingContext = new MongoMappingContext();
 		this.converter = new MappingMongoConverter(new NoOpDbRefResolver(), mappingContext);
 		this.template = new ReactiveMongoTemplate(factory, converter);
+
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1444
@@ -72,6 +107,155 @@ public class ReactiveMongoTemplateUnitTests {
 	public void defaultsConverterToMappingMongoConverter() throws Exception {
 		ReactiveMongoTemplate template = new ReactiveMongoTemplate(mongoClient, "database");
 		assertTrue(ReflectionTestUtils.getField(template, "mongoConverter") instanceof MappingMongoConverter);
+	}
+
+	@Test // DATAMONGO-1518
+	public void findShouldUseCollationWhenPresent() {
+
+		template.find(new BasicQuery("{}").collation(Collation.of("fr")), AutogenerateableId.class).subscribe();
+
+		verify(findPublisher).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
+	}
+
+	//
+	@Test // DATAMONGO-1518
+	public void findOneShouldUseCollationWhenPresent() {
+
+		template.findOne(new BasicQuery("{}").collation(Collation.of("fr")), AutogenerateableId.class).subscribe();
+
+		verify(findPublisher).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
+	}
+
+	@Test // DATAMONGO-1518
+	public void existsShouldUseCollationWhenPresent() {
+
+		template.exists(new BasicQuery("{}").collation(Collation.of("fr")), AutogenerateableId.class).subscribe();
+
+		verify(findPublisher).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
+	}
+
+	@Test // DATAMONGO-1518
+	public void findAndModfiyShoudUseCollationWhenPresent() {
+
+		template.findAndModify(new BasicQuery("{}").collation(Collation.of("fr")), new Update(), AutogenerateableId.class)
+				.subscribe();
+
+		ArgumentCaptor<FindOneAndUpdateOptions> options = ArgumentCaptor.forClass(FindOneAndUpdateOptions.class);
+		verify(collection).findOneAndUpdate(Mockito.any(), Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+	}
+
+	@Test // DATAMONGO-1518
+	public void findAndRemoveShouldUseCollationWhenPresent() {
+
+		template.findAndRemove(new BasicQuery("{}").collation(Collation.of("fr")), AutogenerateableId.class).subscribe();
+
+		ArgumentCaptor<FindOneAndDeleteOptions> options = ArgumentCaptor.forClass(FindOneAndDeleteOptions.class);
+		verify(collection).findOneAndDelete(Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+	}
+
+	@Ignore("see https://jira.mongodb.org/browse/JAVARS-27")
+	@Test // DATAMONGO-1518
+	public void findAndRemoveManyShouldUseCollationWhenPresent() {
+
+		template.doRemove("collection-1", new BasicQuery("{}").collation(Collation.of("fr")), AutogenerateableId.class)
+				.subscribe();
+
+		ArgumentCaptor<DeleteOptions> options = ArgumentCaptor.forClass(DeleteOptions.class);
+		// the current mongodb-driver-reactivestreams:1.4.0 driver does not offer deleteMany with options.
+		// verify(collection).deleteMany(Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+	}
+
+	@Test // DATAMONGO-1518
+	public void updateOneShouldUseCollationWhenPresent() {
+
+		template.updateFirst(new BasicQuery("{}").collation(Collation.of("fr")), new Update().set("foo", "bar"),
+				AutogenerateableId.class).subscribe();
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateOne(Mockito.any(), Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+	}
+
+	@Test // DATAMONGO-1518
+	public void updateManyShouldUseCollationWhenPresent() {
+
+		template.updateMulti(new BasicQuery("{}").collation(Collation.of("fr")), new Update().set("foo", "bar"),
+				AutogenerateableId.class).subscribe();
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateMany(Mockito.any(), Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+
+	}
+
+	@Test // DATAMONGO-1518
+	public void replaceOneShouldUseCollationWhenPresent() {
+
+		template.updateFirst(new BasicQuery("{}").collation(Collation.of("fr")), new Update(), AutogenerateableId.class)
+				.subscribe();
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).replaceOne(Mockito.any(), Mockito.any(), options.capture());
+
+		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
+	}
+
+	@Ignore("currently no aggregation")
+	@Test // DATAMONGO-1518
+	public void aggregateShouldUseCollationWhenPresent() {
+
+		Aggregation aggregation = newAggregation(project("id"))
+				.withOptions(newAggregationOptions().collation(Collation.of("fr")).build());
+		// template.aggregate(aggregation, AutogenerateableId.class, Document.class).subscribe();
+
+		ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
+		verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
+
+		assertThat(cmd.getValue().get("collation", Document.class), equalTo(new Document("locale", "fr")));
+	}
+
+	@Ignore("currently no mapReduce")
+	@Test // DATAMONGO-1518
+	public void mapReduceShouldUseCollationWhenPresent() {
+
+		// template.mapReduce("", "", "", MapReduceOptions.options().collation(Collation.of("fr")),
+		// AutogenerateableId.class).subscribe();
+		//
+		// verify(mapReduceIterable).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
+	}
+
+	@Test // DATAMONGO-1518
+	public void geoNearShouldUseCollationWhenPresent() {
+
+		NearQuery query = NearQuery.near(0D, 0D).query(new BasicQuery("{}").collation(Collation.of("fr")));
+		template.geoNear(query, AutogenerateableId.class).subscribe();
+
+		ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
+		verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
+
+		assertThat(cmd.getValue().get("collation", Document.class), equalTo(new Document("locale", "fr")));
+	}
+
+	@Ignore("currently no groupBy")
+	@Test // DATAMONGO-1518
+	public void groupShouldUseCollationWhenPresent() {
+
+		// template.group("collection-1", GroupBy.key("id").reduceFunction("bar").collation(Collation.of("fr")),
+		// AutogenerateableId.class).subscribe();
+		//
+		// ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
+		// verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
+		//
+		// assertThat(cmd.getValue().get("group", Document.class).get("collation", Document.class),
+		// equalTo(new Document("locale", "fr")));
 	}
 
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -244,18 +244,4 @@ public class ReactiveMongoTemplateUnitTests {
 		assertThat(cmd.getValue().get("collation", Document.class), equalTo(new Document("locale", "fr")));
 	}
 
-	@Ignore("currently no groupBy")
-	@Test // DATAMONGO-1518
-	public void groupShouldUseCollationWhenPresent() {
-
-		// template.group("collection-1", GroupBy.key("id").reduceFunction("bar").collation(Collation.of("fr")),
-		// AutogenerateableId.class).subscribe();
-		//
-		// ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
-		// verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
-		//
-		// assertThat(cmd.getValue().get("group", Document.class).get("collation", Document.class),
-		// equalTo(new Document("locale", "fr")));
-	}
-
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOptionsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOptionsTests.java
@@ -19,8 +19,6 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +28,7 @@ import org.junit.Test;
  * 
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 1.6
  */
 public class AggregationOptionsTests {
@@ -49,7 +48,7 @@ public class AggregationOptionsTests {
 
 		assertThat(aggregationOptions.isAllowDiskUse(), is(true));
 		assertThat(aggregationOptions.isExplain(), is(true));
-		assertThat(aggregationOptions.getCursor(), is(new Document("batchSize", 1)));
+		assertThat(aggregationOptions.getCursor().get(), is(new Document("batchSize", 1)));
 	}
 
 	@Test // DATAMONGO-1637
@@ -64,7 +63,7 @@ public class AggregationOptionsTests {
 
 		assertThat(aggregationOptions.isAllowDiskUse(), is(true));
 		assertThat(aggregationOptions.isExplain(), is(true));
-		assertThat(aggregationOptions.getCursor(), is(new Document("batchSize", 1)));
+		assertThat(aggregationOptions.getCursor().get(), is(new Document("batchSize", 1)));
 		assertThat(aggregationOptions.getCursorBatchSize(), is(1));
 	}
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,6 +7,7 @@
 * Usage of the `Document` API instead of `DBObject`.
 * <<mongo.reactive>>.
 * Support for aggregation result streaming via Java 8 `Stream`.
+* Integration of collations for collection and index creation and query operations.
 
 [[new-features.1-10-0]]
 == What's new in Spring Data MongoDB 1.10

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1344,6 +1344,85 @@ TextQuery.searching(new TextCriteria().phrase("coffee cake"));
 
 The flags for `$caseSensitive` and `$diacriticSensitive` can be set via the according methods on `TextCriteria`. Please note that these two optional flags have been introduced in MongoDB 3.2 and will not be included in the query unless explicitly set.
 
+[[mongo.collation]]
+=== Collations
+
+MongoDB supports since 3.4 collations for collection and index creation and various query operations. Collations define string comparison rules based on the http://userguide.icu-project.org/collation/concepts[ICU collations]. A collation document consists of various properties that are encapsulated in `Collation`:
+
+====
+[source,java]
+----
+Collation collation = Collation.of("fr")         <1>
+
+  .strength(ComparisonLevel.secondary()          <2>
+    .includeCase())
+
+  .numericOrderingEnabled()                      <3>
+
+  .alternate(Alternate.shifted().punct())        <4>
+
+  .forwardDiacriticSort()                        <5>
+
+  .normalizationEnabled();                       <6>
+----
+<1> `Collation` requires a locale for creation. This can be either a string representation of the locale, a `Locale` (considering language, country and variant) or a `CollationLocale`. The locale is mandatory for creation.
+<2> Collation strength defines comparison levels denoting differences between characters. You can configure various options (case-sensitivity, case-ordering) depending on the selected strength.
+<3> Specify whether to compare numeric strings as numbers or as strings.
+<4> Specify whether the collation should consider whitespace and punctuation as base characters for purposes of comparison.
+<5> Specify whether strings with diacritics sort from back of the string, such as with some French dictionary ordering.
+<6> Specify whether to check if text requires normalization and to perform normalization.
+====
+
+Collations can be used to create collections and indexes. If you create a collection specifying a collation, the collation is applied to index creation and queries unless you specify a different collation. A collation is valid for a whole operation and cannot be specified on a per-field basis.
+
+[source,java]
+----
+Collation french = Collation.of("fr");
+Collation german = Collation.of("de");
+
+template.createCollection(Person.class, CollectionOptions.just(collation));
+
+template.indexOps(Person.class).ensureIndex(new Index("name", Direction.ASC).collation(german));
+----
+
+NOTE: MongoDB uses simple binary comparison if no collation is specified (`Collation.simple()`).
+
+Using collations with collection operations is a matter of specifying a `Collation` instance in your query or operation options.
+
+.Using collation with `find`
+====
+[source,java]
+----
+Collation collation = Collation.of("de");
+
+Query query = new Query(Criteria.where("firstName").is("Amél")).collation(collation);
+
+List<Person> results = template.find(query, Person.class);
+----
+====
+
+.Using collation with `aggregate`
+====
+[source,java]
+----
+Collation collation = Collation.of("de");
+
+AggregationOptions options = new AggregationOptions.Builder().collation(collation).build();
+
+Aggregation aggregation = newAggregation(
+  project("tags"),
+  unwind("tags"),
+  group("tags")
+    .count().as("count")
+).withOptions(options);
+
+AggregationResults<TagCount> results = template.aggregate(aggregation, "tags", TagCount.class);
+----
+====
+
+WARNING: Indexes are only used if the collation used for the operation and the index collation matches.
+
+
 include::../{spring-data-commons-docs}/query-by-example.adoc[leveloffset=+1]
 include::query-by-example.adoc[leveloffset=+1]
 
@@ -2241,6 +2320,8 @@ You can create standard, geospatial and text indexes using the classes `IndexDef
 mongoTemplate.indexOps(Venue.class).ensureIndex(new GeospatialIndex("location"));
 ----
 
+NOTE: `Index` and `GeospatialIndex` support configuration of <<mongo.collation,collations>>.
+
 [[mongo-template.index-and-collections.access]]
 === Accessing index information
 
@@ -2280,6 +2361,8 @@ mongoTemplate.dropCollection("MyNewCollection");
 * *createCollection* Create an uncapped collection
 * *dropCollection* Drop the collection
 * *getCollection* Get a collection by name, creating it if it doesn't exist.
+
+NOTE: Collection creation allows customization via `CollectionOptions` and supports <<mongo.collation,collations>>.
 
 [[mongo-template.commands]]
 == Executing Commands


### PR DESCRIPTION
We now support ``Collation``s for collections, indexes, queries, findAndModify, delete, geo, bulk and aggregation operations in both the imperative and reactive implementations on template level.

We still need to think about collation support via annotations for the repository layer and QueryByExampleExecuter.