### PR TITLE
DATAMONGO-1685 - Adapt to QueryByExampleExecutor API changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -28,7 +28,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.0.0.DATACMNS-1058-SNAPSHOT</springdata.commons>
 		<mongo>3.4.2</mongo>
 		<mongo.reactivestreams>1.3.0</mongo.reactivestreams>
 	</properties>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1685-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
@@ -312,12 +312,13 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 	 * @see org.springframework.data.repository.query.QueryByExampleExecutor#findOne(org.springframework.data.domain.Example)
 	 */
 	@Override
-	public <S extends T> S findOne(Example<S> example) {
+	public <S extends T> Optional<S> findOne(Example<S> example) {
 
 		Assert.notNull(example, "Sample must not be null!");
 
 		Query q = new Query(new Criteria().alike(example));
-		return mongoOperations.findOne(q, example.getProbeType(), entityInformation.getCollectionName());
+		return Optional
+				.ofNullable(mongoOperations.findOne(q, example.getProbeType(), entityInformation.getCollectionName()));
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ContactRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ContactRepositoryIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * 
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("config/MongoNamespaceIntegrationTests-context.xml")
@@ -57,6 +58,6 @@ public class ContactRepositoryIntegrationTests {
 
 		Person person = repository.save(new Person("Oliver", "Gierke"));
 
-		assertThat(repository.findOne(Example.of(person)), instanceOf(Person.class));
+		assertThat(repository.findOne(Example.of(person)).get(), instanceOf(Person.class));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ContactRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ContactRepositoryIntegrationTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.mongodb.repository;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class ContactRepositoryIntegrationTests {
 		Person person = new Person("Oliver", "Gierke");
 		Contact result = repository.save(person);
 
-		assertTrue(repository.findById(result.getId().toString()).get() instanceof Person);
+		assertThat(repository.findById(result.getId().toString())).containsInstanceOf(Person.class);
 	}
 
 	@Test // DATAMONGO-1245
@@ -58,6 +57,6 @@ public class ContactRepositoryIntegrationTests {
 
 		Person person = repository.save(new Person("Oliver", "Gierke"));
 
-		assertThat(repository.findOne(Example.of(person)).get(), instanceOf(Person.class));
+		assertThat(repository.findOne(Example.of(person))).containsInstanceOf(Person.class);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.support;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.domain.ExampleMatcher.*;
 
 import java.util.ArrayList;
@@ -29,15 +28,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
-import org.springframework.data.domain.ExampleMatcher.StringMatcher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.ExampleMatcher.*;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
@@ -87,32 +85,28 @@ public class SimpleMongoRepositoryTests {
 
 	@Test
 	public void findALlFromCustomCollectionName() {
-		List<Person> result = repository.findAll();
-		assertThat(result, hasSize(all.size()));
+		assertThat(repository.findAll()).hasSize(all.size());
 	}
 
 	@Test
 	public void findOneFromCustomCollectionName() {
-		Person result = repository.findById(dave.getId()).get();
-		assertThat(result, is(dave));
+		assertThat(repository.findById(dave.getId()).get()).isEqualTo(dave);
 	}
 
 	@Test
 	public void deleteFromCustomCollectionName() {
-		repository.delete(dave);
-		List<Person> result = repository.findAll();
 
-		assertThat(result, hasSize(all.size() - 1));
-		assertThat(result, not(hasItem(dave)));
+		repository.delete(dave);
+
+		assertThat(repository.findAll()).hasSize(all.size() - 1).doesNotContain(dave);
 	}
 
 	@Test
 	public void deleteByIdFromCustomCollectionName() {
-		repository.deleteById(dave.getId());
-		List<Person> result = repository.findAll();
 
-		assertThat(result, hasSize(all.size() - 1));
-		assertThat(result, not(hasItem(dave)));
+		repository.deleteById(dave.getId());
+
+		assertThat(repository.findAll()).hasSize(all.size() - 1).doesNotContain(dave);
 	}
 
 	@Test // DATAMONGO-1054
@@ -123,9 +117,7 @@ public class SimpleMongoRepositoryTests {
 		Person person1 = new Person("First1" + randomId, "Last2" + randomId, 42);
 		person1 = repository.insert(person1);
 
-		Person saved = repository.findById(person1.getId()).get();
-
-		assertThat(saved, is(equalTo(person1)));
+		assertThat(repository.findById(person1.getId())).contains(person1);
 	}
 
 	@Test // DATAMONGO-1054
@@ -143,7 +135,7 @@ public class SimpleMongoRepositoryTests {
 
 		List<Person> saved = repository.insert(persons);
 
-		assertThat(saved, hasSize(persons.size()));
+		assertThat(saved).hasSize(persons.size());
 		assertThatAllReferencePersonsWereStoredCorrectly(idToPerson, saved);
 	}
 
@@ -162,7 +154,7 @@ public class SimpleMongoRepositoryTests {
 
 		List<Person> saved = repository.insert(persons);
 
-		assertThat(saved, hasSize(persons.size()));
+		assertThat(saved).hasSize(persons.size());
 		assertThatAllReferencePersonsWereStoredCorrectly(idToPerson, saved);
 	}
 
@@ -175,9 +167,8 @@ public class SimpleMongoRepositoryTests {
 
 		Page<Person> result = repository.findAll(Example.of(sample), PageRequest.of(0, 10));
 
-		assertThat(result.getContent(), hasItems(dave, oliver));
-		assertThat(result.getContent(), hasSize(2));
-		assertThat(result.getTotalPages(), is(1));
+		assertThat(result.getContent()).hasSize(2).contains(dave, oliver);
+		assertThat(result.getTotalPages()).isEqualTo(1);
 	}
 
 	@Test // DATAMONGO-1464
@@ -189,8 +180,8 @@ public class SimpleMongoRepositoryTests {
 
 		Page<Person> result = repository.findAll(Example.of(sample), PageRequest.of(0, 1));
 
-		assertThat(result.getContent(), hasSize(1));
-		assertThat(result.getTotalPages(), is(2));
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getTotalPages()).isEqualTo(2);
 	}
 
 	@Test // DATAMONGO-1245
@@ -200,10 +191,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setLastname("Matthews");
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, containsInAnyOrder(dave, oliver));
-		assertThat(result, hasSize(2));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(2).contains(dave, oliver);
 	}
 
 	@Test // DATAMONGO-1245
@@ -219,10 +207,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setAddress(dave.getAddress());
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasItem(dave));
-		assertThat(result, hasSize(1));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(1).contains(dave);
 	}
 
 	@Test // DATAMONGO-1245
@@ -238,10 +223,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setAddress(new Address(null, null, "Washington"));
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasItems(dave, oliver));
-		assertThat(result, hasSize(2));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(2).contains(dave, oliver);
 	}
 
 	@Test // DATAMONGO-1245
@@ -255,9 +237,8 @@ public class SimpleMongoRepositoryTests {
 		trimDomainType(sample, "id", "createdAt", "email");
 
 		Example<Person> example = Example.of(sample, matching().withIncludeNullValues());
-		List<Person> result = repository.findAll(example);
 
-		assertThat(result, empty());
+		assertThat(repository.findAll(example)).isEmpty();
 	}
 
 	@Test // DATAMONGO-1245
@@ -271,10 +252,8 @@ public class SimpleMongoRepositoryTests {
 		trimDomainType(sample, "id", "createdAt", "email");
 
 		Example<Person> example = Example.of(sample, matching().withIncludeNullValues());
-		List<Person> result = repository.findAll(example);
 
-		assertThat(result, hasItem(dave));
-		assertThat(result, hasSize(1));
+		assertThat(repository.findAll(example)).hasSize(1).contains(dave);
 	}
 
 	@Test // DATAMONGO-1245
@@ -285,10 +264,8 @@ public class SimpleMongoRepositoryTests {
 		trimDomainType(sample, "id", "createdAt", "email");
 
 		Example<Person> example = Example.of(sample, matching().withStringMatcher(StringMatcher.STARTING));
-		List<Person> result = repository.findAll(example);
 
-		assertThat(result, hasItems(dave, oliver));
-		assertThat(result, hasSize(2));
+		assertThat(repository.findAll(example)).hasSize(2).contains(dave, oliver);
 	}
 
 	@Test // DATAMONGO-1245
@@ -308,10 +285,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setCreator(user);
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasItem(megan));
-		assertThat(result, hasSize(1));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(1).contains(megan);
 	}
 
 	@Test // DATAMONGO-1245
@@ -326,10 +300,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setLocation(megan.getLocation());
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasItem(megan));
-		assertThat(result, hasSize(1));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(1).contains(megan);
 	}
 
 	@Test // DATAMONGO-1245
@@ -344,10 +315,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setLocation(megan.getLocation());
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<Person> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasItem(megan));
-		assertThat(result, hasSize(1));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(1).contains(megan);
 	}
 
 	@Test // DATAMONGO-1245
@@ -363,10 +331,7 @@ public class SimpleMongoRepositoryTests {
 
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		List<PersonExtended> result = repository.findAll(Example.of(sample));
-
-		assertThat(result, hasSize(1));
-		assertThat(result, hasItem(reference));
+		assertThat(repository.findAll(Example.of(sample))).hasSize(1).contains(reference);
 	}
 
 	@Test // DATAMONGO-1245
@@ -377,9 +342,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setLastname("Matthews");
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		Optional<Person> result = repository.findOne(Example.of(sample));
-
-		Assertions.assertThat(result).isPresent().contains(dave);
+		assertThat(repository.findOne(Example.of(sample))).isPresent().contains(dave);
 	}
 
 	@Test // DATAMONGO-1245
@@ -390,9 +353,7 @@ public class SimpleMongoRepositoryTests {
 		sample.setLastname("Matthews");
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		boolean result = repository.exists(Example.of(sample));
-
-		assertThat(result, is(true));
+		assertThat(repository.exists(Example.of(sample))).isTrue();
 	}
 
 	@Test // DATAMONGO-1245
@@ -402,16 +363,14 @@ public class SimpleMongoRepositoryTests {
 		sample.setLastname("Matthews");
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		long result = repository.count(Example.of(sample));
-
-		assertThat(result, is(equalTo(2L)));
+		assertThat(repository.count(Example.of(sample))).isEqualTo(2L);
 	}
 
 	private void assertThatAllReferencePersonsWereStoredCorrectly(Map<String, Person> references, List<Person> saved) {
 
 		for (Person person : saved) {
 			Person reference = references.get(person.getId());
-			assertThat(person, is(equalTo(reference)));
+			assertThat(person).isEqualTo(reference);
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryTests.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -376,9 +377,9 @@ public class SimpleMongoRepositoryTests {
 		sample.setLastname("Matthews");
 		trimDomainType(sample, "id", "createdAt", "email");
 
-		Person result = repository.findOne(Example.of(sample));
+		Optional<Person> result = repository.findOne(Example.of(sample));
 
-		assertThat(result, is(equalTo(dave)));
+		Assertions.assertThat(result).isPresent().contains(dave);
 	}
 
 	@Test // DATAMONGO-1245


### PR DESCRIPTION
Use `Optional` as return type for `findOne(Example example)`.

See DATACMNS-1058 (spring-projects/spring-data-commons#214) for details.