### PR TITLE
DATAMONGO-1690 - Adapt to QuerydslPredicateExecutor API changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -28,7 +28,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.0.0.DATACMNS-1059-SNAPSHOT</springdata.commons>
 		<mongo>3.4.2</mongo>
 		<mongo.reactivestreams>1.3.0</mongo.reactivestreams>
 	</properties>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1690-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
@@ -106,7 +106,7 @@ public class MongoRepositoryFactory extends RepositoryFactorySupport {
 			return SimpleReactiveMongoRepository.class;
 		}
 
-		return isQueryDslRepository ? QueryDslMongoRepository.class : SimpleMongoRepository.class;
+		return isQueryDslRepository ? QuerydslMongoRepository.class : SimpleMongoRepository.class;
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoRepository.java
@@ -45,14 +45,14 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.mongodb.AbstractMongodbQuery;
 
 /**
- * Special QueryDsl based repository implementation that allows execution {@link Predicate}s in various forms.
- * 
+ * Special Querydsl based repository implementation that allows execution {@link Predicate}s in various forms.
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
  */
-public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleMongoRepository<T, ID>
+public class QuerydslMongoRepository<T, ID extends Serializable> extends SimpleMongoRepository<T, ID>
 		implements QuerydslPredicateExecutor<T> {
 
 	private final PathBuilder<T> builder;
@@ -60,25 +60,25 @@ public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleM
 	private final MongoOperations mongoOperations;
 
 	/**
-	 * Creates a new {@link QueryDslMongoRepository} for the given {@link EntityMetadata} and {@link MongoTemplate}. Uses
+	 * Creates a new {@link QuerydslMongoRepository} for the given {@link EntityMetadata} and {@link MongoTemplate}. Uses
 	 * the {@link SimpleEntityPathResolver} to create an {@link EntityPath} for the given domain class.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param mongoOperations must not be {@literal null}.
 	 */
-	public QueryDslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations) {
+	public QuerydslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations) {
 		this(entityInformation, mongoOperations, SimpleEntityPathResolver.INSTANCE);
 	}
 
 	/**
-	 * Creates a new {@link QueryDslMongoRepository} for the given {@link MongoEntityInformation}, {@link MongoTemplate}
+	 * Creates a new {@link QuerydslMongoRepository} for the given {@link MongoEntityInformation}, {@link MongoTemplate}
 	 * and {@link EntityPathResolver}.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param mongoOperations must not be {@literal null}.
 	 * @param resolver must not be {@literal null}.
 	 */
-	public QueryDslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations,
+	public QuerydslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations,
 			EntityPathResolver resolver) {
 
 		super(entityInformation, mongoOperations);
@@ -227,7 +227,7 @@ public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleM
 
 	/**
 	 * Creates a {@link MongodbQuery} for the given {@link Predicate}.
-	 * 
+	 *
 	 * @param predicate
 	 * @return
 	 */
@@ -246,7 +246,7 @@ public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleM
 
 	/**
 	 * Applies the given {@link Pageable} to the given {@link MongodbQuery}.
-	 * 
+	 *
 	 * @param query
 	 * @param pageable
 	 * @return
@@ -260,7 +260,7 @@ public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleM
 
 	/**
 	 * Applies the given {@link Sort} to the given {@link MongodbQuery}.
-	 * 
+	 *
 	 * @param query
 	 * @param sort
 	 * @return
@@ -284,7 +284,7 @@ public class QueryDslMongoRepository<T, ID extends Serializable> extends SimpleM
 
 	/**
 	 * Transforms a plain {@link Order} into a QueryDsl specific {@link OrderSpecifier}.
-	 * 
+	 *
 	 * @param order
 	 * @return
 	 */

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -917,7 +917,7 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 		dave.setCreator(user);
 		operations.save(dave);
 
-		assertThat(repository.findOne(QPerson.person.creator.eq(user)), is(dave));
+		assertThat(repository.findOne(QPerson.person.creator.eq(user)).get(), is(dave));
 	}
 
 	@Test // DATAMONGO-969

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QueryDslMongoRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QueryDslMongoRepositoryIntegrationTests.java
@@ -15,13 +15,11 @@
  */
 package org.springframework.data.mongodb.repository.support;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +35,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
- * Integration test for {@link QueryDslMongoRepository}.
+ * Integration test for {@link QuerydslMongoRepository}.
  *
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -49,7 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class QueryDslMongoRepositoryIntegrationTests {
 
 	@Autowired MongoOperations operations;
-	QueryDslMongoRepository<Person, String> repository;
+	QuerydslMongoRepository<Person, String> repository;
 
 	Person dave, oliver, carter;
 	QPerson person;
@@ -59,7 +57,7 @@ public class QueryDslMongoRepositoryIntegrationTests {
 
 		MongoRepositoryFactory factory = new MongoRepositoryFactory(operations);
 		MongoEntityInformation<Person, String> entityInformation = factory.getEntityInformation(Person.class);
-		repository = new QueryDslMongoRepository<Person, String>(entityInformation, operations);
+		repository = new QuerydslMongoRepository<>(entityInformation, operations);
 
 		operations.dropCollection(Person.class);
 
@@ -75,8 +73,8 @@ public class QueryDslMongoRepositoryIntegrationTests {
 	@Test // DATAMONGO-1146
 	public void shouldSupportExistsWithPredicate() throws Exception {
 
-		assertThat(repository.exists(person.firstname.eq("Dave")), is(true));
-		assertThat(repository.exists(person.firstname.eq("Unknown")), is(false));
+		assertThat(repository.exists(person.firstname.eq("Dave"))).isTrue();
+		assertThat(repository.exists(person.firstname.eq("Unknown"))).isFalse();
 	}
 
 	@Test // DATAMONGO-1167
@@ -84,20 +82,17 @@ public class QueryDslMongoRepositoryIntegrationTests {
 
 		List<Person> users = repository.findAll(person.lastname.isNotNull(), Sort.by(Direction.ASC, "firstname"));
 
-		assertThat(users, hasSize(3));
-		assertThat(users.get(0).getFirstname(), is(carter.getFirstname()));
-		assertThat(users.get(2).getFirstname(), is(oliver.getFirstname()));
-		assertThat(users, hasItems(carter, dave, oliver));
+		assertThat(users).containsExactly(carter, dave, oliver);
 	}
 
 	@Test // DATAMONGO-1690
 	public void findOneWithPredicateReturnsResultCorrectly() {
-		Assertions.assertThat(repository.findOne(person.firstname.eq(dave.getFirstname()))).contains(dave);
+		assertThat(repository.findOne(person.firstname.eq(dave.getFirstname()))).contains(dave);
 	}
 
 	@Test // DATAMONGO-1690
 	public void findOneWithPredicateReturnsOptionalEmptyWhenNoDataFound() {
-		Assertions.assertThat(repository.findOne(person.firstname.eq("batman"))).isNotPresent();
+		assertThat(repository.findOne(person.firstname.eq("batman"))).isNotPresent();
 	}
 
 	@Test(expected = IncorrectResultSizeDataAccessException.class) // DATAMONGO-1690


### PR DESCRIPTION
We now return `Optional<T>` for `findOne(Predicate)`.

See DATACMNS-1059 for details.

Depends on: spring-projects/spring-data-commons#215