### PR TITLE
DATAMONGO-1678 - Run bulk update / remove operations through Query-/UpdateMappers.

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.nonNull.exceptionType = IllegalArgumentException
+lombok.log.fieldName = LOG

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1678-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1678-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1678-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1678-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1678-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/BulkOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/BulkOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import com.mongodb.bulk.BulkWriteResult;
  * 2.6 and make use of low level bulk commands on the protocol level. This interface defines a fluent API to add
  * multiple single operations or list of similar operations in sequence which can then eventually be executed by calling
  * {@link #execute()}.
- * 
+ *
  * @author Tobias Trelle
  * @author Oliver Gierke
  * @since 1.9
@@ -49,7 +49,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a single insert to the bulk operation.
-	 * 
+	 *
 	 * @param documents the document to insert, must not be {@literal null}.
 	 * @return the current {@link BulkOperations} instance with the insert added, will never be {@literal null}.
 	 */
@@ -57,7 +57,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a list of inserts to the bulk operation.
-	 * 
+	 *
 	 * @param documents List of documents to insert, must not be {@literal null}.
 	 * @return the current {@link BulkOperations} instance with the insert added, will never be {@literal null}.
 	 */
@@ -65,7 +65,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a single update to the bulk operation. For the update request, only the first matching document is updated.
-	 * 
+	 *
 	 * @param query update criteria, must not be {@literal null}.
 	 * @param update {@link Update} operation to perform, must not be {@literal null}.
 	 * @return the current {@link BulkOperations} instance with the update added, will never be {@literal null}.
@@ -74,7 +74,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a list of updates to the bulk operation. For each update request, only the first matching document is updated.
-	 * 
+	 *
 	 * @param updates Update operations to perform.
 	 * @return the current {@link BulkOperations} instance with the update added, will never be {@literal null}.
 	 */
@@ -82,7 +82,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a single update to the bulk operation. For the update request, all matching documents are updated.
-	 * 
+	 *
 	 * @param query Update criteria.
 	 * @param update Update operation to perform.
 	 * @return the current {@link BulkOperations} instance with the update added, will never be {@literal null}.
@@ -91,7 +91,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a list of updates to the bulk operation. For each update request, all matching documents are updated.
-	 * 
+	 *
 	 * @param updates Update operations to perform.
 	 * @return The bulk operation.
 	 * @return the current {@link BulkOperations} instance with the update added, will never be {@literal null}.
@@ -101,7 +101,7 @@ public interface BulkOperations {
 	/**
 	 * Add a single upsert to the bulk operation. An upsert is an update if the set of matching documents is not empty,
 	 * else an insert.
-	 * 
+	 *
 	 * @param query Update criteria.
 	 * @param update Update operation to perform.
 	 * @return The bulk operation.
@@ -112,7 +112,7 @@ public interface BulkOperations {
 	/**
 	 * Add a list of upserts to the bulk operation. An upsert is an update if the set of matching documents is not empty,
 	 * else an insert.
-	 * 
+	 *
 	 * @param updates Updates/insert operations to perform.
 	 * @return The bulk operation.
 	 * @return the current {@link BulkOperations} instance with the update added, will never be {@literal null}.
@@ -121,7 +121,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a single remove operation to the bulk operation.
-	 * 
+	 *
 	 * @param remove the {@link Query} to select the documents to be removed, must not be {@literal null}.
 	 * @return the current {@link BulkOperations} instance with the removal added, will never be {@literal null}.
 	 */
@@ -129,7 +129,7 @@ public interface BulkOperations {
 
 	/**
 	 * Add a list of remove operations to the bulk operation.
-	 * 
+	 *
 	 * @param removes the remove operations to perform, must not be {@literal null}.
 	 * @return the current {@link BulkOperations} instance with the removal added, will never be {@literal null}.
 	 */
@@ -137,9 +137,9 @@ public interface BulkOperations {
 
 	/**
 	 * Execute all bulk operations using the default write concern.
-	 * 
+	 *
 	 * @return Result of the bulk operation providing counters for inserts/updates etc.
-	 * @throws {@link BulkOperationException} if an error occurred during bulk processing.
+	 * @throws org.springframework.data.mongodb.BulkOperationException if an error occurred during bulk processing.
 	 */
 	BulkWriteResult execute();
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -562,7 +562,6 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				new BulkOperationContext(mode, getPersistentEntity(entityType), queryMapper, updateMapper));
 
 		operations.setExceptionTranslator(exceptionTranslator);
-		operations.setWriteConcernResolver(writeConcernResolver);
 		operations.setDefaultWriteConcern(writeConcern);
 
 		return operations;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -67,6 +67,7 @@ import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
+import org.springframework.data.mongodb.core.DefaultBulkOperations.BulkOperationContext;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
@@ -557,7 +558,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Assert.notNull(mode, "BulkMode must not be null!");
 		Assert.hasText(collectionName, "Collection name must not be null or empty!");
 
-		DefaultBulkOperations operations = new DefaultBulkOperations(this, mode, collectionName, entityType);
+		DefaultBulkOperations operations = new DefaultBulkOperations(this, collectionName,
+				new BulkOperationContext(mode, getPersistentEntity(entityType), queryMapper, updateMapper));
 
 		operations.setExceptionTranslator(exceptionTranslator);
 		operations.setWriteConcernResolver(writeConcernResolver);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.any;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
 
 import java.util.List;
 
@@ -31,7 +33,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
+import org.springframework.data.mongodb.core.DefaultBulkOperations.BulkOperationContext;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.convert.UpdateMapper;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Update;
 
@@ -49,14 +58,25 @@ public class DefaultBulkOperationsUnitTests {
 
 	@Mock MongoTemplate template;
 	@Mock MongoCollection collection;
+	@Mock DbRefResolver dbRefResolver;
+	MongoConverter converter;
+	MongoMappingContext mappingContext;
 
 	DefaultBulkOperations ops;
 
 	@Before
 	public void setUp() {
 
+		mappingContext = new MongoMappingContext();
+		mappingContext.afterPropertiesSet();
+
+		converter = new MappingMongoConverter(dbRefResolver, mappingContext);
+
 		when(template.getCollection(anyString())).thenReturn(collection);
-		ops = new DefaultBulkOperations(template, BulkMode.ORDERED, "collection-1", SomeDomainType.class);
+
+		ops = new DefaultBulkOperations(template, "collection-1",
+				new BulkOperationContext(BulkMode.ORDERED, mappingContext.getPersistentEntity(SomeDomainType.class),
+						new QueryMapper(converter), new UpdateMapper(converter)));
 	}
 
 	@Test // DATAMONGO-1518
@@ -101,6 +121,33 @@ public class DefaultBulkOperationsUnitTests {
 		assertThat(captor.getValue().get(0)).isInstanceOf(DeleteManyModel.class);
 		assertThat(((DeleteManyModel) captor.getValue().get(0)).getOptions().getCollation())
 				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
+	}
+
+	@Test // DATAMONGO-1678
+	public void bulkUpdateShouldMapQueryAndUpdateCorrectly() {
+
+		ops.updateOne(query(where("firstName").is("danerys")), Update.update("firstName", "queen danerys")).execute();
+
+		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
+
+		verify(collection).bulkWrite(captor.capture(), any());
+
+		UpdateOneModel<Document> updateModel = (UpdateOneModel) captor.getValue().get(0);
+		assertThat(updateModel.getFilter()).isEqualTo(new Document("first_name", "danerys"));
+		assertThat(updateModel.getUpdate()).isEqualTo(new Document("$set", new Document("first_name", "queen danerys")));
+	}
+
+	@Test // DATAMONGO-1678
+	public void bulkRemoveShouldMapQueryCorrectly() {
+
+		ops.remove(query(where("firstName").is("danerys"))).execute();
+
+		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
+
+		verify(collection).bulkWrite(captor.capture(), any());
+
+		DeleteManyModel<Document> updateModel = (DeleteManyModel) captor.getValue().get(0);
+		assertThat(updateModel.getFilter()).isEqualTo(new Document("first_name", "danerys"));
 	}
 
 	class SomeDomainType {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.annotation.Id;
@@ -57,8 +58,9 @@ import com.mongodb.client.model.WriteModel;
 public class DefaultBulkOperationsUnitTests {
 
 	@Mock MongoTemplate template;
-	@Mock MongoCollection collection;
+	@Mock MongoCollection<Document> collection;
 	@Mock DbRefResolver dbRefResolver;
+	@Captor ArgumentCaptor<List<WriteModel<Document>>> captor;
 	MongoConverter converter;
 	MongoMappingContext mappingContext;
 
@@ -85,12 +87,10 @@ public class DefaultBulkOperationsUnitTests {
 		ops.updateOne(new BasicQuery("{}").collation(Collation.of("de")), new Update().set("lastName", "targaryen"))
 				.execute();
 
-		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
-
 		verify(collection).bulkWrite(captor.capture(), any());
 
 		assertThat(captor.getValue().get(0)).isInstanceOf(UpdateOneModel.class);
-		assertThat(((UpdateOneModel) captor.getValue().get(0)).getOptions().getCollation())
+		assertThat(((UpdateOneModel<Document>) captor.getValue().get(0)).getOptions().getCollation())
 				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
 	}
 
@@ -100,12 +100,10 @@ public class DefaultBulkOperationsUnitTests {
 		ops.updateMulti(new BasicQuery("{}").collation(Collation.of("de")), new Update().set("lastName", "targaryen"))
 				.execute();
 
-		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
-
 		verify(collection).bulkWrite(captor.capture(), any());
 
 		assertThat(captor.getValue().get(0)).isInstanceOf(UpdateManyModel.class);
-		assertThat(((UpdateManyModel) captor.getValue().get(0)).getOptions().getCollation())
+		assertThat(((UpdateManyModel<Document>) captor.getValue().get(0)).getOptions().getCollation())
 				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
 	}
 
@@ -114,12 +112,10 @@ public class DefaultBulkOperationsUnitTests {
 
 		ops.remove(new BasicQuery("{}").collation(Collation.of("de"))).execute();
 
-		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
-
 		verify(collection).bulkWrite(captor.capture(), any());
 
 		assertThat(captor.getValue().get(0)).isInstanceOf(DeleteManyModel.class);
-		assertThat(((DeleteManyModel) captor.getValue().get(0)).getOptions().getCollation())
+		assertThat(((DeleteManyModel<Document>) captor.getValue().get(0)).getOptions().getCollation())
 				.isEqualTo(com.mongodb.client.model.Collation.builder().locale("de").build());
 	}
 
@@ -128,11 +124,9 @@ public class DefaultBulkOperationsUnitTests {
 
 		ops.updateOne(query(where("firstName").is("danerys")), Update.update("firstName", "queen danerys")).execute();
 
-		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
-
 		verify(collection).bulkWrite(captor.capture(), any());
 
-		UpdateOneModel<Document> updateModel = (UpdateOneModel) captor.getValue().get(0);
+		UpdateOneModel<Document> updateModel = (UpdateOneModel<Document>) captor.getValue().get(0);
 		assertThat(updateModel.getFilter()).isEqualTo(new Document("first_name", "danerys"));
 		assertThat(updateModel.getUpdate()).isEqualTo(new Document("$set", new Document("first_name", "queen danerys")));
 	}
@@ -142,11 +136,9 @@ public class DefaultBulkOperationsUnitTests {
 
 		ops.remove(query(where("firstName").is("danerys"))).execute();
 
-		ArgumentCaptor<List<WriteModel<Document>>> captor = ArgumentCaptor.forClass(List.class);
-
 		verify(collection).bulkWrite(captor.capture(), any());
 
-		DeleteManyModel<Document> updateModel = (DeleteManyModel) captor.getValue().get(0);
+		DeleteManyModel<Document> updateModel = (DeleteManyModel<Document>) captor.getValue().get(0);
 		assertThat(updateModel.getFilter()).isEqualTo(new Document("first_name", "danerys"));
 	}
 


### PR DESCRIPTION
We now make sure to run any query / update object through the `Query-` / `UpdateMapper`. This ensures `@Field` annotations and potential custom conversions get processed correctly for update / remove operations.