### PR TITLE
Add Kotlin extensions for Criteria API.

### DIFF
--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensions.kt
@@ -1,0 +1,17 @@
+package org.springframework.data.mongodb.core.query
+
+/**
+ * Extension for [Criteria.is] providing an `isEqualTo` alias since `in` is a reserved keyword in Kotlin.
+ *
+ * @author Sebastien Deleuze
+ * @since 2.0
+ */
+fun Criteria.isEqualTo(o: Any) : Criteria = `is`(o)
+
+/**
+ * Extension for [Criteria.in] providing an `inValues` alias since `in` is a reserved keyword in Kotlin.
+ *
+ * @author Sebastien Deleuze
+ * @since 2.0
+ */
+fun Criteria.inValues(vararg o: Any) : Criteria = `in`(*o)

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensionsTests.kt
@@ -1,0 +1,34 @@
+package org.springframework.data.mongodb.core.query
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * @author Sebastien Deleuze
+ */
+@RunWith(MockitoJUnitRunner::class)
+class CriteriaExtensionsTests {
+
+	@Mock(answer = Answers.RETURNS_MOCKS)
+	lateinit var criteria: Criteria
+
+	@Test
+	fun `isEqualTo() extension should call its Java counterpart`() {
+		val foo = "foo"
+		criteria.isEqualTo(foo)
+		Mockito.verify(criteria, Mockito.times(1)).`is`(foo)
+	}
+
+	@Test
+	fun `inValues() extension should call its Java counterpart`() {
+		val foo = "foo"
+		val bar = "bar"
+		criteria.inValues(foo, bar)
+		Mockito.verify(criteria, Mockito.times(1)).`in`(foo, bar)
+	}
+
+}


### PR DESCRIPTION
This commit introduces 2 Criteria method aliases because
`in` and `is` are reserved keywords in Kotlin:
 - `isEqualTo` alias for is
 - `inValues` alias for in

I have considered using `containsAny` instead of `inValues` but I think the later will be more discoverable via autocomplete.
