### PR TITLE
	DATAMONGO-1682 - Add support partialFilterExpression for reactive index creation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1682-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import org.bson.Document;
 import org.springframework.dao.DataAccessException;
-import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
@@ -38,7 +38,7 @@ import com.mongodb.client.model.IndexOptions;
 
 /**
  * Default implementation of {@link IndexOperations}.
- * 
+ *
  * @author Mark Pollack
  * @author Oliver Gierke
  * @author Komi Innocent
@@ -56,7 +56,7 @@ public class DefaultIndexOperations implements IndexOperations {
 
 	/**
 	 * Creates a new {@link DefaultIndexOperations}.
-	 * 
+	 *
 	 * @param mongoDbFactory must not be {@literal null}.
 	 * @param collectionName must not be {@literal null}.
 	 * @param queryMapper must not be {@literal null}.
@@ -98,24 +98,22 @@ public class DefaultIndexOperations implements IndexOperations {
 
 			Document indexOptions = indexDefinition.getIndexOptions();
 
-			if (indexOptions != null) {
-
-				IndexOptions ops = IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition);
-
-				if (indexOptions.containsKey(PARTIAL_FILTER_EXPRESSION_KEY)) {
-
-					Assert.isInstanceOf(Document.class, indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
-
-					ops.partialFilterExpression( mapper.getMappedObject(
-							(Document) indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY), lookupPersistentEntity(type, collectionName)));
-				}
-
-				return collection.createIndex(indexDefinition.getIndexKeys(), ops);
+			if (indexOptions == null) {
+				return collection.createIndex(indexDefinition.getIndexKeys());
 			}
-			return collection.createIndex(indexDefinition.getIndexKeys());
-		}
 
-		);
+			IndexOptions ops = IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition);
+
+			if (indexOptions.containsKey(PARTIAL_FILTER_EXPRESSION_KEY)) {
+
+				Assert.isInstanceOf(Document.class, indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
+
+				ops.partialFilterExpression(mapper.getMappedObject((Document) indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY),
+						lookupPersistentEntity(type, collectionName)));
+			}
+
+			return collection.createIndex(indexDefinition.getIndexKeys(), ops);
+		});
 	}
 
 	private MongoPersistentEntity<?> lookupPersistentEntity(Class<?> entityType, String collection) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,13 @@ import org.bson.Document;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexInfo;
-import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.util.Assert;
 
 import com.mongodb.client.model.IndexOptions;
-import com.mongodb.reactivestreams.client.ListIndexesPublisher;
 
 /**
- * Default implementation of {@link IndexOperations}.
+ * Default implementation of {@link ReactiveIndexOperations}.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -53,11 +51,11 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 	 *
 	 * @param mongoOperations must not be {@literal null}.
 	 * @param collectionName must not be {@literal null}.
+	 * @param queryMapper must not be {@literal null}.
 	 */
 	public DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName,
 			QueryMapper queryMapper) {
-
-		this(mongoOperations, collectionName, queryMapper, null);
+		this(mongoOperations, collectionName, queryMapper, Optional.empty());
 	}
 
 	/**
@@ -65,9 +63,16 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 	 *
 	 * @param mongoOperations must not be {@literal null}.
 	 * @param collectionName must not be {@literal null}.
+	 * @param queryMapper must not be {@literal null}.
+	 * @param type used for mapping potential partial index filter expression, must not be {@literal null}.
 	 */
 	public DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName,
 			QueryMapper queryMapper, Class<?> type) {
+		this(mongoOperations, collectionName, queryMapper, Optional.of(type));
+	}
+
+	private DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName,
+			QueryMapper queryMapper, Optional<Class<?>> type) {
 
 		Assert.notNull(mongoOperations, "ReactiveMongoOperations must not be null!");
 		Assert.notNull(collectionName, "Collection must not be null!");
@@ -76,7 +81,7 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 		this.mongoOperations = mongoOperations;
 		this.collectionName = collectionName;
 		this.queryMapper = queryMapper;
-		this.type = Optional.ofNullable(type);
+		this.type = type;
 	}
 
 	/* (non-Javadoc)
@@ -88,26 +93,26 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 
 			Document indexOptions = indexDefinition.getIndexOptions();
 
-			if (indexOptions != null) {
-
-				IndexOptions ops = IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition);
-
-				if (indexOptions.containsKey(PARTIAL_FILTER_EXPRESSION_KEY)) {
-
-					Assert.isInstanceOf(Document.class, indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
-
-					MongoPersistentEntity<?> entity = type
-							.map(val -> (MongoPersistentEntity) queryMapper.getMappingContext().getRequiredPersistentEntity(val))
-							.orElseGet(() -> lookupPersistentEntity(collectionName));
-
-					ops = ops.partialFilterExpression(
-							queryMapper.getMappedObject((Document) indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY), entity));
-				}
-
-				return collection.createIndex(indexDefinition.getIndexKeys(), ops);
+			if (indexOptions == null) {
+				return collection.createIndex(indexDefinition.getIndexKeys());
 			}
 
-			return collection.createIndex(indexDefinition.getIndexKeys());
+			IndexOptions ops = IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition);
+
+			if (indexOptions.containsKey(PARTIAL_FILTER_EXPRESSION_KEY)) {
+
+				Assert.isInstanceOf(Document.class, indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
+
+				MongoPersistentEntity<?> entity = type
+						.map(val -> (MongoPersistentEntity) queryMapper.getMappingContext().getRequiredPersistentEntity(val))
+						.orElseGet(() -> lookupPersistentEntity(collectionName));
+
+				ops = ops.partialFilterExpression(
+						queryMapper.getMappedObject(indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY, Document.class), entity));
+			}
+
+			return collection.createIndex(indexDefinition.getIndexKeys(), ops);
+
 		}).next();
 	}
 
@@ -115,24 +120,17 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 
 		Collection<? extends MongoPersistentEntity<?>> entities = queryMapper.getMappingContext().getPersistentEntities();
 
-		for (MongoPersistentEntity<?> entity : entities) {
-			if (entity.getCollection().equals(collection)) {
-				return entity;
-			}
-		}
-
-		return null;
+		return entities.stream() //
+				.filter(entity -> entity.getCollection().equals(collection)) //
+				.findFirst() //
+				.orElse(null);
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.ReactiveIndexOperations#dropIndex(java.lang.String)
 	 */
 	public Mono<Void> dropIndex(final String name) {
-
-		return mongoOperations.execute(collectionName, collection -> {
-
-			return Mono.from(collection.dropIndex(name));
-		}).flatMap(success -> Mono.<Void> empty()).next();
+		return mongoOperations.execute(collectionName, collection -> collection.dropIndex(name)).then();
 	}
 
 	/* (non-Javadoc)
@@ -147,11 +145,7 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 	 */
 	public Flux<IndexInfo> getIndexInfo() {
 
-		return mongoOperations.execute(collectionName, collection -> {
-
-			ListIndexesPublisher<Document> indexesPublisher = collection.listIndexes(Document.class);
-
-			return Flux.from(indexesPublisher).map(IndexConverters.documentToIndexInfoConverter()::convert);
-		});
+		return mongoOperations.execute(collectionName, collection -> collection.listIndexes(Document.class)) //
+				.map(IndexConverters.documentToIndexInfoConverter()::convert);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperations.java
@@ -15,27 +15,38 @@
  */
 package org.springframework.data.mongodb.core;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Optional;
+
 import org.bson.Document;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.util.Assert;
 
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.ListIndexesPublisher;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * Default implementation of {@link IndexOperations}.
  *
  * @author Mark Paluch
- * @since 1.11
+ * @author Christoph Strobl
+ * @since 2.0
  */
 public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 
+	private static final String PARTIAL_FILTER_EXPRESSION_KEY = "partialFilterExpression";
+
 	private final ReactiveMongoOperations mongoOperations;
 	private final String collectionName;
+	private final QueryMapper queryMapper;
+	private final Optional<Class<?>> type;
 
 	/**
 	 * Creates a new {@link DefaultReactiveIndexOperations}.
@@ -43,13 +54,29 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 	 * @param mongoOperations must not be {@literal null}.
 	 * @param collectionName must not be {@literal null}.
 	 */
-	public DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName) {
+	public DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName,
+			QueryMapper queryMapper) {
+
+		this(mongoOperations, collectionName, queryMapper, null);
+	}
+
+	/**
+	 * Creates a new {@link DefaultReactiveIndexOperations}.
+	 *
+	 * @param mongoOperations must not be {@literal null}.
+	 * @param collectionName must not be {@literal null}.
+	 */
+	public DefaultReactiveIndexOperations(ReactiveMongoOperations mongoOperations, String collectionName,
+			QueryMapper queryMapper, Class<?> type) {
 
 		Assert.notNull(mongoOperations, "ReactiveMongoOperations must not be null!");
 		Assert.notNull(collectionName, "Collection must not be null!");
+		Assert.notNull(queryMapper, "QueryMapper must not be null!");
 
 		this.mongoOperations = mongoOperations;
 		this.collectionName = collectionName;
+		this.queryMapper = queryMapper;
+		this.type = Optional.ofNullable(type);
 	}
 
 	/* (non-Javadoc)
@@ -57,17 +84,44 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 	 */
 	public Mono<String> ensureIndex(final IndexDefinition indexDefinition) {
 
-		return mongoOperations.execute(collectionName, (ReactiveCollectionCallback<String>) collection -> {
+		return mongoOperations.execute(collectionName, collection -> {
 
 			Document indexOptions = indexDefinition.getIndexOptions();
 
 			if (indexOptions != null) {
-				return collection.createIndex(indexDefinition.getIndexKeys(),
-						IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition));
+
+				IndexOptions ops = IndexConverters.indexDefinitionToIndexOptionsConverter().convert(indexDefinition);
+
+				if (indexOptions.containsKey(PARTIAL_FILTER_EXPRESSION_KEY)) {
+
+					Assert.isInstanceOf(Document.class, indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
+
+					MongoPersistentEntity<?> entity = type
+							.map(val -> (MongoPersistentEntity) queryMapper.getMappingContext().getRequiredPersistentEntity(val))
+							.orElseGet(() -> lookupPersistentEntity(collectionName));
+
+					ops = ops.partialFilterExpression(
+							queryMapper.getMappedObject((Document) indexOptions.get(PARTIAL_FILTER_EXPRESSION_KEY), entity));
+				}
+
+				return collection.createIndex(indexDefinition.getIndexKeys(), ops);
 			}
 
 			return collection.createIndex(indexDefinition.getIndexKeys());
 		}).next();
+	}
+
+	private MongoPersistentEntity<?> lookupPersistentEntity(String collection) {
+
+		Collection<? extends MongoPersistentEntity<?>> entities = queryMapper.getMappingContext().getPersistentEntities();
+
+		for (MongoPersistentEntity<?> entity : entities) {
+			if (entity.getCollection().equals(collection)) {
+				return entity;
+			}
+		}
+
+		return null;
 	}
 
 	/* (non-Javadoc)
@@ -78,7 +132,7 @@ public class DefaultReactiveIndexOperations implements ReactiveIndexOperations {
 		return mongoOperations.execute(collectionName, collection -> {
 
 			return Mono.from(collection.dropIndex(name));
-		}).flatMap(success -> Mono.<Void>empty()).next();
+		}).flatMap(success -> Mono.<Void> empty()).next();
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -548,7 +548,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	public IndexOperations indexOps(Class<?> entityClass) {
-		return new DefaultIndexOperations(getMongoDbFactory(), determineCollectionName(entityClass), queryMapper);
+		return new DefaultIndexOperations(getMongoDbFactory(), determineCollectionName(entityClass), queryMapper,
+				entityClass);
 	}
 
 	public BulkOperations bulkOps(BulkMode bulkMode, String collectionName) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveIndexOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package org.springframework.data.mongodb.core;
-
-import java.util.List;
 
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexInfo;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveIndexOperations.java
@@ -56,5 +56,4 @@ public interface ReactiveIndexOperations {
 	 * @return index information on the collection
 	 */
 	Flux<IndexInfo> getIndexInfo();
-
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -302,14 +302,14 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 * @see org.springframework.data.mongodb.core.ReactiveMongoOperations#reactiveIndexOps(java.lang.String)
 	 */
 	public ReactiveIndexOperations indexOps(String collectionName) {
-		return new DefaultReactiveIndexOperations(this, collectionName);
+		return new DefaultReactiveIndexOperations(this, collectionName, this.queryMapper);
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.ReactiveMongoOperations#reactiveIndexOps(java.lang.Class)
 	 */
 	public ReactiveIndexOperations indexOps(Class<?> entityClass) {
-		return new DefaultReactiveIndexOperations(this, determineCollectionName(entityClass));
+		return new DefaultReactiveIndexOperations(this, determineCollectionName(entityClass), this.queryMapper);
 	}
 
 	public String getCollectionName(Class<?> entityClass) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -309,7 +309,8 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 * @see org.springframework.data.mongodb.core.ReactiveMongoOperations#reactiveIndexOps(java.lang.Class)
 	 */
 	public ReactiveIndexOperations indexOps(Class<?> entityClass) {
-		return new DefaultReactiveIndexOperations(this, determineCollectionName(entityClass), this.queryMapper);
+		return new DefaultReactiveIndexOperations(this, determineCollectionName(entityClass), this.queryMapper,
+				entityClass);
 	}
 
 	public String getCollectionName(Class<?> entityClass) {
@@ -1915,8 +1916,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 					"No class parameter provided, entity collection can't be determined!");
 		}
 
-		MongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(entityClass);
-		return entity.getCollection();
+		return mappingContext.getRequiredPersistentEntity(entityClass).getCollection();
 	}
 
 	private static MappingMongoConverter getDefaultMongoConverter() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
@@ -18,8 +18,13 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.core.Is.*;
 import static org.junit.Assume.*;
+import static org.springframework.data.mongodb.core.index.PartialIndexFilter.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
 
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.function.Predicate;
 
 import org.bson.Document;
 import org.junit.Before;
@@ -31,9 +36,11 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.config.AbstractReactiveMongoConfiguration;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Collation.CaseFirst;
-import org.springframework.data.mongodb.core.DefaultIndexOperationsIntegrationTests.DefaultIndexOperationsIntegrationTestsSample;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -64,6 +71,7 @@ public class DefaultReactiveIndexOperationsTests {
 		}
 	}
 
+	private static final Version THREE_DOT_TWO = new Version(3, 2);
 	private static final Version THREE_DOT_FOUR = new Version(3, 4);
 	private static Version mongoVersion;
 
@@ -79,8 +87,10 @@ public class DefaultReactiveIndexOperationsTests {
 		String collectionName = this.template.getCollectionName(DefaultIndexOperationsIntegrationTestsSample.class);
 
 		this.collection = this.template.getMongoDatabase().getCollection(collectionName, Document.class);
-		this.collection.dropIndexes();
-		this.indexOps = new DefaultReactiveIndexOperations(template, collectionName);
+		Mono.from(this.collection.dropIndexes()).subscribe();
+
+		this.indexOps = new DefaultReactiveIndexOperations(template, collectionName,
+				new QueryMapper(template.getConverter()));
 	}
 
 	private void queryMongoVersionIfNecessary() {
@@ -111,7 +121,7 @@ public class DefaultReactiveIndexOperationsTests {
 				.append("normalization", false) //
 				.append("backwards", false);
 
-		StepVerifier.create(indexOps.getIndexInfo().filter(val -> val.getName().equals("with-collation")))
+		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("with-collation"))) //
 				.consumeNextWith(indexInfo -> {
 
 					assertThat(indexInfo.getCollation()).isPresent();
@@ -122,7 +132,96 @@ public class DefaultReactiveIndexOperationsTests {
 
 					assertThat(result).isEqualTo(expected);
 				}) //
+				.thenAwait();
+	}
+
+	@Test // DATAMONGO-1682
+	public void shouldApplyPartialFilterCorrectly() {
+
+		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+
+		IndexDefinition id = new Index().named("partial-with-criteria").on("k3y", Direction.ASC)
+				.partial(of(where("q-t-y").gte(10)));
+
+		indexOps.ensureIndex(id).subscribe();
+
+		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("partial-with-criteria"))) //
+				.consumeNextWith(indexInfo -> {
+					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"q-t-y\" : { \"$gte\" : 10 } }");
+				}) //
+				.thenAwait();
+	}
+
+	@Test // DATAMONGO-1682
+	public void shouldApplyPartialFilterWithMappedPropertyCorrectly() {
+
+		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+
+		IndexDefinition id = new Index().named("partial-with-mapped-criteria").on("k3y", Direction.ASC)
+				.partial(of(where("quantity").gte(10)));
+
+		indexOps.ensureIndex(id).subscribe();
+
+		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("partial-with-mapped-criteria"))) //
+				.consumeNextWith(indexInfo -> {
+					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"qty\" : { \"$gte\" : 10 } }");
+				}).thenAwait();
+	}
+
+	@Test // DATAMONGO-1682
+	public void shouldApplyPartialDBOFilterCorrectly() {
+
+		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+
+		IndexDefinition id = new Index().named("partial-with-dbo").on("k3y", Direction.ASC)
+				.partial(of(new org.bson.Document("qty", new org.bson.Document("$gte", 10))));
+
+		indexOps.ensureIndex(id).subscribe();
+
+		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("partial-with-dbo"))) //
+				.consumeNextWith(indexInfo -> {
+					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"qty\" : { \"$gte\" : 10 } }");
+				}) //
+				.thenAwait();
+
+	}
+
+	@Test // DATAMONGO-1682
+	public void shouldFavorExplicitMappingHintViaClass() {
+
+		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+
+		IndexDefinition id = new Index().named("partial-with-inheritance").on("k3y", Direction.ASC)
+				.partial(of(where("age").gte(10)));
+
+		indexOps = new DefaultReactiveIndexOperations(template,
+				this.template.getCollectionName(DefaultIndexOperationsIntegrationTestsSample.class),
+				new QueryMapper(template.getConverter()), MappingToSameCollection.class);
+
+		indexOps.ensureIndex(id).subscribe();
+
+		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("partial-with-inheritance"))) //
+				.consumeNextWith(indexInfo -> {
+					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"a_g_e\" : { \"$gte\" : 10 } }");
+				}) //
 				.verifyComplete();
+	}
+
+	Predicate<IndexInfo> indexByName(String name) {
+		return indexInfo -> indexInfo.getName().equals(name);
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document(collection = "default-index-operations-tests")
+	static class DefaultIndexOperationsIntegrationTestsSample {
+
+		@Field("qty") Integer quantity;
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document(collection = "default-index-operations-tests")
+	static class MappingToSameCollection
+			extends DefaultIndexOperationsIntegrationTests.DefaultIndexOperationsIntegrationTestsSample {
+
+		@Field("a_g_e") Integer age;
 	}
 
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
@@ -16,12 +16,10 @@
 package org.springframework.data.mongodb.core;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.hamcrest.core.Is.*;
 import static org.junit.Assume.*;
 import static org.springframework.data.mongodb.core.index.PartialIndexFilter.*;
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.function.Predicate;
@@ -87,10 +85,10 @@ public class DefaultReactiveIndexOperationsTests {
 		String collectionName = this.template.getCollectionName(DefaultIndexOperationsIntegrationTestsSample.class);
 
 		this.collection = this.template.getMongoDatabase().getCollection(collectionName, Document.class);
-		Mono.from(this.collection.dropIndexes()).subscribe();
-
 		this.indexOps = new DefaultReactiveIndexOperations(template, collectionName,
 				new QueryMapper(template.getConverter()));
+
+		StepVerifier.create(this.collection.dropIndexes()).expectNextCount(1).verifyComplete();
 	}
 
 	private void queryMongoVersionIfNecessary() {
@@ -104,7 +102,7 @@ public class DefaultReactiveIndexOperationsTests {
 	@Test // DATAMONGO-1518
 	public void shouldCreateIndexWithCollationCorrectly() {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR), is(true));
+		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		IndexDefinition id = new Index().named("with-collation").on("xyz", Direction.ASC)
 				.collation(Collation.of("de_AT").caseFirst(CaseFirst.off()));
@@ -132,13 +130,13 @@ public class DefaultReactiveIndexOperationsTests {
 
 					assertThat(result).isEqualTo(expected);
 				}) //
-				.thenAwait();
+				.verifyComplete();
 	}
 
 	@Test // DATAMONGO-1682
 	public void shouldApplyPartialFilterCorrectly() {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		IndexDefinition id = new Index().named("partial-with-criteria").on("k3y", Direction.ASC)
 				.partial(of(where("q-t-y").gte(10)));
@@ -149,13 +147,13 @@ public class DefaultReactiveIndexOperationsTests {
 				.consumeNextWith(indexInfo -> {
 					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"q-t-y\" : { \"$gte\" : 10 } }");
 				}) //
-				.thenAwait();
+				.verifyComplete();
 	}
 
 	@Test // DATAMONGO-1682
 	public void shouldApplyPartialFilterWithMappedPropertyCorrectly() {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		IndexDefinition id = new Index().named("partial-with-mapped-criteria").on("k3y", Direction.ASC)
 				.partial(of(where("quantity").gte(10)));
@@ -165,13 +163,13 @@ public class DefaultReactiveIndexOperationsTests {
 		StepVerifier.create(indexOps.getIndexInfo().filter(this.indexByName("partial-with-mapped-criteria"))) //
 				.consumeNextWith(indexInfo -> {
 					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"qty\" : { \"$gte\" : 10 } }");
-				}).thenAwait();
+				}).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1682
 	public void shouldApplyPartialDBOFilterCorrectly() {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		IndexDefinition id = new Index().named("partial-with-dbo").on("k3y", Direction.ASC)
 				.partial(of(new org.bson.Document("qty", new org.bson.Document("$gte", 10))));
@@ -182,14 +180,14 @@ public class DefaultReactiveIndexOperationsTests {
 				.consumeNextWith(indexInfo -> {
 					assertThat(indexInfo.getPartialFilterExpression()).isEqualTo("{ \"qty\" : { \"$gte\" : 10 } }");
 				}) //
-				.thenAwait();
+				.verifyComplete();
 
 	}
 
 	@Test // DATAMONGO-1682
 	public void shouldFavorExplicitMappingHintViaClass() {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO), is(true));
+		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		IndexDefinition id = new Index().named("partial-with-inheritance").on("k3y", Direction.ASC)
 				.partial(of(where("age").gte(10)));


### PR DESCRIPTION
We now support partial filter expression on indexes via `Index.partial(…)` on the reactive API. This allows to create partial indexes that only index the documents in a collection that meet a specified filter expression.