### PR TITLE
DATAMONGO-1726 - Add oneValue() & findValue() to FluentMongo API returning null instead of Optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1726-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1726-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1726-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1726-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1726-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
@@ -73,14 +73,33 @@ public interface ExecutableFindOperation {
 		 * @return {@link Optional#empty()} if no match found.
 		 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
 		 */
-		Optional<T> one();
+		default Optional<T> one() {
+			return Optional.ofNullable(oneValue());
+		}
+
+		/**
+		 * Get exactly zero or one result.
+		 *
+		 * @return {@literal null} if no match found.
+		 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+		 */
+		T oneValue();
 
 		/**
 		 * Get the first or no result.
 		 *
 		 * @return {@link Optional#empty()} if no match found.
 		 */
-		Optional<T> first();
+		default Optional<T> first() {
+			return Optional.ofNullable(firstValue());
+		}
+
+		/**
+		 * Get the first or no result.
+		 *
+		 * @return {@literal null} if no match found.
+		 */
+		T firstValue();
 
 		/**
 		 * Get all matching elements.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
@@ -104,27 +104,27 @@ class ExecutableFindOperationSupport implements ExecutableFindOperation {
 		}
 
 		@Override
-		public Optional<T> one() {
+		public T oneValue() {
 
 			List<T> result = doFind(new DelegatingQueryCursorPreparer(getCursorPreparer(query, null)).limit(2));
 
 			if (ObjectUtils.isEmpty(result)) {
-				return Optional.empty();
+				return null;
 			}
 
 			if (result.size() > 1) {
 				throw new IncorrectResultSizeDataAccessException("Query " + asString() + " returned non unique result.", 1);
 			}
 
-			return Optional.of(result.iterator().next());
+			return result.iterator().next();
 		}
 
 		@Override
-		public Optional<T> first() {
+		public T firstValue() {
 
 			List<T> result = doFind(new DelegatingQueryCursorPreparer(getCursorPreparer(query, null)).limit(1));
 
-			return ObjectUtils.isEmpty(result) ? Optional.empty() : Optional.of(result.iterator().next());
+			return ObjectUtils.isEmpty(result) ? null : result.iterator().next();
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -140,6 +140,30 @@ public class ExecutableFindOperationSupportTests {
 		template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).one();
 	}
 
+	@Test // DATAMONGO-1726
+	public void findByReturningOneValue() {
+		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).oneValue()).isEqualTo(luke);
+	}
+
+	@Test(expected = IncorrectResultSizeDataAccessException.class) // DATAMONGO-1726
+	public void findByReturningOneValueButTooManyResults() {
+		template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).oneValue();
+	}
+
+	@Test // DATAMONGO-1726
+	public void findByReturningFirstValue() {
+
+		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).firstValue())
+				.isEqualTo(luke);
+	}
+
+	@Test // DATAMONGO-1726
+	public void findByReturningFirstValueForManyResults() {
+
+		assertThat(template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).firstValue())
+				.isIn(han, luke);
+	}
+
 	@Test // DATAMONGO-1563
 	public void streamAll() {
 


### PR DESCRIPTION
We leave the choice of using `Optional` open by also providing terminating find operation methods that return `null` instead of `Optional`.
