### PR TITLE
DATAMONGO-1702 - Adopt to composable repositories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1702-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1702-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1702-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1702-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1702-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.support;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
+import org.springframework.data.querydsl.EntityPathResolver;
+import org.springframework.data.querydsl.QSort;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.repository.core.EntityInformation;
+import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.util.Assert;
+
+import com.querydsl.core.NonUniqueResultException;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.mongodb.AbstractMongodbQuery;
+
+/**
+ * MongoDB-specific {@link QuerydslPredicateExecutor} that allows execution {@link Predicate}s in various forms.
+ *
+ * @author Oliver Gierke
+ * @author Thomas Darimont
+ * @author Mark Paluch
+ * @author Christoph Strobl
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecutor<T> {
+
+	private final PathBuilder<T> builder;
+	private final EntityInformation<T, ?> entityInformation;
+	private final MongoOperations mongoOperations;
+
+	/**
+	 * Creates a new {@link QuerydslMongoPredicateExecutor} for the given {@link MongoEntityInformation} and
+	 * {@link MongoTemplate}. Uses the {@link SimpleEntityPathResolver} to create an {@link EntityPath} for the given
+	 * domain class.
+	 *
+	 * @param entityInformation must not be {@literal null}.
+	 * @param mongoOperations must not be {@literal null}.
+	 */
+	public QuerydslMongoPredicateExecutor(MongoEntityInformation<T, ?> entityInformation,
+			MongoOperations mongoOperations) {
+		this(entityInformation, mongoOperations, SimpleEntityPathResolver.INSTANCE);
+	}
+
+	/**
+	 * Creates a new {@link QuerydslMongoPredicateExecutor} for the given {@link MongoEntityInformation},
+	 * {@link MongoTemplate} and {@link EntityPathResolver}.
+	 *
+	 * @param entityInformation must not be {@literal null}.
+	 * @param mongoOperations must not be {@literal null}.
+	 * @param resolver must not be {@literal null}.
+	 */
+	public QuerydslMongoPredicateExecutor(MongoEntityInformation<T, ?> entityInformation, MongoOperations mongoOperations,
+			EntityPathResolver resolver) {
+
+		Assert.notNull(resolver, "EntityPathResolver must not be null!");
+
+		EntityPath<T> path = resolver.createPath(entityInformation.getJavaType());
+
+		this.builder = new PathBuilder<T>(path.getType(), path.getMetadata());
+		this.entityInformation = entityInformation;
+		this.mongoOperations = mongoOperations;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QuerydslPredicateExecutor#findById(com.querydsl.core.types.Predicate)
+	 */
+	@Override
+	public Optional<T> findOne(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+
+		try {
+			return Optional.ofNullable(createQueryFor(predicate).fetchOne());
+		} catch (NonUniqueResultException ex) {
+			throw new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate)
+	 */
+	@Override
+	public List<T> findAll(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+
+		return createQueryFor(predicate).fetchResults().getResults();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, com.mysema.query.types.OrderSpecifier<?>[])
+	 */
+	@Override
+	public List<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+		Assert.notNull(orders, "Order specifiers must not be null!");
+
+		return createQueryFor(predicate).orderBy(orders).fetchResults().getResults();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
+	 */
+	@Override
+	public List<T> findAll(Predicate predicate, Sort sort) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+		Assert.notNull(sort, "Sort must not be null!");
+
+		return applySorting(createQueryFor(predicate), sort).fetchResults().getResults();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.OrderSpecifier[])
+	 */
+	@Override
+	public Iterable<T> findAll(OrderSpecifier<?>... orders) {
+
+		Assert.notNull(orders, "Order specifiers must not be null!");
+
+		return createQuery().orderBy(orders).fetchResults().getResults();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Pageable)
+	 */
+	@Override
+	public Page<T> findAll(Predicate predicate, Pageable pageable) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+		Assert.notNull(pageable, "Pageable must not be null!");
+
+		AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query = createQueryFor(predicate);
+
+		return PageableExecutionUtils.getPage(applyPagination(query, pageable).fetchResults().getResults(), pageable,
+				() -> createQueryFor(predicate).fetchCount());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.mysema.query.types.Predicate)
+	 */
+	@Override
+	public long count(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+
+		return createQueryFor(predicate).fetchCount();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
+	 */
+	@Override
+	public boolean exists(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+
+		return createQueryFor(predicate).fetchCount() > 0;
+	}
+
+	/**
+	 * Creates a {@link MongodbQuery} for the given {@link Predicate}.
+	 *
+	 * @param predicate
+	 * @return
+	 */
+	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> createQueryFor(Predicate predicate) {
+		return createQuery().where(predicate);
+	}
+
+	/**
+	 * Creates a {@link MongodbQuery}.
+	 *
+	 * @return
+	 */
+	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> createQuery() {
+		return new SpringDataMongodbQuery<T>(mongoOperations, entityInformation.getJavaType());
+	}
+
+	/**
+	 * Applies the given {@link Pageable} to the given {@link MongodbQuery}.
+	 *
+	 * @param query
+	 * @param pageable
+	 * @return
+	 */
+	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> applyPagination(
+			AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query, Pageable pageable) {
+
+		query = query.offset(pageable.getOffset()).limit(pageable.getPageSize());
+		return applySorting(query, pageable.getSort());
+	}
+
+	/**
+	 * Applies the given {@link Sort} to the given {@link MongodbQuery}.
+	 *
+	 * @param query
+	 * @param sort
+	 * @return
+	 */
+	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> applySorting(
+			AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query, Sort sort) {
+
+		// TODO: find better solution than instanceof check
+		if (sort instanceof QSort) {
+
+			List<OrderSpecifier<?>> orderSpecifiers = ((QSort) sort).getOrderSpecifiers();
+			query.orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[orderSpecifiers.size()]));
+
+			return query;
+		}
+
+		sort.stream().map(this::toOrder).forEach(it -> query.orderBy(it));
+
+		return query;
+	}
+
+	/**
+	 * Transforms a plain {@link Order} into a QueryDsl specific {@link OrderSpecifier}.
+	 *
+	 * @param order
+	 * @return
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private OrderSpecifier<?> toOrder(Order order) {
+
+		Expression<Object> property = builder.get(order.getProperty());
+
+		return new OrderSpecifier(
+				order.isAscending() ? com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC, property);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoRepository.java
@@ -16,33 +16,13 @@
 package org.springframework.data.mongodb.repository.support;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Optional;
 
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
 import org.springframework.data.querydsl.EntityPathResolver;
-import org.springframework.data.querydsl.QSort;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import org.springframework.data.querydsl.SimpleEntityPathResolver;
-import org.springframework.data.repository.core.EntityInformation;
-import org.springframework.data.repository.core.EntityMetadata;
-import org.springframework.data.repository.support.PageableExecutionUtils;
-import org.springframework.util.Assert;
 
-import com.querydsl.core.NonUniqueResultException;
-import com.querydsl.core.types.EntityPath;
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.PathBuilder;
-import com.querydsl.mongodb.AbstractMongodbQuery;
 
 /**
  * Special Querydsl based repository implementation that allows execution {@link Predicate}s in various forms.
@@ -51,249 +31,20 @@ import com.querydsl.mongodb.AbstractMongodbQuery;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @deprecated since 2.0. Querydsl execution is now linked via composable repositories and no longer requires to be a
+ *             subclass of {@link SimpleMongoRepository}. Use {@link QuerydslMongoPredicateExecutor} for standalone
+ *             Querydsl {@link Predicate} execution.
  */
-public class QuerydslMongoRepository<T, ID extends Serializable> extends SimpleMongoRepository<T, ID>
+@Deprecated
+public class QuerydslMongoRepository<T, ID extends Serializable> extends QuerydslMongoPredicateExecutor<T>
 		implements QuerydslPredicateExecutor<T> {
 
-	private final PathBuilder<T> builder;
-	private final EntityInformation<T, ID> entityInformation;
-	private final MongoOperations mongoOperations;
-
-	/**
-	 * Creates a new {@link QuerydslMongoRepository} for the given {@link EntityMetadata} and {@link MongoTemplate}. Uses
-	 * the {@link SimpleEntityPathResolver} to create an {@link EntityPath} for the given domain class.
-	 *
-	 * @param entityInformation must not be {@literal null}.
-	 * @param mongoOperations must not be {@literal null}.
-	 */
-	public QuerydslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations) {
-		this(entityInformation, mongoOperations, SimpleEntityPathResolver.INSTANCE);
-	}
-
-	/**
-	 * Creates a new {@link QuerydslMongoRepository} for the given {@link MongoEntityInformation}, {@link MongoTemplate}
-	 * and {@link EntityPathResolver}.
-	 *
-	 * @param entityInformation must not be {@literal null}.
-	 * @param mongoOperations must not be {@literal null}.
-	 * @param resolver must not be {@literal null}.
-	 */
-	public QuerydslMongoRepository(MongoEntityInformation<T, ID> entityInformation, MongoOperations mongoOperations,
-			EntityPathResolver resolver) {
-
+	public QuerydslMongoRepository(MongoEntityInformation<T, ?> entityInformation, MongoOperations mongoOperations) {
 		super(entityInformation, mongoOperations);
-
-		Assert.notNull(resolver, "EntityPathResolver must not be null!");
-
-		EntityPath<T> path = resolver.createPath(entityInformation.getJavaType());
-
-		this.builder = new PathBuilder<T>(path.getType(), path.getMetadata());
-		this.entityInformation = entityInformation;
-		this.mongoOperations = mongoOperations;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QuerydslPredicateExecutor#findById(com.querydsl.core.types.Predicate)
-	 */
-	@Override
-	public Optional<T> findOne(Predicate predicate) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-
-		try {
-			return Optional.ofNullable(createQueryFor(predicate).fetchOne());
-		} catch (NonUniqueResultException ex) {
-			throw new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, ex);
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate)
-	 */
-	@Override
-	public List<T> findAll(Predicate predicate) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-
-		return createQueryFor(predicate).fetchResults().getResults();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, com.mysema.query.types.OrderSpecifier<?>[])
-	 */
-	@Override
-	public List<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-		Assert.notNull(orders, "Order specifiers must not be null!");
-
-		return createQueryFor(predicate).orderBy(orders).fetchResults().getResults();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
-	 */
-	@Override
-	public List<T> findAll(Predicate predicate, Sort sort) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-		Assert.notNull(sort, "Sort must not be null!");
-
-		return applySorting(createQueryFor(predicate), sort).fetchResults().getResults();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.OrderSpecifier[])
-	 */
-	@Override
-	public Iterable<T> findAll(OrderSpecifier<?>... orders) {
-
-		Assert.notNull(orders, "Order specifiers must not be null!");
-
-		return createQuery().orderBy(orders).fetchResults().getResults();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Pageable)
-	 */
-	@Override
-	public Page<T> findAll(Predicate predicate, Pageable pageable) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-		Assert.notNull(pageable, "Pageable must not be null!");
-
-		AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query = createQueryFor(predicate);
-
-		return PageableExecutionUtils.getPage(applyPagination(query, pageable).fetchResults().getResults(), pageable,
-				() -> createQueryFor(predicate).fetchCount());
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.support.SimpleMongoRepository#findAll(org.springframework.data.domain.Pageable)
-	 */
-	@Override
-	public Page<T> findAll(Pageable pageable) {
-
-		Assert.notNull(pageable, "Pageable must not be null!");
-
-		AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query = createQuery();
-
-		return PageableExecutionUtils.getPage(applyPagination(query, pageable).fetchResults().getResults(), pageable,
-				() -> createQuery().fetchCount());
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.support.SimpleMongoRepository#findAll(org.springframework.data.domain.Sort)
-	 */
-	@Override
-	public List<T> findAll(Sort sort) {
-
-		Assert.notNull(sort, "Sort must not be null!");
-
-		return applySorting(createQuery(), sort).fetchResults().getResults();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.mysema.query.types.Predicate)
-	 */
-	@Override
-	public long count(Predicate predicate) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-
-		return createQueryFor(predicate).fetchCount();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
-	 */
-	@Override
-	public boolean exists(Predicate predicate) {
-
-		Assert.notNull(predicate, "Predicate must not be null!");
-
-		return createQueryFor(predicate).fetchCount() > 0;
-	}
-
-	/**
-	 * Creates a {@link MongodbQuery} for the given {@link Predicate}.
-	 *
-	 * @param predicate
-	 * @return
-	 */
-	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> createQueryFor(Predicate predicate) {
-		return createQuery().where(predicate);
-	}
-
-	/**
-	 * Creates a {@link MongodbQuery}.
-	 * 
-	 * @return
-	 */
-	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> createQuery() {
-		return new SpringDataMongodbQuery<T>(mongoOperations, entityInformation.getJavaType());
-	}
-
-	/**
-	 * Applies the given {@link Pageable} to the given {@link MongodbQuery}.
-	 *
-	 * @param query
-	 * @param pageable
-	 * @return
-	 */
-	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> applyPagination(
-			AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query, Pageable pageable) {
-
-		query = query.offset(pageable.getOffset()).limit(pageable.getPageSize());
-		return applySorting(query, pageable.getSort());
-	}
-
-	/**
-	 * Applies the given {@link Sort} to the given {@link MongodbQuery}.
-	 *
-	 * @param query
-	 * @param sort
-	 * @return
-	 */
-	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> applySorting(
-			AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query, Sort sort) {
-
-		// TODO: find better solution than instanceof check
-		if (sort instanceof QSort) {
-
-			List<OrderSpecifier<?>> orderSpecifiers = ((QSort) sort).getOrderSpecifiers();
-			query.orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[orderSpecifiers.size()]));
-
-			return query;
-		}
-
-		sort.stream().map(this::toOrder).forEach(it -> query.orderBy(it));
-
-		return query;
-	}
-
-	/**
-	 * Transforms a plain {@link Order} into a QueryDsl specific {@link OrderSpecifier}.
-	 *
-	 * @param order
-	 * @return
-	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private OrderSpecifier<?> toOrder(Order order) {
-
-		Expression<Object> property = builder.get(order.getProperty());
-
-		return new OrderSpecifier(
-				order.isAscending() ? com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC, property);
+	public QuerydslMongoRepository(MongoEntityInformation<T, ?> entityInformation, MongoOperations mongoOperations,
+			EntityPathResolver resolver) {
+		super(entityInformation, mongoOperations, resolver);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/ComposedRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/ComposedRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.custom;
+
+import org.springframework.data.mongodb.core.User;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Mark Paluch
+ */
+public interface ComposedRepository extends Repository<User, String>, RepositoryMixin {
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/ComposedRepositoryImplementationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/ComposedRepositoryImplementationTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.custom;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration tests for composed Repository implementations.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class ComposedRepositoryImplementationTests {
+
+	@Configuration
+	@EnableMongoRepositories
+	@ImportResource("classpath:infrastructure.xml")
+	static class Config {}
+
+	@Autowired ComposedRepository composedRepository;
+
+	@Test // DATAMONGO-1702
+	public void shouldExecuteMethodOnCustomRepositoryImplementation() {
+		assertThat(composedRepository.getFoo()).isEqualTo("foo");
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/RepositoryMixin.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/RepositoryMixin.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.custom;
+
+/**
+ * @author Mark Paluch
+ */
+public interface RepositoryMixin {
+
+	String getFoo();
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/RepositoryMixinImpl.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/custom/RepositoryMixinImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.custom;
+
+/**
+ * @author Mark Paluch
+ */
+public class RepositoryMixinImpl implements RepositoryMixin {
+
+	@Override
+	public String getFoo() {
+		return "foo";
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutorIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutorIntegrationTests.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
- * Integration test for {@link QuerydslMongoRepository}.
+ * Integration test for {@link QuerydslMongoPredicateExecutor}.
  *
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -44,10 +44,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(
 		locations = "/org/springframework/data/mongodb/repository/PersonRepositoryIntegrationTests-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
-public class QueryDslMongoRepositoryIntegrationTests {
+public class QuerydslMongoPredicateExecutorIntegrationTests {
 
 	@Autowired MongoOperations operations;
-	QuerydslMongoRepository<Person, String> repository;
+	QuerydslMongoPredicateExecutor<Person> repository;
 
 	Person dave, oliver, carter;
 	QPerson person;
@@ -57,7 +57,7 @@ public class QueryDslMongoRepositoryIntegrationTests {
 
 		MongoRepositoryFactory factory = new MongoRepositoryFactory(operations);
 		MongoEntityInformation<Person, String> entityInformation = factory.getEntityInformation(Person.class);
-		repository = new QuerydslMongoRepository<>(entityInformation, operations);
+		repository = new QuerydslMongoPredicateExecutor<Person>(entityInformation, operations);
 
 		operations.dropCollection(Person.class);
 
@@ -67,7 +67,7 @@ public class QueryDslMongoRepositoryIntegrationTests {
 
 		person = new QPerson("person");
 
-		repository.saveAll(Arrays.asList(oliver, dave, carter));
+		operations.insertAll(Arrays.asList(oliver, dave, carter));
 	}
 
 	@Test // DATAMONGO-1146


### PR DESCRIPTION
Deprecate `QueryDslMongoRepository`, introduce `QuerydslMongoPredicateExecutor` instead without extending `SimpleMongoRepository`. Use `RepositoryFragments` to mix in requested repository aspects.

---

Related ticket: [DATAMONGO-1702](https://jira.spring.io/browse/DATAMONGO-1702).