### PR TITLE
DATAMONGO-1738 - Move repository query execution to fluent operations API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1738-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1738-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1738-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1738-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1738-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -17,8 +17,8 @@ package org.springframework.data.mongodb.repository.query;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
@@ -57,7 +57,6 @@ import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
 
-import com.mongodb.WriteResult;
 import com.mongodb.client.result.DeleteResult;
 
 /**
@@ -77,7 +76,6 @@ public class AbstractMongoQueryUnitTests {
 	@Mock FindOperationWithQuery<?> withQueryMock;
 	@Mock BasicMongoPersistentEntity<?> persitentEntityMock;
 	@Mock MongoMappingContext mappingContextMock;
-	@Mock WriteResult writeResultMock;
 	@Mock DeleteResult deleteResultMock;
 
 	@Before
@@ -100,7 +98,7 @@ public class AbstractMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-566
-	public void testDeleteExecutionCallsRemoveCorreclty() {
+	public void testDeleteExecutionCallsRemoveCorrectly() {
 
 		createQueryForMethod("deletePersonByLastname", String.class).setDeleteQuery(true).execute(new Object[] { "booh" });
 
@@ -134,7 +132,7 @@ public class AbstractMongoQueryUnitTests {
 		MongoQueryFake query = createQueryForMethod("deletePersonByLastname", String.class);
 		query.setDeleteQuery(true);
 
-		assertThat(query.execute(new Object[] { "fake" }), is((Object) 100L));
+		assertThat(query.execute(new Object[] { "fake" }), is(100L));
 		verify(mongoOperationsMock, times(1)).remove(any(), eq(Person.class), eq("persons"));
 	}
 
@@ -268,7 +266,7 @@ public class AbstractMongoQueryUnitTests {
 
 		AbstractMongoQuery query = createQueryForMethod("findByLastname", String.class);
 
-		assertThat(query.execute(new Object[] { "lastname" }), is((Object) reference));
+		assertThat(query.execute(new Object[] { "lastname" }), is(reference));
 	}
 
 	private MongoQueryFake createQueryForMethod(String methodName, Class<?>... paramTypes) {
@@ -282,16 +280,13 @@ public class AbstractMongoQueryUnitTests {
 
 			return new MongoQueryFake(queryMethod, mongoOperationsMock);
 
-		} catch (NoSuchMethodException e) {
-			throw new IllegalArgumentException(e.getMessage(), e);
-		} catch (SecurityException e) {
+		} catch (Exception e) {
 			throw new IllegalArgumentException(e.getMessage(), e);
 		}
 	}
 
 	private static class MongoQueryFake extends AbstractMongoQuery {
 
-		private boolean isCountQuery;
 		private boolean isDeleteQuery;
 
 		public MongoQueryFake(MongoQueryMethod method, MongoOperations operations) {
@@ -305,7 +300,7 @@ public class AbstractMongoQueryUnitTests {
 
 		@Override
 		protected boolean isCountQuery() {
-			return isCountQuery;
+			return false;
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.repository.query;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.mongodb.core.query.IsTextQuery.*;
 
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.ExecutableFindOperation.FindOperation;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
@@ -63,6 +65,7 @@ import com.mongodb.util.JSONParseException;
 public class PartTreeMongoQueryUnitTests {
 
 	@Mock MongoOperations mongoOperationsMock;
+	@Mock FindOperation<?> findOperationMock;
 
 	MongoMappingContext mappingContext;
 
@@ -75,7 +78,8 @@ public class PartTreeMongoQueryUnitTests {
 		DbRefResolver dbRefResolver = new DefaultDbRefResolver(mock(MongoDbFactory.class));
 		MongoConverter converter = new MappingMongoConverter(dbRefResolver, mappingContext);
 
-		when(mongoOperationsMock.getConverter()).thenReturn(converter);
+		doReturn(converter).when(mongoOperationsMock).getConverter();
+		doReturn(findOperationMock).when(mongoOperationsMock).query(any());
 	}
 
 	@Test // DATAMOGO-952

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/PartTreeMongoQueryUnitTests.java
@@ -88,14 +88,13 @@ public class PartTreeMongoQueryUnitTests {
 		exception.expect(IllegalStateException.class);
 		exception.expectMessage("findByLastname");
 
-		deriveQueryFromMethod("findByLastname", new Object[] { "foo" });
+		deriveQueryFromMethod("findByLastname", "foo");
 	}
 
 	@Test // DATAMOGO-952
 	public void singleFieldJsonIncludeRestrictionShouldBeConsidered() {
 
-		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findByFirstname",
-				new Object[] { "foo" });
+		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findByFirstname", "foo");
 
 		assertThat(query.getFieldsObject(), is(new Document().append("firstname", 1)));
 	}
@@ -103,8 +102,8 @@ public class PartTreeMongoQueryUnitTests {
 	@Test // DATAMOGO-952
 	public void multiFieldJsonIncludeRestrictionShouldBeConsidered() {
 
-		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findByFirstnameAndLastname",
-				new Object[] { "foo", "bar" });
+		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findByFirstnameAndLastname", "foo",
+				"bar");
 
 		assertThat(query.getFieldsObject(), is(new Document().append("firstname", 1).append("lastname", 1)));
 	}
@@ -113,7 +112,7 @@ public class PartTreeMongoQueryUnitTests {
 	public void multiFieldJsonExcludeRestrictionShouldBeConsidered() {
 
 		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findPersonByFirstnameAndLastname",
-				new Object[] { "foo", "bar" });
+				"foo", "bar");
 
 		assertThat(query.getFieldsObject(), is(new Document().append("firstname", 0).append("lastname", 0)));
 	}
@@ -121,8 +120,8 @@ public class PartTreeMongoQueryUnitTests {
 	@Test // DATAMOGO-973
 	public void shouldAddFullTextParamCorrectlyToDerivedQuery() {
 
-		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findPersonByFirstname",
-				new Object[] { "text", TextCriteria.forDefaultLanguage().matching("search") });
+		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findPersonByFirstname", "text",
+				TextCriteria.forDefaultLanguage().matching("search"));
 
 		assertThat(query, isTextQuery().searchingFor("search").where(new Criteria("firstname").is("text")));
 	}
@@ -131,9 +130,9 @@ public class PartTreeMongoQueryUnitTests {
 	public void propagatesRootExceptionForInvalidQuery() {
 
 		exception.expect(IllegalStateException.class);
-		exception.expectCause(is(org.hamcrest.Matchers.<Throwable> instanceOf(JSONParseException.class)));
+		exception.expectCause(is(instanceOf(JSONParseException.class)));
 
-		deriveQueryFromMethod("findByAge", new Object[] { 1 });
+		deriveQueryFromMethod("findByAge", 1);
 	}
 
 	@Test // DATAMONGO-1345, DATAMONGO-1735
@@ -146,8 +145,8 @@ public class PartTreeMongoQueryUnitTests {
 
 		Document fieldsObject = deriveQueryFromMethod("findPersonProjectedBy", new Object[0]).getFieldsObject();
 
-		assertThat(fieldsObject.get("firstname"), is((Object) 1));
-		assertThat(fieldsObject.get("lastname"), is((Object) 1));
+		assertThat(fieldsObject.get("firstname"), is(1));
+		assertThat(fieldsObject.get("lastname"), is(1));
 	}
 
 	@Test // DATAMONGO-1345
@@ -155,8 +154,8 @@ public class PartTreeMongoQueryUnitTests {
 
 		Document fieldsObject = deriveQueryFromMethod("findPersonDtoByAge", new Object[] { 42 }).getFieldsObject();
 
-		assertThat(fieldsObject.get("firstname"), is((Object) 1));
-		assertThat(fieldsObject.get("lastname"), is((Object) 1));
+		assertThat(fieldsObject.get("firstname"), is(1));
+		assertThat(fieldsObject.get("lastname"), is(1));
 	}
 
 	@Test // DATAMONGO-1345
@@ -164,9 +163,9 @@ public class PartTreeMongoQueryUnitTests {
 
 		Document fields = deriveQueryFromMethod("findDynamicallyProjectedBy", ExtendedProjection.class).getFieldsObject();
 
-		assertThat(fields.get("firstname"), is((Object) 1));
-		assertThat(fields.get("lastname"), is((Object) 1));
-		assertThat(fields.get("age"), is((Object) 1));
+		assertThat(fields.get("firstname"), is(1));
+		assertThat(fields.get("lastname"), is(1));
+		assertThat(fields.get("age"), is(1));
 	}
 
 	@Test // DATAMONGO-1500
@@ -174,8 +173,8 @@ public class PartTreeMongoQueryUnitTests {
 
 		org.springframework.data.mongodb.core.query.Query query = deriveQueryFromMethod("findBySex", Sex.FEMALE);
 
-		assertThat(query.getQueryObject().get("sex"), is((Object) Sex.FEMALE));
-		assertThat(query.getFieldsObject().get("firstname"), is((Object) 1));
+		assertThat(query.getQueryObject().get("sex"), is(Sex.FEMALE));
+		assertThat(query.getFieldsObject().get("firstname"), is(1));
 	}
 
 	@Test // DATAMONGO-1729, DATAMONGO-1735
@@ -210,9 +209,7 @@ public class PartTreeMongoQueryUnitTests {
 					mappingContext);
 
 			return new PartTreeMongoQuery(queryMethod, mongoOperationsMock);
-		} catch (NoSuchMethodException e) {
-			throw new IllegalArgumentException(e.getMessage(), e);
-		} catch (SecurityException e) {
+		} catch (Exception e) {
 			throw new IllegalArgumentException(e.getMessage(), e);
 		}
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.repository.query;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
@@ -36,6 +37,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
+import org.springframework.data.mongodb.core.ExecutableFindOperation.FindOperation;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
@@ -67,6 +69,7 @@ public class StringBasedMongoQueryUnitTests {
 	SpelExpressionParser PARSER = new SpelExpressionParser();
 
 	@Mock MongoOperations operations;
+	@Mock FindOperation<Object> findOperation;
 	@Mock DbRefResolver factory;
 
 	MongoConverter converter;
@@ -75,6 +78,8 @@ public class StringBasedMongoQueryUnitTests {
 	public void setUp() {
 
 		this.converter = new MappingMongoConverter(factory, new MongoMappingContext());
+
+		doReturn(findOperation).when(operations).query(any());
 	}
 
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQueryUnitTests.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +84,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test
-	public void bindsSimplePropertyCorrectly() throws Exception {
+	public void bindsSimplePropertyCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastname", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "Matthews");
@@ -95,7 +96,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test
-	public void bindsComplexPropertyCorrectly() throws Exception {
+	public void bindsComplexPropertyCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByAddress", Address.class);
 
@@ -114,7 +115,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test
-	public void bindsMultipleParametersCorrectly() throws Exception {
+	public void bindsMultipleParametersCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameAndAddress", String.class, Address.class);
 
@@ -133,7 +134,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test
-	public void bindsNullParametersCorrectly() throws Exception {
+	public void bindsNullParametersCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByAddress", Address.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] { null });
@@ -144,7 +145,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-821
-	public void bindsDbrefCorrectly() throws Exception {
+	public void bindsDbrefCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByHavingSizeFansNotZero");
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter);
@@ -154,19 +155,19 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-566
-	public void constructsDeleteQueryCorrectly() throws Exception {
+	public void constructsDeleteQueryCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("removeByLastname", String.class);
 		assertThat(mongoQuery.isDeleteQuery(), is(true));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-566
-	public void preventsDeleteAndCountFlagAtTheSameTime() throws Exception {
+	public void preventsDeleteAndCountFlagAtTheSameTime() {
 		createQueryForMethod("invalidMethod", String.class);
 	}
 
 	@Test // DATAMONGO-420
-	public void shouldSupportFindByParameterizedCriteriaAndFields() throws Exception {
+	public void shouldSupportFindByParameterizedCriteriaAndFields() {
 
 		ConvertingParameterAccessor accessor = new ConvertingParameterAccessor(converter,
 				StubParameterAccessor.getAccessor(converter, //
@@ -183,7 +184,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-420
-	public void shouldSupportRespectExistingQuotingInFindByTitleBeginsWithExplicitQuoting() throws Exception {
+	public void shouldSupportRespectExistingQuotingInFindByTitleBeginsWithExplicitQuoting() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "fun");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByTitleBeginsWithExplicitQuoting", String.class);
@@ -195,7 +196,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-995, DATAMONGO-420
-	public void shouldParseQueryWithParametersInExpression() throws Exception {
+	public void shouldParseQueryWithParametersInExpression() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, 1, 2, 3, 4);
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByQueryWithParametersInExpression", int.class,
@@ -209,7 +210,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-995, DATAMONGO-420
-	public void bindsSimplePropertyAlreadyQuotedCorrectly() throws Exception {
+	public void bindsSimplePropertyAlreadyQuotedCorrectly() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "Matthews");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
@@ -221,7 +222,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-995, DATAMONGO-420
-	public void bindsSimplePropertyAlreadyQuotedWithRegexCorrectly() throws Exception {
+	public void bindsSimplePropertyAlreadyQuotedWithRegexCorrectly() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "^Mat.*");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
@@ -233,7 +234,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-995, DATAMONGO-420
-	public void bindsSimplePropertyWithRegexCorrectly() throws Exception {
+	public void bindsSimplePropertyWithRegexCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastname", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "^Mat.*");
@@ -245,7 +246,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1070
-	public void parsesDbRefDeclarationsCorrectly() throws Exception {
+	public void parsesDbRefDeclarationsCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("methodWithManuallyDefinedDbRef", String.class);
 		ConvertingParameterAccessor parameterAccessor = StubParameterAccessor.getAccessor(converter, "myid");
@@ -257,7 +258,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1072
-	public void shouldParseJsonKeyReplacementCorrectly() throws Exception {
+	public void shouldParseJsonKeyReplacementCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("methodWithPlaceholderInKeyOfJsonStructure", String.class,
 				String.class);
@@ -269,7 +270,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-990
-	public void shouldSupportExpressionsInCustomQueries() throws Exception {
+	public void shouldSupportExpressionsInCustomQueries() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "Matthews");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByQueryWithExpression", String.class);
@@ -281,7 +282,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1244
-	public void shouldSupportExpressionsInCustomQueriesWithNestedObject() throws Exception {
+	public void shouldSupportExpressionsInCustomQueriesWithNestedObject() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, true, "param1", "param2");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByQueryWithExpressionAndNestedObject", boolean.class,
@@ -294,7 +295,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1244
-	public void shouldSupportExpressionsInCustomQueriesWithMultipleNestedObjects() throws Exception {
+	public void shouldSupportExpressionsInCustomQueriesWithMultipleNestedObjects() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, true, "param1", "param2");
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByQueryWithExpressionAndMultipleNestedObjects",
@@ -308,10 +309,10 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1290
-	public void shouldSupportNonQuotedBinaryDataReplacement() throws Exception {
+	public void shouldSupportNonQuotedBinaryDataReplacement() {
 
-		byte[] binaryData = "Matthews".getBytes("UTF-8");
-		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, binaryData);
+		byte[] binaryData = "Matthews".getBytes(StandardCharsets.UTF_8);
+		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, (Object) binaryData);
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameAsBinary", byte[].class);
 
 		org.springframework.data.mongodb.core.query.Query query = mongoQuery.createQuery(accessor);
@@ -322,7 +323,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1454
-	public void shouldSupportExistsProjection() throws Exception {
+	public void shouldSupportExistsProjection() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("existsByLastname", String.class);
 
@@ -330,7 +331,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565
-	public void bindsPropertyReferenceMultipleTimesCorrectly() throws Exception {
+	public void bindsPropertyReferenceMultipleTimesCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByAgeQuotedAndUnquoted", Integer.TYPE);
 
@@ -347,7 +348,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565
-	public void shouldIgnorePlaceholderPatternInReplacementValue() throws Exception {
+	public void shouldIgnorePlaceholderPatternInReplacementValue() {
 
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "argWith?1andText",
 				"nothing-special");
@@ -360,7 +361,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565
-	public void shouldQuoteStringReplacementCorrectly() throws Exception {
+	public void shouldQuoteStringReplacementCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "Matthews', password: 'foo");
@@ -372,7 +373,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565
-	public void shouldQuoteStringReplacementContainingQuotesCorrectly() throws Exception {
+	public void shouldQuoteStringReplacementContainingQuotesCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "Matthews\", password: \"foo");
@@ -384,7 +385,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565
-	public void shouldQuoteStringReplacementWithQuotationsCorrectly() throws Exception {
+	public void shouldQuoteStringReplacementWithQuotationsCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter,
@@ -395,7 +396,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565, DATAMONGO-1575
-	public void shouldQuoteComplexQueryStringCorrectly() throws Exception {
+	public void shouldQuoteComplexQueryStringCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "{ $ne : \"calamity\" }");
@@ -405,7 +406,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1565, DATAMONGO-1575
-	public void shouldQuotationInQuotedComplexQueryString() throws Exception {
+	public void shouldQuotationInQuotedComplexQueryString() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameQuoted", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter,
@@ -417,7 +418,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1575
-	public void shouldTakeBsonParameterAsIs() throws Exception {
+	public void shouldTakeBsonParameterAsIs() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByWithBsonArgument", Document.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter,
@@ -428,7 +429,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1575
-	public void shouldReplaceParametersInInQuotedExpressionOfNestedQueryOperator() throws Exception {
+	public void shouldReplaceParametersInInQuotedExpressionOfNestedQueryOperator() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameRegex", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "calamity");
@@ -438,7 +439,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldAllowReuseOfPlaceholderWithinQuery() throws Exception {
+	public void shouldAllowReuseOfPlaceholderWithinQuery() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByReusingPlaceholdersMultipleTimes", String.class,
 				String.class);
@@ -450,7 +451,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldAllowReuseOfQuotedPlaceholderWithinQuery() throws Exception {
+	public void shouldAllowReuseOfQuotedPlaceholderWithinQuery() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByReusingPlaceholdersMultipleTimesWhenQuoted",
 				String.class, String.class);
@@ -462,7 +463,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldAllowReuseOfQuotedPlaceholderWithinQueryAndIncludeSuffixCorrectly() throws Exception {
+	public void shouldAllowReuseOfQuotedPlaceholderWithinQueryAndIncludeSuffixCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod(
 				"findByReusingPlaceholdersMultipleTimesWhenQuotedAndSomeStuffAppended", String.class, String.class);
@@ -474,7 +475,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldAllowQuotedParameterWithSuffixAppended() throws Exception {
+	public void shouldAllowQuotedParameterWithSuffixAppended() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByWhenQuotedAndSomeStuffAppended", String.class,
 				String.class);
@@ -485,7 +486,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldCaptureReplacementWithComplexSuffixCorrectly() throws Exception {
+	public void shouldCaptureReplacementWithComplexSuffixCorrectly() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByMultiRegex", String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "calamity");
@@ -497,7 +498,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1603
-	public void shouldAllowPlaceholderReuseInQuotedValue() throws Exception {
+	public void shouldAllowPlaceholderReuseInQuotedValue() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByLastnameRegex", String.class, String.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, "calamity", "regalia");
@@ -509,7 +510,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1605
-	public void findUsingSpelShouldRetainParameterType() throws Exception {
+	public void findUsingSpelShouldRetainParameterType() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByUsingSpel", Object.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, 100.01D);
@@ -519,7 +520,7 @@ public class StringBasedMongoQueryUnitTests {
 	}
 
 	@Test // DATAMONGO-1605
-	public void findUsingSpelShouldRetainNullValues() throws Exception {
+	public void findUsingSpelShouldRetainNullValues() {
 
 		StringBasedMongoQuery mongoQuery = createQueryForMethod("findByUsingSpel", Object.class);
 		ConvertingParameterAccessor accessor = StubParameterAccessor.getAccessor(converter, new Object[] { null });
@@ -528,13 +529,19 @@ public class StringBasedMongoQueryUnitTests {
 		assertThat(query.getQueryObject(), is(new Document("arg0", null)));
 	}
 
-	private StringBasedMongoQuery createQueryForMethod(String name, Class<?>... parameters) throws Exception {
+	private StringBasedMongoQuery createQueryForMethod(String name, Class<?>... parameters) {
 
-		Method method = SampleRepository.class.getMethod(name, parameters);
-		ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
-		MongoQueryMethod queryMethod = new MongoQueryMethod(method, new DefaultRepositoryMetadata(SampleRepository.class),
-				factory, converter.getMappingContext());
-		return new StringBasedMongoQuery(queryMethod, operations, PARSER, DefaultEvaluationContextProvider.INSTANCE);
+		try {
+
+			Method method = SampleRepository.class.getMethod(name, parameters);
+			ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+			MongoQueryMethod queryMethod = new MongoQueryMethod(method, new DefaultRepositoryMetadata(SampleRepository.class),
+					factory, converter.getMappingContext());
+			return new StringBasedMongoQuery(queryMethod, operations, PARSER, DefaultEvaluationContextProvider.INSTANCE);
+
+		} catch (Exception e) {
+			throw new IllegalArgumentException(e.getMessage(), e);
+		}
 	}
 
 	private interface SampleRepository extends Repository<Person, Long> {


### PR DESCRIPTION
We now use the fluent FindOperations API in AbstractMongoQuery and MongoQueryExecution instead of the MongoOperations. This allows us to eagerly resolve some general execution coordinates (which collection to query etc.) and thus simplify the eventual execution.

Got rid of a couple of very simple QueryExecution implementations that can be replace by a simple lambda. Removed the need to read into a partially filled domain object and then map to the projection DTO as we can now tell the operations to read into the DTO directly.

Adapted unit tests.

Open points:

- if the fluent operations returned a `Stream` for the call to `….stream()` immediately we could even further reduce complexity of the stream execution