### PR TITLE
DATAMONGO-1739 - Changed TerminatingFindOperation.stream() to return Stream.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1739-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1739-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1739-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1739-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1739-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
@@ -17,11 +17,11 @@ package org.springframework.data.mongodb.core;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.util.CloseableIterator;
 
 /**
  * {@link ExecutableFindOperation} allows creation and execution of MongoDB find operations in a fluent API style.
@@ -111,10 +111,10 @@ public interface ExecutableFindOperation {
 		/**
 		 * Stream all matching elements.
 		 *
-		 * @return a {@link CloseableIterator} that wraps the a Mongo DB {@link com.mongodb.Cursor} that needs to be closed.
-		 *         Never {@literal null}.
+		 * @return a {@link Stream} that wraps the a Mongo DB {@link com.mongodb.Cursor} that needs to be closed. Never
+		 *         {@literal null}.
 		 */
-		CloseableIterator<T> stream();
+		Stream<T> stream();
 
 		/**
 		 * Get the number of matching elements.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.bson.Document;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -26,6 +27,7 @@ import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.SerializationUtils;
 import org.springframework.data.util.CloseableIterator;
+import org.springframework.data.util.StreamUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -135,8 +137,8 @@ class ExecutableFindOperationSupport implements ExecutableFindOperation {
 		}
 
 		@Override
-		public CloseableIterator<T> stream() {
-			return doStream();
+		public Stream<T> stream() {
+			return StreamUtils.createStreamFromIterator(doStream());
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -22,6 +22,8 @@ import static org.springframework.data.mongodb.core.query.Query.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.stream.Stream;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -33,7 +35,6 @@ import org.springframework.data.mongodb.core.index.GeospatialIndex;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.NearQuery;
-import org.springframework.data.util.CloseableIterator;
 
 import com.mongodb.MongoClient;
 
@@ -168,7 +169,7 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void streamAll() {
 
-		try (CloseableIterator<Person> stream = template.query(Person.class).stream()) {
+		try (Stream<Person> stream = template.query(Person.class).stream()) {
 			assertThat(stream).containsExactlyInAnyOrder(han, luke);
 		}
 	}
@@ -176,7 +177,7 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void streamAllWithCollection() {
 
-		try (CloseableIterator<Human> stream = template.query(Human.class).inCollection(STAR_WARS).stream()) {
+		try (Stream<Human> stream = template.query(Human.class).inCollection(STAR_WARS).stream()) {
 			assertThat(stream).hasSize(2);
 		}
 	}
@@ -184,7 +185,7 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void streamAllWithProjection() {
 
-		try (CloseableIterator<Jedi> stream = template.query(Person.class).as(Jedi.class).stream()) {
+		try (Stream<Jedi> stream = template.query(Person.class).as(Jedi.class).stream()) {
 			assertThat(stream).hasOnlyElementsOfType(Jedi.class).hasSize(2);
 		}
 	}
@@ -192,9 +193,7 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void streamAllBy() {
 
-		try (CloseableIterator<Person> stream = template.query(Person.class).matching(query(where("firstname").is("luke")))
-				.stream()) {
-
+		try (Stream<Person> stream = template.query(Person.class).matching(query(where("firstname").is("luke"))).stream()) {
 			assertThat(stream).containsExactlyInAnyOrder(luke);
 		}
 	}


### PR DESCRIPTION
TerminatingFindOperation.stream() now returns a Stream directly, leveraging Spring Data Commons' StreamUtils.createStreamFromIterator(…) to create a Stream and register a callback to forward calls to Stream.close() to the iterator.