### PR TITLE
DATAMONGO-1733 - Allow open/closed interface projections directly via fluent API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-benchmarks/src/main/java/org/springframework/data/mongodb/core/ProjectionsBenchmark.java
+++ b/spring-data-mongodb-benchmarks/src/main/java/org/springframework/data/mongodb/core/ProjectionsBenchmark.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.bson.Document;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.ExecutableFindOperation.FindOperationWithQuery;
+import org.springframework.data.mongodb.core.ExecutableFindOperation.TerminatingFindOperation;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.microbenchmark.AbstractMicrobenchmark;
+
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+
+/**
+ * @author Christoph Strobl
+ */
+public class ProjectionsBenchmark extends AbstractMicrobenchmark {
+
+	private static final String DB_NAME = "projections-benchmark";
+	private static final String COLLECTION_NAME = "projections";
+
+	private MongoTemplate template;
+	private MongoClient client;
+	private MongoCollection<Document> mongoCollection;
+
+	private Person source;
+
+	private FindOperationWithQuery<Person> asPerson;
+	private FindOperationWithQuery<DtoProjection> asDtoProjection;
+	private FindOperationWithQuery<ClosedProjection> asClosedProjection;
+	private FindOperationWithQuery<OpenProjection> asOpenProjection;
+
+	private TerminatingFindOperation<Person> asPersonWithFieldsRestriction;
+	private Document fields = new Document("firstname", 1);
+
+	@Setup
+	public void setUp() {
+
+		client = new MongoClient(new ServerAddress());
+		template = new MongoTemplate(client, DB_NAME);
+
+		source = new Person();
+		source.firstname = "luke";
+		source.lastname = "skywalker";
+
+		source.address = new Address();
+		source.address.street = "melenium falcon 1";
+		source.address.city = "deathstar";
+
+		template.save(source, COLLECTION_NAME);
+
+		asPerson = template.query(Person.class).inCollection(COLLECTION_NAME);
+		asDtoProjection = template.query(Person.class).inCollection(COLLECTION_NAME).as(DtoProjection.class);
+		asClosedProjection = template.query(Person.class).inCollection(COLLECTION_NAME).as(ClosedProjection.class);
+		asOpenProjection = template.query(Person.class).inCollection(COLLECTION_NAME).as(OpenProjection.class);
+
+		asPersonWithFieldsRestriction = template.query(Person.class).inCollection(COLLECTION_NAME)
+				.matching(new BasicQuery(new Document(), fields));
+
+		mongoCollection = client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME);
+	}
+
+	@TearDown
+	public void tearDown() {
+
+		client.dropDatabase(DB_NAME);
+		client.close();
+	}
+
+	/**
+	 * Set the baseline for comparison by using the plain MongoDB java driver api without any additional fluff.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object baseline() {
+		return mongoCollection.find().first();
+	}
+
+	/**
+	 * Read into the domain type including all fields.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object readIntoDomainType() {
+		return asPerson.all();
+	}
+
+	/**
+	 * Read into the domain type but restrict query to only return one field.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object readIntoDomainTypeRestrictingToOneField() {
+		return asPersonWithFieldsRestriction.all();
+	}
+
+	/**
+	 * Read into dto projection that only needs to map one field back.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object readIntoDtoProjectionWithOneField() {
+		return asDtoProjection.all();
+	}
+
+	/**
+	 * Read into closed interface projection.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object readIntoClosedProjectionWithOneField() {
+		return asClosedProjection.all();
+	}
+
+	/**
+	 * Read into an open projection backed by the mapped domain object.
+	 *
+	 * @return
+	 */
+	@Benchmark // DATAMONGO-1733
+	public Object readIntoOpenProjection() {
+		return asOpenProjection.all();
+	}
+
+	static class Person {
+
+		@Id String id;
+		String firstname;
+		String lastname;
+		Address address;
+	}
+
+	static class Address {
+
+		String city;
+		String street;
+	}
+
+	static class DtoProjection {
+
+		@Field("firstname") String name;
+	}
+
+	static interface ClosedProjection {
+
+		String getFirstname();
+	}
+
+	static interface OpenProjection {
+
+		@Value("#{target.firstname}")
+		String name();
+	}
+
+}

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1733-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -68,7 +68,6 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
-import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.DefaultBulkOperations.BulkOperationContext;
@@ -2338,49 +2337,30 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	private Document getMappedFieldsObject(Document fields, MongoPersistentEntity<?> entity, Class<?> targetType) {
-
-		Document mappedFields = queryMapper.getMappedFields(fields, entity);
-		return addFieldsForProjection(mappedFields, entity.getType(), targetType);
+		return queryMapper.getMappedFields(addFieldsForProjection(fields, entity.getType(), targetType), entity);
 	}
 
 	/**
-	 * For cases where {@code mappedFields} is {@literal null} or {@literal empty} add fields required for creating the
-	 * projection (target) type if the {@code targetType} is a {@literal closed projection}.
+	 * For cases where {@code fields} is {@literal null} or {@literal empty} add fields required for creating the
+	 * projection (target) type if the {@code targetType} is a {@literal closed interface projection}.
 	 *
-	 * @param mappedFields can be {@literal null}.
+	 * @param fields can be {@literal null}.
 	 * @param domainType must not be {@literal null}.
 	 * @param targetType must not be {@literal null}.
 	 * @return {@link Document} with fields to be included.
 	 */
-	private Document addFieldsForProjection(Document mappedFields, Class<?> domainType, Class<?> targetType) {
+	private Document addFieldsForProjection(Document fields, Class<?> domainType, Class<?> targetType) {
 
-		if ((mappedFields != null && !mappedFields.isEmpty()) || ClassUtils.isAssignable(domainType, targetType)) {
-			return mappedFields;
-		}
-
-		Document fields = new Document();
-
-		if (!targetType.isInterface()) {
-
-			MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(targetType);
-
-			for (MongoPersistentProperty property : entity) {
-				if (!property.isTransient()) {
-					fields.append(property.getFieldName(), 1);
-				}
-			}
-
+		if ((fields != null && !fields.isEmpty()) || !targetType.isInterface()
+				|| ClassUtils.isAssignable(domainType, targetType)) {
 			return fields;
 		}
 
-		ProjectionInformation pi = PROJECTION_FACTORY.getProjectionInformation(targetType);
-		if (pi.isClosed()) {
+		ProjectionInformation projectionInformation = PROJECTION_FACTORY.getProjectionInformation(targetType);
+		if (projectionInformation.isClosed()) {
 
-			for (PropertyDescriptor pd : pi.getInputProperties()) {
-
-				MongoPersistentProperty pp = ((MongoMappingContext) mappingContext).createPersistentProperty(Property.of(pd),
-						((MongoMappingContext) mappingContext).getPersistentEntity(targetType), MongoSimpleTypes.HOLDER);
-				fields.append(pp.getFieldName(), 1);
+			for (PropertyDescriptor descriptor : projectionInformation.getInputProperties()) {
+				fields.append(descriptor.getName(), 1);
 			}
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -696,7 +696,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		results = results == null ? Collections.emptyList() : results;
 
 		DocumentCallback<GeoResult<T>> callback = new GeoNearResultDocumentCallback<T>(
-				new ReadDocumentCallback<T>(mongoConverter, returnType, collectionName), near.getMetric());
+				new ProjectingReadCallback<>(mongoConverter, domainType, returnType, collectionName), near.getMetric());
 		List<GeoResult<T>> result = new ArrayList<GeoResult<T>>(results.size());
 
 		int index = 0;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -381,7 +381,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 						.prepare(collection.find(mappedQuery).projection(mappedFields));
 
 				return new CloseableIterableCursorAdapter<T>(cursor, exceptionTranslator,
-						new ReadDocumentCallback<T>(mongoConverter, returnType, collectionName));
+						new ProjectingReadCallback<>(mongoConverter, entityType, returnType, collectionName));
 			}
 		});
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -241,7 +241,7 @@ public class UpdateMapper extends QueryMapper {
 			MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
 		return entity == null ? super.createPropertyField(entity, key, mappingContext)
-				: new MetadataBackedUpdateField(entity, key, mappingContext);
+				: new MetadataBackedUpdateField(entity, key, mappingContext, getPropertyPaths());
 	}
 
 	private static Document getSortObject(Sort sort) {
@@ -278,9 +278,9 @@ public class UpdateMapper extends QueryMapper {
 		 * @param mappingContext must not be {@literal null}.
 		 */
 		public MetadataBackedUpdateField(MongoPersistentEntity<?> entity, String key,
-				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
+				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext, PropertyPaths paths) {
 
-			super(key.replaceAll("\\.\\$", ""), entity, mappingContext);
+			super(key.replaceAll("\\.\\$", ""), entity, mappingContext, paths);
 			this.key = key;
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -48,27 +48,27 @@ import com.mongodb.MongoClient;
 public class ExecutableFindOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
+	private static final String STAR_WARS_PLANETS = "star-wars-universe";
 	MongoTemplate template;
 
 	Person han;
 	Person luke;
+
+	Planet alderan;
+	Planet dantooine;
 
 	@Before
 	public void setUp() {
 
 		template = new MongoTemplate(new SimpleMongoDbFactory(new MongoClient(), "ExecutableFindOperationSupportTests"));
 		template.dropCollection(STAR_WARS);
+		template.dropCollection(STAR_WARS_PLANETS);
 
-		han = new Person();
-		han.firstname = "han";
-		han.id = "id-1";
+		template.indexOps(Planet.class).ensureIndex(
+				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
 
-		luke = new Person();
-		luke.firstname = "luke";
-		luke.id = "id-2";
-
-		template.save(han);
-		template.save(luke);
+		initPersons();
+		initPlanets();
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1563
@@ -99,6 +99,13 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void findAllWithProjection() {
 		assertThat(template.query(Person.class).as(Jedi.class).all()).hasOnlyElementsOfType(Jedi.class).hasSize(2);
+	}
+
+	@Test // DATAMONGO-1733
+	public void findByReturningAllValuesAsClosedInterfaceProjection() {
+
+		assertThat(template.query(Person.class).as(PersonProjection.class).all())
+				.hasOnlyElementsOfTypes(PersonProjection.class);
 	}
 
 	@Test // DATAMONGO-1563
@@ -167,6 +174,26 @@ public class ExecutableFindOperationSupportTests {
 				.isIn(han, luke);
 	}
 
+	@Test // DATAMONGO-1733
+	public void findByReturningFirstValueAsClosedInterfaceProjection() {
+
+		PersonProjection result = template.query(Person.class).as(PersonProjection.class)
+				.matching(query(where("firstname").is("han"))).firstValue();
+
+		assertThat(result).isInstanceOf(PersonProjection.class);
+		assertThat(result.getFirstname()).isEqualTo("han");
+	}
+
+	@Test // DATAMONGO-1733
+	public void findByReturningFirstValueAsOpenInterfaceProjection() {
+
+		PersonSpELProjection result = template.query(Person.class).as(PersonSpELProjection.class)
+				.matching(query(where("firstname").is("han"))).firstValue();
+
+		assertThat(result).isInstanceOf(PersonSpELProjection.class);
+		assertThat(result.getName()).isEqualTo("han");
+	}
+
 	@Test // DATAMONGO-1563
 	public void streamAll() {
 
@@ -202,15 +229,6 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void findAllNearBy() {
 
-		template.indexOps(Planet.class).ensureIndex(
-				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
-
-		Planet alderan = new Planet("alderan", new Point(-73.9836, 40.7538));
-		Planet dantooine = new Planet("dantooine", new Point(-73.9928, 40.7193));
-
-		template.save(alderan);
-		template.save(dantooine);
-
 		GeoResults<Planet> results = template.query(Planet.class).near(NearQuery.near(-73.9667, 40.78).spherical(true))
 				.all();
 		assertThat(results.getContent()).hasSize(2);
@@ -220,22 +238,39 @@ public class ExecutableFindOperationSupportTests {
 	@Test // DATAMONGO-1563
 	public void findAllNearByWithCollectionAndProjection() {
 
-		template.indexOps(Planet.class).ensureIndex(
-				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
-
-		Planet alderan = new Planet("alderan", new Point(-73.9836, 40.7538));
-		Planet dantooine = new Planet("dantooine", new Point(-73.9928, 40.7193));
-
-		template.save(alderan);
-		template.save(dantooine);
-
-		GeoResults<Human> results = template.query(Object.class).inCollection(STAR_WARS).as(Human.class)
+		GeoResults<Human> results = template.query(Object.class).inCollection(STAR_WARS_PLANETS).as(Human.class)
 				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
 
 		assertThat(results.getContent()).hasSize(2);
 		assertThat(results.getContent().get(0).getDistance()).isNotNull();
 		assertThat(results.getContent().get(0).getContent()).isInstanceOf(Human.class);
 		assertThat(results.getContent().get(0).getContent().getId()).isEqualTo("alderan");
+	}
+
+	@Test // DATAMONGO-1733
+	public void findAllNearByReturningGeoResultContentAsClosedInterfaceProjection() {
+
+		GeoResults<PlanetProjection> results = template.query(Planet.class).as(PlanetProjection.class)
+				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
+
+		assertThat(results.getContent()).allSatisfy(it -> {
+
+			assertThat(it.getContent()).isInstanceOf(PlanetProjection.class);
+			assertThat(it.getContent().getName()).isNotBlank();
+		});
+	}
+
+	@Test // DATAMONGO-1733
+	public void findAllNearByReturningGeoResultContentAsOpenInterfaceProjection() {
+
+		GeoResults<PlanetSpELProjection> results = template.query(Planet.class).as(PlanetSpELProjection.class)
+				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
+
+		assertThat(results.getContent()).allSatisfy(it -> {
+
+			assertThat(it.getContent()).isInstanceOf(PlanetSpELProjection.class);
+			assertThat(it.getContent().getId()).isNotBlank();
+		});
 	}
 
 	@Test // DATAMONGO-1728
@@ -287,6 +322,16 @@ public class ExecutableFindOperationSupportTests {
 		String firstname;
 	}
 
+	interface PersonProjection {
+		String getFirstname();
+	}
+
+	public interface PersonSpELProjection {
+
+		@Value("#{target.firstname}")
+		String getName();
+	}
+
 	@Data
 	static class Human {
 		@Id String id;
@@ -300,41 +345,43 @@ public class ExecutableFindOperationSupportTests {
 
 	@Data
 	@AllArgsConstructor
-	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS)
+	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS_PLANETS)
 	static class Planet {
 
 		@Id String name;
 		Point coordinates;
 	}
 
-	interface PersonProjection {
-		String getFirstname();
-	}
-
-	public interface PersonSpELProjection {
-
-		@Value("#{target.firstname}")
+	interface PlanetProjection {
 		String getName();
 	}
 
-	@Test // DATAMONGO-1733
-	public void intoClosedProjectionInterface() {
+	interface PlanetSpELProjection {
 
-		PersonProjection projection = template.query(Person.class).as(PersonProjection.class)
-				.matching(query(where("firstname").is("han"))).firstValue();
-
-		assertThat(projection).isInstanceOf(PersonProjection.class);
-		assertThat(projection.getFirstname()).isEqualTo("han");
+		@Value("#{target.name}")
+		String getId();
 	}
 
-	@Test // DATAMONGO-1733
-	public void intoOpenProjectionInterface() {
+	private void initPersons() {
 
-		PersonSpELProjection projection = template.query(Person.class).as(PersonSpELProjection.class)
-				.matching(query(where("firstname").is("han"))).firstValue();
+		han = new Person();
+		han.firstname = "han";
+		han.id = "id-1";
 
-		assertThat(projection).isInstanceOf(PersonSpELProjection.class);
-		assertThat(projection.getName()).isEqualTo("han");
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.id = "id-2";
+
+		template.save(han);
+		template.save(luke);
 	}
 
+	private void initPlanets() {
+
+		alderan = new Planet("alderan", new Point(-73.9836, 40.7538));
+		dantooine = new Planet("dantooine", new Point(-73.9928, 40.7193));
+
+		template.save(alderan);
+		template.save(dantooine);
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.geo.GeoResults;
@@ -305,4 +306,35 @@ public class ExecutableFindOperationSupportTests {
 		@Id String name;
 		Point coordinates;
 	}
+
+	interface PersonProjection {
+		String getFirstname();
+	}
+
+	public interface PersonSpELProjection {
+
+		@Value("#{target.firstname}")
+		String getName();
+	}
+
+	@Test // DATAMONGO-1733
+	public void intoClosedProjectionInterface() {
+
+		PersonProjection projection = template.query(Person.class).as(PersonProjection.class)
+				.matching(query(where("firstname").is("han"))).firstValue();
+
+		assertThat(projection).isInstanceOf(PersonProjection.class);
+		assertThat(projection.getFirstname()).isEqualTo("han");
+	}
+
+	@Test // DATAMONGO-1733
+	public void intoOpenProjectionInterface() {
+
+		PersonSpELProjection projection = template.query(Person.class).as(PersonSpELProjection.class)
+				.matching(query(where("firstname").is("han"))).firstValue();
+
+		assertThat(projection).isInstanceOf(PersonSpELProjection.class);
+		assertThat(projection.getName()).isEqualTo("han");
+	}
+
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -31,6 +31,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Point;
+import org.springframework.data.mongodb.core.ExecutableFindOperation.TerminatingFindOperation;
 import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
 import org.springframework.data.mongodb.core.index.GeospatialIndex;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -216,6 +217,33 @@ public class ExecutableFindOperationSupportTests {
 		try (Stream<Jedi> stream = template.query(Person.class).as(Jedi.class).stream()) {
 			assertThat(stream).hasOnlyElementsOfType(Jedi.class).hasSize(2);
 		}
+	}
+
+	@Test // DATAMONGO-1733
+	public void streamAllReturningResultsAsClosedInterfaceProjection() {
+
+		TerminatingFindOperation<PersonProjection> operation = template.query(Person.class).as(PersonProjection.class);
+
+		assertThat(operation.stream()) //
+				.hasSize(2) //
+				.allSatisfy(it -> {
+					assertThat(it).isInstanceOf(PersonProjection.class);
+					assertThat(it.getFirstname()).isNotBlank();
+				});
+	}
+
+	@Test // DATAMONGO-1733
+	public void streamAllReturningResultsAsOpenInterfaceProjection() {
+
+		TerminatingFindOperation<PersonSpELProjection> operation = template.query(Person.class)
+				.as(PersonSpELProjection.class);
+
+		assertThat(operation.stream()) //
+				.hasSize(2) //
+				.allSatisfy(it -> {
+					assertThat(it).isInstanceOf(PersonSpELProjection.class);
+					assertThat(it.getName()).isNotBlank();
+				});
 	}
 
 	@Test // DATAMONGO-1563

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -821,15 +821,15 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void appliesFieldsToClosedDtoProjectionWhenQueryDoesNotDefineFields() {
+	public void doesNotApplyFieldsToDtoProjection() {
 
 		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class, null);
 
-		verify(findIterable).projection(eq(new Document("firstname", 1)));
+		verify(findIterable, never()).projection(any());
 	}
 
 	@Test // DATAMONGO-1733
-	public void doesNotApplyFieldsToClosedDtoProjectionWhenQueryDefinesFields() {
+	public void doesNotApplyFieldsToDtoProjectionWhenQueryDefinesFields() {
 
 		template.doFind("star-wars", new Document(), new Document("bar", 1), Person.class, Jedi.class, null);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.any;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 
+import lombok.Data;
+
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
@@ -44,6 +46,7 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
@@ -61,6 +64,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexCreator;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
@@ -782,12 +786,70 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	public void groupShouldUseCollationWhenPresent() {
 
 		commandResultDocument.append("retval", Collections.emptySet());
-		template.group("collection-1", GroupBy.key("id").reduceFunction("bar").collation(Collation.of("fr")), AutogenerateableId.class);
+		template.group("collection-1", GroupBy.key("id").reduceFunction("bar").collation(Collation.of("fr")),
+				AutogenerateableId.class);
 
 		ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
 		verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
 
-		assertThat(cmd.getValue().get("group", Document.class).get("collation", Document.class), equalTo(new Document("locale", "fr")));
+		assertThat(cmd.getValue().get("group", Document.class).get("collation", Document.class),
+				equalTo(new Document("locale", "fr")));
+	}
+
+	@Test // DATAMONGO-1733
+	public void appliesFieldsWhenInterfaceProjectionIsClosedAndQueryDoesNotDefineFields() {
+
+		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonProjection.class, null);
+
+		verify(findIterable).projection(eq(new Document("firstname", 1)));
+	}
+
+	@Test // DATAMONGO-1733
+	public void doesNotApplyFieldsWhenInterfaceProjectionIsClosedAndQueryDefinesFields() {
+
+		template.doFind("star-wars", new Document(), new Document("bar", 1), Person.class, PersonProjection.class, null);
+
+		verify(findIterable).projection(eq(new Document("bar", 1)));
+	}
+
+	@Test // DATAMONGO-1733
+	public void doesNotApplyFieldsWhenInterfaceProjectionIsOpen() {
+
+		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonSpELProjection.class, null);
+
+		verify(findIterable, never()).projection(any());
+	}
+
+	@Test // DATAMONGO-1733
+	public void appliesFieldsToClosedDtoProjectionWhenQueryDoesNotDefineFields() {
+
+		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class, null);
+
+		verify(findIterable).projection(eq(new Document("firstname", 1)));
+	}
+
+	@Test // DATAMONGO-1733
+	public void doesNotApplyFieldsToClosedDtoProjectionWhenQueryDefinesFields() {
+
+		template.doFind("star-wars", new Document(), new Document("bar", 1), Person.class, Jedi.class, null);
+
+		verify(findIterable).projection(eq(new Document("bar", 1)));
+	}
+
+	@Test // DATAMONGO-1733
+	public void doesNotApplyFieldsWhenTargetIsNotAProjection() {
+
+		template.doFind("star-wars", new Document(), new Document(), Person.class, Person.class, null);
+
+		verify(findIterable, never()).projection(any());
+	}
+
+	@Test // DATAMONGO-1733
+	public void doesNotApplyFieldsWhenTargetExtendsDomainType() {
+
+		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonExtended.class, null);
+
+		verify(findIterable, never()).projection(any());
 	}
 
 	class AutogenerateableId {
@@ -817,6 +879,40 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		public String convert(AutogenerateableId source) {
 			return source.toString();
 		}
+	}
+
+	@Data
+	@org.springframework.data.mongodb.core.mapping.Document(collection = "star-wars")
+	static class Person {
+
+		@Id String id;
+		String firstname;
+	}
+
+	static class PersonExtended extends Person {
+
+		String lastname;
+	}
+
+	interface PersonProjection {
+		String getFirstname();
+	}
+
+	public interface PersonSpELProjection {
+
+		@Value("#{target.firstname}")
+		String getName();
+	}
+
+	@Data
+	static class Human {
+		@Id String id;
+	}
+
+	@Data
+	static class Jedi {
+
+		@Field("firstname") String name;
 	}
 
 	class Wrapper {

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1425,6 +1425,55 @@ AggregationResults<TagCount> results = template.aggregate(aggregation, "tags", T
 
 WARNING: Indexes are only used if the collation used for the operation and the index collation matches.
 
+[[mongo.query.fluent-template-api]]
+=== Fluent Template API
+
+The `MongoOperations` interface is one of the central components when it comes to more low level interaction with MongoDB. It offers a wide range of methods covering needs from collection / index creation and CRUD operations to more advanced functionality like map-reduce and aggregations.
+One can find multiple overloads for each and every method. Most of them just cover optional / nullable parts of the API.
+
+`FluentMongoOperations` provide a more narrow interface for common methods of `MongoOperations` providing a more readable, fluent API.
+The entry points `insert(…)`, `find(…)`, `update(…)`, etc. follow a natural naming schema based on the operation to execute. Moving on from the entry point the API is designed to only offer context dependent methods guiding towards a terminating method that invokes the actual `MongoOperations` counterpart.
+
+====
+[source,java]
+----
+List<SWCharacter> all = ops.find(SWCharacter.class)
+  .inCollection("star-wars")                        <1>
+  .all();
+----
+<1> Skip this step if `SWCharacter` defines the collection via `@Document` or if using the class name as the collection name is just fine.
+====
+
+Sometimes a collection in MongoDB holds entities of different types. Like a `Jedi` within a collection of `SWCharacters`.
+To use different types for `Query` and return value mapping one can use `as(Class<?> targetType)` map results differently.
+
+====
+[source,java]
+----
+List<Jedi> all = ops.find(SWCharacter.class)    <1>
+  .as(Jedi.class)                               <2>
+  .matching(query(where("jedi").is(true)))
+  .all();
+----
+<1> The query fields are mapped against the `SWCharacter` type.
+<2> Resulting documents are mapped into `Jedi`.
+====
+
+TIP: It is possible to directly apply <<projections>> to resulting documents by providing just the `interface` type via `as(Class<?>)`.
+
+Switching between retrieving a single entity, multiple ones as `List` or `Stream` like is done via the terminating methods `first()`, `one()`, `all()` or `stream()`.
+
+When writing a geo-spatial query via `near(NearQuery)` the number of terminating methods is altered to just the ones valid for executing a `geoNear` command in MongoDB fetching entities as `GeoResult` within `GeoResults`.
+
+====
+[source,java]
+----
+GeoResults<Jedi> results = mongoOps.query(SWCharacter.class)
+  .as(Jedi.class)
+  .near(alderaan) // NearQuery.near(-73.9667, 40.78).maxDis…
+  .all();
+----
+====
 
 include::../{spring-data-commons-docs}/query-by-example.adoc[leveloffset=+1]
 include::query-by-example.adoc[leveloffset=+1]


### PR DESCRIPTION
ℹ️  This is work in progress. Do not merge - needs discussion!

We now directly support open and closed interface projections in the fluent API. For closed interface projections we add the according field list to optimize query execution in those cases where the actual `Query` does not already define the fields to load/exclude.