### PR TITLE
DATAMONGO-1631 - Better method names for reactive configuration support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.mongodb.config;
 
 import org.springframework.context.annotation.Bean;
@@ -21,9 +20,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 
 import com.mongodb.reactivestreams.client.MongoClient;
@@ -39,12 +38,12 @@ import com.mongodb.reactivestreams.client.MongoClient;
 public abstract class AbstractReactiveMongoConfiguration extends MongoConfigurationSupport {
 
 	/**
-	 * Return the {@link MongoClient} instance to connect to. Annotate with {@link Bean} in case you want to expose a
+	 * Return the Reactive Streams {@link MongoClient} instance to connect to. Annotate with {@link Bean} in case you want to expose a
 	 * {@link MongoClient} instance to the {@link org.springframework.context.ApplicationContext}.
 	 *
 	 * @return
 	 */
-	public abstract MongoClient mongoClient();
+	public abstract MongoClient reactiveMongoClient();
 
 	/**
 	 * Creates a {@link ReactiveMongoTemplate}.
@@ -53,30 +52,29 @@ public abstract class AbstractReactiveMongoConfiguration extends MongoConfigurat
 	 */
 	@Bean
 	public ReactiveMongoOperations reactiveMongoTemplate() throws Exception {
-		return new ReactiveMongoTemplate(mongoDbFactory(), mappingMongoConverter());
+		return new ReactiveMongoTemplate(reactiveMongoDbFactory(), mappingMongoConverter());
 	}
 
 	/**
 	 * Creates a {@link SimpleMongoDbFactory} to be used by the {@link MongoTemplate}. Will use the {@link Mongo} instance
-	 * configured in {@link #mongoClient()}.
+	 * configured in {@link #reactiveMongoClient()}.
 	 *
-	 * @see #mongoClient()
+	 * @see #reactiveMongoClient()
 	 * @see #reactiveMongoTemplate()
 	 * @return
-	 * @throws Exception
 	 */
 	@Bean
-	public ReactiveMongoDatabaseFactory mongoDbFactory() {
-		return new SimpleReactiveMongoDatabaseFactory(mongoClient(), getDatabaseName());
+	public ReactiveMongoDatabaseFactory reactiveMongoDbFactory() {
+		return new SimpleReactiveMongoDatabaseFactory(reactiveMongoClient(), getDatabaseName());
 	}
 
 	/**
-	 * Creates a {@link MappingMongoConverter} using the configured {@link #mongoDbFactory()} and
+	 * Creates a {@link MappingMongoConverter} using the configured {@link #reactiveMongoDbFactory()} and
 	 * {@link #mongoMappingContext()}. Will get {@link #customConversions()} applied.
 	 *
 	 * @see #customConversions()
 	 * @see #mongoMappingContext()
-	 * @see #mongoDbFactory()
+	 * @see #reactiveMongoDbFactory()
 	 * @return
 	 * @throws Exception
 	 */

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationIntegrationTests.java
@@ -54,7 +54,7 @@ public class AbstractReactiveMongoConfigurationIntegrationTests {
 	static class ReactiveConfiguration extends AbstractReactiveMongoConfiguration {
 
 		@Override
-		public MongoClient mongoClient() {
+		public MongoClient reactiveMongoClient() {
 			return MongoClients.create();
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationUnitTests.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.mongodb.config;
 
 import static org.hamcrest.Matchers.*;
@@ -158,7 +157,7 @@ public class AbstractReactiveMongoConfigurationUnitTests {
 		}
 
 		@Override
-		public MongoClient mongoClient() {
+		public MongoClient reactiveMongoClient() {
 			return MongoClients.create();
 		}
 
@@ -186,7 +185,7 @@ public class AbstractReactiveMongoConfigurationUnitTests {
 		}
 
 		@Override
-		public MongoClient mongoClient() {
+		public MongoClient reactiveMongoClient() {
 			return MongoClients.create();
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultReactiveIndexOperationsTests.java
@@ -59,7 +59,7 @@ public class DefaultReactiveIndexOperationsTests {
 	static class Config extends AbstractReactiveMongoConfiguration {
 
 		@Override
-		public MongoClient mongoClient() {
+		public MongoClient reactiveMongoClient() {
 			return MongoClients.create();
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateCollationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateCollationTests.java
@@ -51,7 +51,7 @@ public class ReactiveMongoTemplateCollationTests {
 	static class Config extends AbstractReactiveMongoConfiguration {
 
 		@Override
-		public com.mongodb.reactivestreams.client.MongoClient mongoClient() {
+		public com.mongodb.reactivestreams.client.MongoClient reactiveMongoClient() {
 			return MongoClients.create();
 		}
 

--- a/src/main/asciidoc/reference/reactive-mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/reactive-mongo-repositories.adoc
@@ -81,7 +81,7 @@ class ApplicationConfig extends AbstractReactiveMongoConfiguration {
   }
 
   @Override
-  public MongoClient mongoClient() {
+  public MongoClient reactiveMongoClient() {
     return MongoClients.create();
   }
 

--- a/src/main/asciidoc/reference/reactive-mongodb.adoc
+++ b/src/main/asciidoc/reference/reactive-mongodb.adoc
@@ -155,7 +155,7 @@ public class AppConfig {
   /*
    * Use the Reactive Streams Mongo Client API to create a com.mongodb.reactivestreams.client.MongoClient instance.
    */
-   public @Bean MongoClient mongoClient()  {
+   public @Bean MongoClient reactiveMongoClient()  {
        return MongoClients.create("mongodb://localhost");
    }
 }
@@ -262,7 +262,7 @@ To register a `ReactiveMongoDatabaseFactory` instance with the container, you wr
 @Configuration
 public class MongoConfiguration {
 
-  public @Bean ReactiveMongoDatabaseFactory mongoDatabaseFactory() {
+  public @Bean ReactiveMongoDatabaseFactory reactiveMongoDatabaseFactory() {
     return new SimpleReactiveMongoDatabaseFactory(MongoClients.create(), "database");
   }
 }
@@ -275,12 +275,12 @@ To define the username and password create MongoDB connection string and pass it
 @Configuration
 public class MongoConfiguration {
 
-  public @Bean ReactiveMongoDatabaseFactory mongoDatabaseFactory() {
-    return new SimpleMongoDbFactory(MongoClients.create("mongodb://joe:secret@localhost"), "database", userCredentials);
+  public @Bean ReactiveMongoDatabaseFactory reactiveMongoDatabaseFactory() {
+    return new SimpleReactiveMongoDatabaseFactory(MongoClients.create("mongodb://joe:secret@localhost"), "database");
   }
 
   public @Bean ReactiveMongoTemplate reactiveMongoTemplate() {
-    return new ReactiveMongoTemplate(mongoDatabaseFactory());
+    return new ReactiveMongoTemplate(reactiveMongoDatabaseFactory());
   }
 }
 ----
@@ -318,12 +318,12 @@ You can use Java to create and register an instance of `ReactiveMongoTemplate` a
 @Configuration
 public class AppConfig {
 
-  public @Bean MongoClient mongoClient() {
+  public @Bean MongoClient reactiveMongoClient() {
       return MongoClients.create("mongodb://localhost");
   }
 
   public @Bean ReactiveMongoTemplate reactiveMongoTemplate() {
-      return new ReactiveMongoTemplate(mongoClient(), "mydatabase");
+      return new ReactiveMongoTemplate(reactiveMongoClient(), "mydatabase");
   }
 }
 ----


### PR DESCRIPTION
This commit renames methods in `AbstractReactiveMongoConfiguration` for methods exposing MongoClient and `ReactiveMongoDatabaseFactory` instances. Renaming prevents possible clashes with beans created via `AbstractMongoConfiguration` (blocking driver) as bean names default to the producing method name.

---

Related ticket: [DATAMONGO-1631](https://jira.spring.io/browse/DATAMONGO-1631).