### PR TITLE
DATAMONGO-1784: Add complex expression support to the sum() aggregation function

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GroupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GroupOperation.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * @author Gustavo de Geus
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Sergey Shcherbakov
  * @since 1.3
  * @see <a href="https://docs.mongodb.org/manual/reference/aggregation/group/">MongoDB Aggregation Framework: $group</a>
  */
@@ -153,6 +154,17 @@ public class GroupOperation implements FieldsExposingAggregationOperation {
 	 */
 	public GroupOperationBuilder sum(String reference) {
 		return sum(reference, null);
+	}
+
+	/**
+	 * Generates an {@link GroupOperationBuilder} for an {@code $sum}-expression for the given
+	 * {@link AggregationExpression}.
+	 *
+	 * @param expr
+	 * @return
+	 */
+	public GroupOperationBuilder sum(AggregationExpression expr) {
+		return newBuilder(GroupOps.SUM, null, expr);
 	}
 
 	private GroupOperationBuilder sum(@Nullable String reference, @Nullable Object value) {


### PR DESCRIPTION
DATAMONGO-1784: Add complex expression support to the sum() aggregation function

Add the `public GroupOperationBuilder sum(AggregationExpression expr)` variant for the sum() aggregation function. Method variants accepting the `AggregationExpression` are available for avg(), first(), min(), max() aggregation functions. It seems that it was forgotten for the sum() function.
