### PR TITLE
DATAMONGO-1777 - Pretty print Modifiers when calling Update.toString().

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAMONGO-1777-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/SerializationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/SerializationUtils.java
@@ -109,7 +109,7 @@ public abstract class SerializationUtils {
 	 * printing raw {@link Document}s containing complex values before actually converting them into Mongo native types.
 	 *
 	 * @param value
-	 * @return
+	 * @return the serialized value or {@literal null}.
 	 */
 	@Nullable
 	public static String serializeToJsonSafely(@Nullable Object value) {
@@ -119,14 +119,15 @@ public abstract class SerializationUtils {
 		}
 
 		try {
-			return JSON.serialize(value);
+			return value instanceof Document ? ((Document) value).toJson() : JSON.serialize(value);
 		} catch (Exception e) {
+
 			if (value instanceof Collection) {
 				return toString((Collection<?>) value);
 			} else if (value instanceof Map) {
 				return toString((Map<?, ?>) value);
 			} else {
-				return String.format("{ $java : %s }", value.toString());
+				return String.format("{ \"$java\" : %s }", value.toString());
 			}
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.bson.Document;
@@ -55,9 +56,9 @@ public class Update {
 	}
 
 	private boolean isolated = false;
-	private Set<String> keysToUpdate = new HashSet<String>();
-	private Map<String, Object> modifierOps = new LinkedHashMap<String, Object>();
-	private Map<String, PushOperatorBuilder> pushCommandBuilders = new LinkedHashMap<String, PushOperatorBuilder>(1);
+	private Set<String> keysToUpdate = new HashSet<>();
+	private Map<String, Object> modifierOps = new LinkedHashMap<>();
+	private Map<String, PushOperatorBuilder> pushCommandBuilders = new LinkedHashMap<>(1);
 
 	/**
 	 * Static factory method to create an Update using the provided key
@@ -122,7 +123,8 @@ public class Update {
 	 * @param key
 	 * @param value
 	 * @return
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/">MongoDB Update operator: $setOnInsert</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/">MongoDB Update operator:
+	 *      $setOnInsert</a>
 	 */
 	public Update setOnInsert(String key, Object value) {
 		addMultiFieldOperation("$setOnInsert", key, value);
@@ -193,7 +195,8 @@ public class Update {
 	 * @param key
 	 * @param values
 	 * @return
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/pushAll/">MongoDB Update operator: $pushAll</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/pushAll/">MongoDB Update operator:
+	 *      $pushAll</a>
 	 */
 	public Update pushAll(String key, Object[] values) {
 		addMultiFieldOperation("$pushAll", key, Arrays.asList(values));
@@ -218,7 +221,8 @@ public class Update {
 	 * @param key
 	 * @param value
 	 * @return
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/addToSet/">MongoDB Update operator: $addToSet</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/addToSet/">MongoDB Update operator:
+	 *      $addToSet</a>
 	 */
 	public Update addToSet(String key, Object value) {
 		addMultiFieldOperation("$addToSet", key, value);
@@ -257,7 +261,8 @@ public class Update {
 	 * @param key
 	 * @param values
 	 * @return
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/pullAll/">MongoDB Update operator: $pullAll</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/pullAll/">MongoDB Update operator:
+	 *      $pullAll</a>
 	 */
 	public Update pullAll(String key, Object[] values) {
 		addMultiFieldOperation("$pullAll", key, Arrays.asList(values));
@@ -270,7 +275,8 @@ public class Update {
 	 * @param oldName
 	 * @param newName
 	 * @return
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/rename/">MongoDB Update operator: $rename</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/rename/">MongoDB Update operator:
+	 *      $rename</a>
 	 */
 	public Update rename(String oldName, String newName) {
 		addMultiFieldOperation("$rename", oldName, newName);
@@ -283,7 +289,8 @@ public class Update {
 	 * @param key
 	 * @return
 	 * @since 1.6
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/currentDate/">MongoDB Update operator: $currentDate</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/currentDate/">MongoDB Update operator:
+	 *      $currentDate</a>
 	 */
 	public Update currentDate(String key) {
 
@@ -297,7 +304,8 @@ public class Update {
 	 * @param key
 	 * @return
 	 * @since 1.6
-	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/currentDate/">MongoDB Update operator: $currentDate</a>
+	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/currentDate/">MongoDB Update operator:
+	 *      $currentDate</a>
 	 */
 	public Update currentTimestamp(String key) {
 
@@ -476,7 +484,7 @@ public class Update {
 		}
 
 		Update that = (Update) obj;
-		return this.getUpdateObject().equals(that.getUpdateObject());
+		return Objects.equals(this.getUpdateObject(), that.getUpdateObject());
 	}
 
 	/*
@@ -506,7 +514,7 @@ public class Update {
 		private Map<String, Modifier> modifiers;
 
 		public Modifiers() {
-			this.modifiers = new LinkedHashMap<String, Modifier>(1);
+			this.modifiers = new LinkedHashMap<>(1);
 		}
 
 		public Collection<Modifier> getModifiers() {
@@ -534,7 +542,8 @@ public class Update {
 			return nullSafeHashCode(modifiers);
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see java.lang.Object#equals(java.lang.Object)
 		 */
 		@Override
@@ -550,7 +559,7 @@ public class Update {
 
 			Modifiers that = (Modifiers) obj;
 
-			return this.modifiers.equals(that.modifiers);
+			return Objects.equals(this.modifiers, that.modifiers);
 		}
 
 		@Override
@@ -958,7 +967,7 @@ public class Update {
 
 			PushOperatorBuilder that = (PushOperatorBuilder) obj;
 
-			if (!getOuterType().equals(that.getOuterType())) {
+			if (!Objects.equals(getOuterType(), that.getOuterType())) {
 				return false;
 			}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SerializationUtilsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SerializationUtilsUnitTests.java
@@ -41,7 +41,7 @@ public class SerializationUtilsUnitTests {
 	public void writesSimpleDocument() {
 
 		Document document = new Document("foo", "bar");
-		assertThat(serializeToJsonSafely(document), is("{ \"foo\" : \"bar\"}"));
+		assertThat(serializeToJsonSafely(document), is("{ \"foo\" : \"bar\" }"));
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class SerializationUtilsUnitTests {
 
 		Document document = new Document("foo", new Complex());
 		assertThat(serializeToJsonSafely(document),
-				startsWith("{ \"foo\" : { $java : org.springframework.data.mongodb.core.SerializationUtilsUnitTests$Complex"));
+				startsWith("{ \"foo\" : { \"$java\" : org.springframework.data.mongodb.core.SerializationUtilsUnitTests$Complex"));
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class SerializationUtilsUnitTests {
 		Document document = new Document("foo", Arrays.asList("bar", new Complex()));
 		Matcher<String> expectedOutput = allOf(
 				startsWith(
-						"{ \"foo\" : [ \"bar\", { $java : org.springframework.data.mongodb.core.SerializationUtilsUnitTests$Complex"),
+						"{ \"foo\" : [ \"bar\", { \"$java\" : org.springframework.data.mongodb.core.SerializationUtilsUnitTests$Complex"),
 				endsWith(" } ] }"));
 		assertThat(serializeToJsonSafely(document), is(expectedOutput));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
@@ -210,7 +210,7 @@ public class QueryTests {
 
 		Query query = new Query(where("name").is("foo")).restrict(SpecialDoc.class);
 		assertThat(query.toString(), is(
-				"Query: { \"name\" : \"foo\", \"_$RESTRICTED_TYPES\" : [ { $java : class org.springframework.data.mongodb.core.SpecialDoc } ] }, Fields: { }, Sort: { }"));
+				"Query: { \"name\" : \"foo\", \"_$RESTRICTED_TYPES\" : [ { \"$java\" : class org.springframework.data.mongodb.core.SpecialDoc } ] }, Fields: { }, Sort: { }"));
 		assertThat(query.getRestrictedTypes(), is(notNullValue()));
 		assertThat(query.getRestrictedTypes().size(), is(1));
 		assertThat(query.getRestrictedTypes(), hasItems(Arrays.asList(SpecialDoc.class).toArray(new Class<?>[0])));
@@ -221,7 +221,7 @@ public class QueryTests {
 
 		exception.expect(InvalidMongoDbApiUsageException.class);
 		exception.expectMessage("second 'value' criteria");
-		exception.expectMessage("already contains '{ \"value\" : { $java : VAL_1 } }'");
+		exception.expectMessage("already contains '{ \"value\" : { \"$java\" : VAL_1 } }'");
 
 		Query query = new Query();
 		query.addCriteria(where("value").is(EnumType.VAL_1));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
@@ -425,8 +425,7 @@ public class UpdateTests {
 
 		Update update = new Update().max("key", 10);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$max", new Document("key", 10))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$max", new Document("key", 10))));
 	}
 
 	@Test // DATAMONGO-1404
@@ -434,8 +433,7 @@ public class UpdateTests {
 
 		Update update = new Update().min("key", 10);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$min", new Document("key", 10))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$min", new Document("key", 10))));
 	}
 
 	@Test // DATAMONGO-1404
@@ -444,8 +442,7 @@ public class UpdateTests {
 		Update update = new Update().max("key", 10);
 		update.max("key", 99);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$max", new Document("key", 99))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$max", new Document("key", 99))));
 	}
 
 	@Test // DATAMONGO-1404
@@ -454,8 +451,7 @@ public class UpdateTests {
 		Update update = new Update().min("key", 10);
 		update.min("key", 99);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$min", new Document("key", 99))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$min", new Document("key", 99))));
 	}
 
 	@Test // DATAMONGO-1404
@@ -464,8 +460,7 @@ public class UpdateTests {
 		Date date = new Date();
 		Update update = new Update().max("key", date);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$max", new Document("key", date))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$max", new Document("key", date))));
 	}
 
 	@Test // DATAMONGO-1404
@@ -474,8 +469,7 @@ public class UpdateTests {
 		Date date = new Date();
 		Update update = new Update().min("key", date);
 
-		assertThat(update.getUpdateObject(),
-				equalTo(new Document("$min", new Document("key", date))));
+		assertThat(update.getUpdateObject(), equalTo(new Document("$min", new Document("key", date))));
 	}
 
 	@Test // DATAMONGO-1777

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/UpdateTests.java
@@ -26,6 +26,7 @@ import org.bson.Document;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
+import org.springframework.data.mongodb.core.query.Update.Position;
 
 /**
  * Test cases for {@link Update}.
@@ -475,5 +476,19 @@ public class UpdateTests {
 
 		assertThat(update.getUpdateObject(),
 				equalTo(new Document("$min", new Document("key", date))));
+	}
+
+	@Test // DATAMONGO-1777
+	public void toStringShouldPrettyPrintModifiers() {
+
+		assertThat(new Update().push("key").atPosition(Position.FIRST).value("Arya").toString(), is(equalTo(
+				"{ \"$push\" : { \"key\" : { \"$java\" : { \"$position\" : { \"$java\" : { \"$position\" : 0} }, \"$each\" : { \"$java\" : { \"$each\" : [ \"Arya\"]} } } } } }")));
+	}
+
+	@Test // DATAMONGO-1777
+	public void toStringConsidersIsolated() {
+
+		assertThat(new Update().set("key", "value").isolated().toString(),
+				is(equalTo("{ \"$set\" : { \"key\" : \"value\" }, \"$isolated\" : 1 }")));
 	}
 }


### PR DESCRIPTION
We now make sure to pretty print `Update` modifiers by safely rendering to a json representation including an optional `$isolated` operator if applicable.
Along the way we also fix a flaw in `PushOperationBuilder` ignoring eg. `$position` when pushing single values.