### PR TITLE
DATAMONGO-1808 - Add support for bitwise query operators.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -52,6 +52,7 @@ import com.mongodb.BasicDBList;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Andreas Zink
  */
 public class Criteria implements CriteriaDefinition {
 
@@ -603,6 +604,118 @@ public class Criteria implements CriteriaDefinition {
 	public Criteria andOperator(Criteria... criteria) {
 		BasicDBList bsonList = createCriteriaList(criteria);
 		return registerCriteriaChainElement(new Criteria("$and").is(bsonList));
+	}
+	
+	/**
+	 * Creates a criterion using the {@literal $bitsAllClear} operator.
+	 *
+	 * @param numericBitmask non-negative numeric bitmask
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAllClear/">MongoDB Query operator:
+	 *      $bitsAllClear</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAllClear(int numericBitmask) {
+		criteria.put("$bitsAllClear", Integer.valueOf(numericBitmask));
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAllClear} operator.
+	 *
+	 * @param bitPositions positions of set bits
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAllClear/">MongoDB Query operator:
+	 *      $bitsAllClear</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAllClear(Collection<Integer> bitPositions) {
+		criteria.put("$bitsAllClear", bitPositions);
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAllSet} operator.
+	 *
+	 * @param numericBitmask non-negative numeric bitmask
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAllSet/">MongoDB Query operator:
+	 *      $bitsAllSet</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAllSet(int numericBitmask) {
+		criteria.put("$bitsAllSet", Integer.valueOf(numericBitmask));
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAllSet} operator.
+	 *
+	 * @param bitPositions positions of set bits
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAllSet/">MongoDB Query operator:
+	 *      $bitsAllSet</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAllSet(Collection<Integer> bitPositions) {
+		criteria.put("$bitsAllSet", bitPositions);
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAnyClear} operator.
+	 *
+	 * @param numericBitmask non-negative numeric bitmask
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAnyClear/">MongoDB Query operator:
+	 *      $bitsAnyClear</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAnyClear(int numericBitmask) {
+		criteria.put("$bitsAnyClear", Integer.valueOf(numericBitmask));
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAnyClear} operator.
+	 *
+	 * @param bitPositions positions of set bits
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAnyClear/">MongoDB Query operator:
+	 *      $bitsAnyClear</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAnyClear(Collection<Integer> bitPositions) {
+		criteria.put("$bitsAnyClear", bitPositions);
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAnySet} operator.
+	 *
+	 * @param numericBitmask non-negative numeric bitmask
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAnySet/">MongoDB Query operator:
+	 *      $bitsAnySet</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAnySet(int numericBitmask) {
+		criteria.put("$bitsAnySet", Integer.valueOf(numericBitmask));
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using the {@literal $bitsAnySet} operator.
+	 *
+	 * @param bitPositions positions of set bits
+	 * @return
+	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/bitsAnySet/">MongoDB Query operator:
+	 *      $bitsAnySet</a>
+	 * @since 2.1
+	 */
+	public Criteria bitsAnySet(Collection<Integer> bitPositions) {
+		criteria.put("$bitsAnySet", bitPositions);
+		return this;
 	}
 
 	private Criteria registerCriteriaChainElement(Criteria criteria) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -3282,6 +3282,61 @@ public class MongoTemplateTests {
 		assertThat(template.find(new Query().limit(1), Sample.class)).hasSize(1);
 	}
 
+	@Test // DATAMONGO-1808
+	public void testFindByBitmasks() {
+		DocumentWithBitmask document = new DocumentWithBitmask(0b101);
+		template.insert(document);
+
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAllClear(0b010)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAllClear(Arrays.asList(1))),
+				DocumentWithBitmask.class)).hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAllClear(0b010)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAllClear(Arrays.asList(1))),
+				DocumentWithBitmask.class)).hasSize(1);
+
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAllSet(0b101)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAllSet(Arrays.asList(0, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAllSet(0b101)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAllSet(Arrays.asList(0, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAnyClear(0b111)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAnyClear(Arrays.asList(0, 1, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAnyClear(0b111)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAnyClear(Arrays.asList(0, 1, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAnySet(0b111)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("intValue").bitsAnySet(Arrays.asList(0, 1, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAnySet(0b111)), DocumentWithBitmask.class))
+				.hasSize(1);
+		assertThat(template.find(Query.query(Criteria.where("binaryValue").bitsAnySet(Arrays.asList(0, 1, 2))),
+				DocumentWithBitmask.class)).hasSize(1);
+	}
+
+	@NoArgsConstructor
+	static class DocumentWithBitmask {
+		@Id String id;
+		int intValue;
+		byte[] binaryValue;
+
+		public DocumentWithBitmask(int value) {
+			this.intValue = value;
+			this.binaryValue = new byte[] { (byte) value };
+		}
+
+	}
+
 	static class TypeWithNumbers {
 
 		@Id String id;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaTests.java
@@ -19,6 +19,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.mongodb.test.util.IsBsonObject.*;
 
+import java.util.Arrays;
+
 import org.bson.Document;
 import org.junit.Test;
 import org.springframework.data.geo.Point;
@@ -212,5 +214,47 @@ public class CriteriaTests {
 		Document document = new Criteria("foo").intersects(lineString).getCriteriaObject();
 
 		assertThat(document, isBsonObject().containing("foo.$geoIntersects.$geometry", lineString));
+	}
+
+	@Test // DATAMONGO-1808
+	public void testBitsAllClear() {
+		Criteria numericBitmaskCriteria = new Criteria("field").bitsAllClear(0b101);
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAllClear\" : 5} }"),
+				numericBitmaskCriteria.getCriteriaObject());
+
+		Criteria bitPositionsBitmaskCriteria = new Criteria("field").bitsAllClear(Arrays.asList(0, 2));
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAllClear\" : [ 0, 2 ]} }"),
+				bitPositionsBitmaskCriteria.getCriteriaObject());
+	}
+
+	@Test // DATAMONGO-1808
+	public void testBitsAllSet() {
+		Criteria numericBitmaskCriteria = new Criteria("field").bitsAllSet(0b101);
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAllSet\" : 5} }"), numericBitmaskCriteria.getCriteriaObject());
+
+		Criteria bitPositionsBitmaskCriteria = new Criteria("field").bitsAllSet(Arrays.asList(0, 2));
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAllSet\" : [ 0, 2 ]} }"),
+				bitPositionsBitmaskCriteria.getCriteriaObject());
+	}
+
+	@Test // DATAMONGO-1808
+	public void testBitsAnyClear() {
+		Criteria numericBitmaskCriteria = new Criteria("field").bitsAnyClear(0b101);
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAnyClear\" : 5} }"),
+				numericBitmaskCriteria.getCriteriaObject());
+
+		Criteria bitPositionsBitmaskCriteria = new Criteria("field").bitsAnyClear(Arrays.asList(0, 2));
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAnyClear\" : [ 0, 2 ]} }"),
+				bitPositionsBitmaskCriteria.getCriteriaObject());
+	}
+
+	@Test // DATAMONGO-1808
+	public void testBitsAnySet() {
+		Criteria numericBitmaskCriteria = new Criteria("field").bitsAnySet(0b101);
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAnySet\" : 5} }"), numericBitmaskCriteria.getCriteriaObject());
+
+		Criteria bitPositionsBitmaskCriteria = new Criteria("field").bitsAnySet(Arrays.asList(0, 2));
+		assertEquals(Document.parse("{ \"field\" : { \"$bitsAnySet\" : [ 0, 2 ]} }"),
+				bitPositionsBitmaskCriteria.getCriteriaObject());
 	}
 }


### PR DESCRIPTION
Bitwise operators are supported since MongoDB 3.2 and would be a good
addition to the bitwise update operator.

See also: DATAMONGO-1101.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
