### PR TITLE
DATAMONGO-1322 - Add support for validator when creating collection.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.data.mongodb.core.validation.ValidationOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -27,6 +28,7 @@ import org.springframework.util.Assert;
  * @author Thomas Risberg
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Andreas Zink
  */
 public class CollectionOptions {
 
@@ -34,6 +36,7 @@ public class CollectionOptions {
 	private @Nullable Long size;
 	private @Nullable Boolean capped;
 	private @Nullable Collation collation;
+	private @Nullable ValidationOptions validation;
 
 	/**
 	 * Constructs a new <code>CollectionOptions</code> instance.
@@ -46,16 +49,17 @@ public class CollectionOptions {
 	 */
 	@Deprecated
 	public CollectionOptions(@Nullable Long size, @Nullable Long maxDocuments, @Nullable Boolean capped) {
-		this(size, maxDocuments, capped, null);
+		this(size, maxDocuments, capped, null, null);
 	}
 
 	private CollectionOptions(@Nullable Long size, @Nullable Long maxDocuments, @Nullable Boolean capped,
-			@Nullable Collation collation) {
+			@Nullable Collation collation, @Nullable ValidationOptions validation) {
 
 		this.maxDocuments = maxDocuments;
 		this.size = size;
 		this.capped = capped;
 		this.collation = collation;
+		this.validation = validation;
 	}
 
 	/**
@@ -69,7 +73,7 @@ public class CollectionOptions {
 
 		Assert.notNull(collation, "Collation must not be null!");
 
-		return new CollectionOptions(null, null, null, collation);
+		return new CollectionOptions(null, null, null, collation, null);
 	}
 
 	/**
@@ -79,7 +83,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public static CollectionOptions empty() {
-		return new CollectionOptions(null, null, null, null);
+		return new CollectionOptions(null, null, null, null, null);
 	}
 
 	/**
@@ -90,7 +94,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions capped() {
-		return new CollectionOptions(size, maxDocuments, true, collation);
+		return new CollectionOptions(size, maxDocuments, true, collation, validation);
 	}
 
 	/**
@@ -101,7 +105,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions maxDocuments(long maxDocuments) {
-		return new CollectionOptions(size, maxDocuments, capped, collation);
+		return new CollectionOptions(size, maxDocuments, capped, collation, validation);
 	}
 
 	/**
@@ -112,7 +116,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions size(long size) {
-		return new CollectionOptions(size, maxDocuments, capped, collation);
+		return new CollectionOptions(size, maxDocuments, capped, collation, validation);
 	}
 
 	/**
@@ -123,7 +127,18 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public CollectionOptions collation(@Nullable Collation collation) {
-		return new CollectionOptions(size, maxDocuments, capped, collation);
+		return new CollectionOptions(size, maxDocuments, capped, collation, validation);
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with already given settings and {@link ValidationOptions} set to given value.
+	 *
+	 * @param validation can be {@literal null}.
+	 * @return new {@link CollectionOptions}.
+	 * @since 2.1
+	 */
+	public CollectionOptions validation(@Nullable ValidationOptions validation) {
+		return new CollectionOptions(size, maxDocuments, capped, collation, validation);
 	}
 
 	/**
@@ -162,5 +177,9 @@ public class CollectionOptions {
 	 */
 	public Optional<Collation> getCollation() {
 		return Optional.ofNullable(collation);
+	}
+
+	public Optional<ValidationOptions> getValidation() {
+		return Optional.ofNullable(validation);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/CriteriaValidator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/CriteriaValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import lombok.EqualsAndHashCode;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+
+/**
+ * Utility to build a MongoDB {@code validator} based on a {@link CriteriaDefinition}.
+ * 
+ * @author Andreas Zink
+ * @since 2.1
+ * @see Criteria
+ */
+@EqualsAndHashCode
+public class CriteriaValidator implements ValidatorDefinition {
+
+	private final Document document;
+
+	private CriteriaValidator(Document document) {
+		Assert.notNull(document, "Document must not be null!");
+		this.document = document;
+	}
+
+	/**
+	 * Builds a {@code validator} object, which is basically setup of query operators, based on a
+	 * {@link CriteriaDefinition} instance.
+	 * 
+	 * @param criteria the criteria to build the {@code validator} from
+	 * @return
+	 */
+	public static CriteriaValidator fromCriteria(@NonNull CriteriaDefinition criteria) {
+		Assert.notNull(criteria, "Criteria must not be null!");
+		return new CriteriaValidator(criteria.getCriteriaObject());
+	}
+
+	@Override
+	public Document toDocument() {
+		return this.document;
+	}
+
+	@Override
+	public String toString() {
+		return document.toString();
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationAction.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import lombok.Getter;
+
+/**
+ * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be
+ * inserted.
+ * 
+ * @author Andreas Zink
+ * @since 2.1
+ * @see <a href="https://docs.mongodb.com/manual/reference/method/db.createCollection/">MongoDB Collection Options</a>
+ */
+public enum ValidationAction {
+
+	/**
+	 * Documents must pass validation before the write occurs. Otherwise, the write operation fails. (MongoDB default)
+	 */
+	ERROR("error"),
+
+	/**
+	 * Documents do not have to pass validation. If the document fails validation, the write operation logs the validation
+	 * failure.
+	 */
+	WARN("warn");
+
+	@Getter private String value;
+
+	private ValidationAction(String value) {
+		this.value = value;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationLevel.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationLevel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import lombok.Getter;
+
+/**
+ * Determines how strictly MongoDB applies the validation rules to existing documents during an update.
+ * 
+ * @author Andreas Zink
+ * @since 2.1
+ * @see <a href="https://docs.mongodb.com/manual/reference/method/db.createCollection/">MongoDB Collection Options</a>
+ */
+public enum ValidationLevel {
+
+	/**
+	 * No validation for inserts or updates.
+	 */
+	OFF("off"),
+
+	/**
+	 * Apply validation rules to all inserts and all updates. (MongoDB default)
+	 */
+	STRICT("strict"),
+
+	/**
+	 * Apply validation rules to inserts and to updates on existing valid documents. Do not apply rules to updates on
+	 * existing invalid documents.
+	 */
+	MODERATE("moderate");
+
+	@Getter private String value;
+
+	private ValidationLevel(String value) {
+		this.value = value;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidationOptions.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.core.CollectionOptions;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Wraps the collection validation options.
+ * 
+ * @author Andreas Zink
+ * @since 2.1
+ * @see {@link CollectionOptions}
+ * @see <a href="https://docs.mongodb.com/manual/core/document-validation/">MongoDB Document Validation</a>
+ * @see <a href="https://docs.mongodb.com/manual/reference/method/db.createCollection/">MongoDB Collection Options</a>
+ */
+@EqualsAndHashCode
+@ToString
+public class ValidationOptions {
+	private ValidatorDefinition validator;
+	private ValidationLevel validationLevel;
+	private ValidationAction validationAction;
+
+	private ValidationOptions(ValidatorDefinition validator) {
+		Assert.notNull(validator, "ValidatorDefinition must not be null!");
+		this.validator = validator;
+	}
+
+	public static ValidationOptions validator(@NonNull ValidatorDefinition validator) {
+		return new ValidationOptions(validator);
+	}
+
+	public ValidationOptions validationLevel(@Nullable ValidationLevel validationLevel) {
+		this.validationLevel = validationLevel;
+		return this;
+	}
+
+	public ValidationOptions validationAction(@Nullable ValidationAction validationAction) {
+		this.validationAction = validationAction;
+		return this;
+	}
+
+	public ValidatorDefinition getValidator() {
+		return validator;
+	}
+
+	public Optional<ValidationLevel> getValidationLevel() {
+		return Optional.ofNullable(validationLevel);
+	}
+
+	public Optional<ValidationAction> getValidationAction() {
+		return Optional.ofNullable(validationAction);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidatorDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/validation/ValidatorDefinition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import org.bson.Document;
+import org.springframework.lang.NonNull;
+
+/**
+ * Provides a {@code validator} object to be used for collection validation.
+ * 
+ * @author Andreas Zink
+ * @since 2.1
+ * @see <a href="https://docs.mongodb.com/manual/reference/method/db.createCollection/">MongoDB Collection Options</a>
+ */
+public interface ValidatorDefinition {
+
+	/**
+	 * @return a MongoDB {@code validator} document
+	 */
+	public @NonNull Document toDocument();
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateValidationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateValidationTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.bson.Document;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.validation.CriteriaValidator;
+import org.springframework.data.mongodb.core.validation.ValidationAction;
+import org.springframework.data.mongodb.core.validation.ValidationLevel;
+import org.springframework.data.mongodb.core.validation.ValidationOptions;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
+import org.springframework.data.util.Version;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.MongoClient;
+
+/**
+ * @author Andreas Zink
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MongoTemplateValidationTests {
+
+	public static @ClassRule MongoVersionRule REQUIRES_AT_LEAST_3_2_0 = MongoVersionRule.atLeast(Version.parse("3.2.0"));
+	public static final String COLLECTION_NAME = "validation-1";
+
+	@Configuration
+	static class Config extends AbstractMongoConfiguration {
+
+		@Override
+		public MongoClient mongoClient() {
+			return new MongoClient();
+		}
+
+		@Override
+		protected String getDatabaseName() {
+			return "validation-tests";
+		}
+	}
+
+	@Autowired MongoTemplate template;
+
+	@Before
+	public void setUp() {
+		template.dropCollection(COLLECTION_NAME);
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionWithSimpleCriteriaBasedValidation() {
+		Criteria criteria = Criteria.where("nonNullString").ne(null).type(2).and("rangedInteger").ne(null).type(16).gte(0)
+				.lte(122);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria));
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		Document validator = getValidatorInfo(COLLECTION_NAME);
+		assertThat(validator.get("nonNullString")).isEqualTo(new Document("$ne", null).append("$type", 2));
+		assertThat(validator.get("rangedInteger"))
+				.isEqualTo(new Document("$ne", null).append("$type", 16).append("$gte", 0).append("$lte", 122));
+
+		template.save(new SimpleBean("hello", 101), COLLECTION_NAME);
+		try {
+			template.save(new SimpleBean(null, 101), COLLECTION_NAME);
+			Assert.fail("The collection validation was setup to check for non-null string");
+		} catch (Exception e) {
+			// ignore
+		}
+		try {
+			template.save(new SimpleBean("hello", -1), COLLECTION_NAME);
+			Assert.fail("The collection validation was setup to check for non-negative int");
+		} catch (Exception e) {
+			// ignore
+		}
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionValidationActionError() {
+		Criteria criteria = Criteria.where("name").type(2);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria))
+				.validationAction(ValidationAction.ERROR);
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		String validationAction = getValidationActionInfo(COLLECTION_NAME);
+		assertThat(ValidationAction.ERROR.getValue()).isEqualTo(validationAction);
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionValidationActionWarn() {
+		Criteria criteria = Criteria.where("name").type(2);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria))
+				.validationAction(ValidationAction.WARN);
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		String validationAction = getValidationActionInfo(COLLECTION_NAME);
+		assertThat(ValidationAction.WARN.getValue()).isEqualTo(validationAction);
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionValidationLevelOff() {
+		Criteria criteria = Criteria.where("name").type(2);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria))
+				.validationLevel(ValidationLevel.OFF);
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		String validationAction = getValidationLevelInfo(COLLECTION_NAME);
+		assertThat(ValidationLevel.OFF.getValue()).isEqualTo(validationAction);
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionValidationLevelModerate() {
+		Criteria criteria = Criteria.where("name").type(2);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria))
+				.validationLevel(ValidationLevel.MODERATE);
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		String validationAction = getValidationLevelInfo(COLLECTION_NAME);
+		assertThat(ValidationLevel.MODERATE.getValue()).isEqualTo(validationAction);
+	}
+
+	@Test // DATAMONGO-1322
+	public void testCollectionValidationLevelStrict() {
+		Criteria criteria = Criteria.where("name").type(2);
+		ValidationOptions validationOptions = ValidationOptions.validator(CriteriaValidator.fromCriteria(criteria))
+				.validationLevel(ValidationLevel.STRICT);
+		template.createCollection(COLLECTION_NAME, CollectionOptions.empty().validation(validationOptions));
+
+		String validationAction = getValidationLevelInfo(COLLECTION_NAME);
+		assertThat(ValidationLevel.STRICT.getValue()).isEqualTo(validationAction);
+	}
+
+	private Document getCollectionOptions(String collectionName) {
+		return getCollectionInfo(collectionName).get("options", Document.class);
+	}
+
+	private Document getValidatorInfo(String collectionName) {
+		return getCollectionOptions(collectionName).get("validator", Document.class);
+	}
+
+	private String getValidationActionInfo(String collectionName) {
+		return getCollectionOptions(collectionName).get("validationAction", String.class);
+	}
+
+	private String getValidationLevelInfo(String collectionName) {
+		return getCollectionOptions(collectionName).get("validationLevel", String.class);
+	}
+
+	private Document getCollectionInfo(String collectionName) {
+		return template.execute(db -> {
+			Document result = db.runCommand(
+					new Document().append("listCollections", 1).append("filter", new Document("name", collectionName)));
+			return (Document) result.get("cursor", Document.class).get("firstBatch", List.class).get(0);
+		});
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class SimpleBean {
+		@NotNull private String nonNullString;
+		@NotNull @Min(0) @Max(122) private Integer rangedInteger;
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/validation/CriteriaValidatorTest.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/validation/CriteriaValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bson.Document;
+import org.junit.Test;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+/**
+ * @author Andreas Zink
+ */
+public class CriteriaValidatorTest {
+
+	@Test // DATAMONGO-1322
+	public void testSimpleCriteria() {
+		Criteria criteria = Criteria.where("nonNullString").ne(null).type(2).and("rangedInteger").type(16).gte(0).lte(122);
+		Document validator = CriteriaValidator.fromCriteria(criteria).toDocument();
+
+		assertThat(validator.get("nonNullString")).isEqualTo(new Document("$ne", null).append("$type", 2));
+		assertThat(validator.get("rangedInteger"))
+				.isEqualTo(new Document("$type", 16).append("$gte", 0).append("$lte", 122));
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1322
+	public void testFailOnNull() {
+		CriteriaValidator.fromCriteria(null);
+	}
+}


### PR DESCRIPTION
Extended the CollectionOptions with a ValidationOptions property which
corresponds to the MongoDB createCollection() parameters. A validator
object can be defined using the Criteria API, or by writing a custom
provider.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
