### PR TITLE
DATAMONGO-1819 - Do not create PersistentEntities for simple types contributed by a converter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1819-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
@@ -31,7 +31,6 @@ import org.bson.types.ObjectId;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
 import org.springframework.data.mongodb.core.script.NamedMongoScript;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -43,9 +42,10 @@ import com.mongodb.client.MongoDatabase;
 
 /**
  * Default implementation of {@link ScriptOperations} capable of saving and executing {@link ServerSideJavaScript}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 1.7
  */
 class DefaultScriptOperations implements ScriptOperations {
@@ -141,7 +141,7 @@ class DefaultScriptOperations implements ScriptOperations {
 
 		Assert.hasText(scriptName, "ScriptName must not be null or empty!");
 
-		return mongoOperations.exists(query(where("name").is(scriptName)), NamedMongoScript.class, SCRIPT_COLLECTION_NAME);
+		return mongoOperations.exists(query(where("_id").is(scriptName)), NamedMongoScript.class, SCRIPT_COLLECTION_NAME);
 	}
 
 	/*
@@ -190,7 +190,7 @@ class DefaultScriptOperations implements ScriptOperations {
 	 * Generate a valid name for the {@literal JavaScript}. MongoDB requires an id of type String for scripts. Calling
 	 * scripts having {@link ObjectId} as id fails. Therefore we create a random UUID without {@code -} (as this won't
 	 * work) an prefix the result with {@link #SCRIPT_NAME_PREFIX}.
-	 * 
+	 *
 	 * @return
 	 */
 	private static String generateScriptName() {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -862,8 +862,9 @@ public class QueryMapper {
 		 */
 		@Override
 		public MongoPersistentEntity<?> getPropertyEntity() {
+
 			MongoPersistentProperty property = getProperty();
-			return property == null ? null : mappingContext.getPersistentEntity(property);
+			return property != null && property.isEntity() ? mappingContext.getPersistentEntity(property) : null;
 		}
 
 		/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateMappingTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateMappingTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.bson.Document;
 import org.junit.Before;
@@ -55,7 +54,7 @@ public class MongoTemplateMappingTests {
 	}
 
 	@Test
-	public void insertsEntityCorrectly1() throws Exception {
+	public void insertsEntityCorrectly1() {
 
 		addAndRetrievePerson(template1);
 		checkPersonPersisted(template1);
@@ -63,7 +62,7 @@ public class MongoTemplateMappingTests {
 	}
 
 	@Test
-	public void insertsEntityCorrectly2() throws Exception {
+	public void insertsEntityCorrectly2() {
 
 		addAndRetrievePerson(template2);
 		checkPersonPersisted(template2);
@@ -76,15 +75,15 @@ public class MongoTemplateMappingTests {
 		template.insert(person);
 
 		Person result = template.findById(person.getId(), Person.class);
-		assertThat(result.getFirstName(), is("Oliver"));
-		assertThat(result.getAge(), is(25));
+		assertThat(result.getFirstName()).isEqualTo("Oliver");
+		assertThat(result.getAge()).isEqualTo(25);
 	}
 
 	private void checkPersonPersisted(MongoTemplate template) {
 		template.execute(Person.class, new CollectionCallback<Object>() {
 			public Object doInCollection(MongoCollection<Document> collection) throws MongoException, DataAccessException {
 				Document document = collection.find(new Document()).first();
-				assertThat((String) document.get("name"), is("Oliver"));
+				assertThat((String) document.get("name")).isEqualTo("Oliver");
 				return null;
 			}
 		});

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/MongoMappingContextUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/MongoMappingContextUnitTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.mongodb.core.mapping;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -65,14 +64,14 @@ public class MongoMappingContextUnitTests {
 	public void doesNotReturnPersistentEntityForMongoSimpleType() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		assertThat(context.getPersistentEntity(DBRef.class), is(nullValue()));
+		assertThat(context.getPersistentEntity(DBRef.class)).isNull();
 	}
 
 	@Test // DATAMONGO-638
 	public void doesNotCreatePersistentEntityForAbstractMap() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		assertThat(context.getPersistentEntity(AbstractMap.class), is(nullValue()));
+		assertThat(context.getPersistentEntity(AbstractMap.class)).isNull();
 	}
 
 	@Test // DATAMONGO-607
@@ -88,7 +87,7 @@ public class MongoMappingContextUnitTests {
 		});
 
 		MongoPersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
-		assertThat(entity.getRequiredPersistentProperty("firstname").getFieldName(), is("FIRSTNAME"));
+		assertThat(entity.getRequiredPersistentProperty("firstname").getFieldName()).isEqualTo("FIRSTNAME");
 	}
 
 	@Test // DATAMONGO-607
@@ -119,8 +118,8 @@ public class MongoMappingContextUnitTests {
 		MongoMappingContext context = new MongoMappingContext();
 		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithImplicitId.class);
 
-		assertThat(pe, is(not(nullValue())));
-		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("id")), is(true));
+		assertThat(pe).isNotNull();
+		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("id"))).isTrue();
 	}
 
 	@Test // DATAMONGO-688
@@ -129,8 +128,8 @@ public class MongoMappingContextUnitTests {
 		MongoMappingContext context = new MongoMappingContext();
 		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitId.class);
 
-		assertThat(pe, is(not(nullValue())));
-		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("myId")), is(true));
+		assertThat(pe).isNotNull();
+		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("myId"))).isTrue();
 	}
 
 	@Test // DATAMONGO-688
@@ -138,7 +137,7 @@ public class MongoMappingContextUnitTests {
 
 		MongoMappingContext context = new MongoMappingContext();
 		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitIdAndImplicitId.class);
-		assertThat(pe, is(not(nullValue())));
+		assertThat(pe).isNotNull();
 	}
 
 	@Test(expected = MappingException.class) // DATAMONGO-688


### PR DESCRIPTION
We now check for registered simple types in `MongoMappingContext.shouldCreatePersistentEntityFor(…)` to prevent `PersistentEntity` creation for unwanted types. Previously, we only checked against `MongoSimpleTypes.HOLDER` instead of the simple types contributed by converters.

This change impacts aggregate root type use with top-level converters: These types are no longer represented with a `PersistentEntity` which removes mapping details and these types cannot be used anymore with a repository and require a collection name if used with the Template API.

---

Related ticket: [DATAMONGO-1819](https://jira.spring.io/browse/DATAMONGO-1819).