### PR TITLE
DATAMONGO-1824 - Assert compatibility with MongoDB 3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -733,19 +733,19 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		Assert.notNull(outputType, "Output type must not be null!");
 
 		AggregationOperationContext rootContext = context == null ? Aggregation.DEFAULT_CONTEXT : context;
-		Document command = aggregation.toDocument(collectionName, rootContext);
-		AggregationOptions options = AggregationOptions.fromDocument(command);
+		AggregationOptions options = aggregation.getOptions();
+		List<Document> pipeline = aggregation.toPipeline(rootContext);
 
 		Assert.isTrue(!options.isExplain(), "Cannot use explain option with streaming!");
 		Assert.isNull(options.getCursorBatchSize(), "Cannot use batchSize cursor option with streaming!");
 
 		if (LOGGER.isDebugEnabled()) {
-			LOGGER.debug("Streaming aggregation: {}", serializeToJsonSafely(command));
+			LOGGER.debug("Streaming aggregation: {} in collection {}", serializeToJsonSafely(pipeline), collectionName);
 		}
 
 		ReadDocumentCallback<O> readCallback = new ReadDocumentCallback<>(mongoConverter, outputType, collectionName);
 		return execute(collectionName,
-				collection -> aggregateAndMap(collection, (List<Document>) command.get("pipeline"), options, readCallback));
+				collection -> aggregateAndMap(collection, pipeline, options, readCallback));
 	}
 
 	private <O> Flux<O> aggregateAndMap(MongoCollection<Document> collection, List<Document> pipeline,

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -181,7 +181,7 @@ public class Aggregation {
 	 * Get the {@link AggregationOptions}.
 	 *
 	 * @return never {@literal null}.
-	 * @since 2.0.2
+	 * @since 2.1
 	 */
 	public AggregationOptions getOptions() {
 		return options;
@@ -585,21 +585,31 @@ public class Aggregation {
 	}
 
 	/**
-	 * Converts this {@link Aggregation} specification to a {@link Document}.
+	 * Renders this {@link Aggregation} specification to an aggregation pipeline returning a {@link List} of
+	 * {@link Document}.
 	 *
-	 * @param inputCollectionName the name of the input collection
-	 * @return the {@code Document} representing this aggregation
+	 * @return the aggregation pipeline representing this aggregation.
+	 * @since 2.1
+	 */
+	public List<Document> toPipeline(AggregationOperationContext rootContext) {
+		return AggregationOperationRenderer.toDocument(operations, rootContext);
+	}
+
+	/**
+	 * Converts this {@link Aggregation} specification to a {@link Document}.
+	 * <p/>
+	 * MongoDB requires as of 3.6 cursor-based aggregation. Use {@link #toPipeline(AggregationOperationContext)} to render
+	 * an aggregation pipeline.
+	 *
+	 * @param inputCollectionName the name of the input collection.
+	 * @return the {@code Document} representing this aggregation.
 	 */
 	public Document toDocument(String inputCollectionName, AggregationOperationContext rootContext) {
 
-		List<Document> operationDocuments = AggregationOperationRenderer.toDocument(operations, rootContext);
-
 		Document command = new Document("aggregate", inputCollectionName);
-		command.put("pipeline", operationDocuments);
+		command.put("pipeline", toPipeline(rootContext));
 
-		command = options.applyAndReturnPotentiallyChangedCommand(command);
-
-		return command;
+		return options.applyAndReturnPotentiallyChangedCommand(command);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -178,6 +178,16 @@ public class Aggregation {
 	}
 
 	/**
+	 * Get the {@link AggregationOptions}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.0.2
+	 */
+	public AggregationOptions getOptions() {
+		return options;
+	}
+
+	/**
 	 * A pointer to the previous {@link AggregationOperation}.
 	 *
 	 * @return

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
@@ -147,6 +147,7 @@ public class AggregationOptions {
 	 * @return the batch size or {@literal null}.
 	 * @since 2.0
 	 */
+	@Nullable
 	public Integer getCursorBatchSize() {
 
 		if (cursor.filter(val -> val.containsKey(BATCH_SIZE)).isPresent()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -188,7 +188,8 @@ public class Update {
 
 	/**
 	 * Update using the {@code $pushAll} update modifier. <br>
-	 * <b>Note</b>: In mongodb 2.4 the usage of {@code $pushAll} has been deprecated in favor of {@code $push $each}.
+	 * <b>Note</b>: In MongoDB 2.4 the usage of {@code $pushAll} has been deprecated in favor of {@code $push $each}.
+	 * <b>Important:</b> As of MongoDB 3.6 {@code $pushAll} is not longer supported. Use {@code $push $each} instead.
 	 * {@link #push(String)}) returns a builder that can be used to populate the {@code $each} object.
 	 *
 	 * @param key
@@ -196,7 +197,9 @@ public class Update {
 	 * @return
 	 * @see <a href="https://docs.mongodb.org/manual/reference/operator/update/pushAll/">MongoDB Update operator:
 	 *      $pushAll</a>
+	 * @deprecated as of MongoDB 2.4. Removed in MongoDB 3.6. Use {@link #push(String) $push $each} instead.
 	 */
+	@Deprecated
 	public Update pushAll(String key, Object[] values) {
 		addMultiFieldOperation("$pushAll", key, Arrays.asList(values));
 		return this;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -33,18 +33,7 @@ import lombok.NoArgsConstructor;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.bson.types.ObjectId;
 import org.hamcrest.collection.IsMapContaining;
@@ -90,6 +79,8 @@ import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.test.util.MongoVersion;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
 import org.springframework.data.mongodb.util.MongoClientVersion;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.test.annotation.DirtiesContext;
@@ -137,9 +128,9 @@ public class MongoTemplateTests {
 
 	ConfigurableApplicationContext context;
 	MongoTemplate mappingTemplate;
-	org.springframework.data.util.Version mongoVersion;
 
 	@Rule public ExpectedException thrown = ExpectedException.none();
+	@Rule public MongoVersionRule mongoVersion = MongoVersionRule.any();
 
 	@Autowired
 	public void setApplicationContext(ConfigurableApplicationContext context) {
@@ -177,7 +168,6 @@ public class MongoTemplateTests {
 	public void setUp() {
 
 		cleanDb();
-		queryMongoVersionIfNecessary();
 
 		this.mappingTemplate.setApplicationContext(context);
 	}
@@ -185,14 +175,6 @@ public class MongoTemplateTests {
 	@After
 	public void cleanUp() {
 		cleanDb();
-	}
-
-	private void queryMongoVersionIfNecessary() {
-
-		if (mongoVersion == null) {
-			org.bson.Document result = template.executeCommand("{ buildInfo: 1 }");
-			mongoVersion = org.springframework.data.util.Version.parse(result.get("version").toString());
-		}
 	}
 
 	protected void cleanDb() {
@@ -2391,7 +2373,9 @@ public class MongoTemplateTests {
 		assertThat(template.findOne(q, VersionedPerson.class), nullValue());
 	}
 
-	@Test // DATAMONGO-354
+	@Test // DATAMONGO-354, DATAMONGO-1824
+	@MongoVersion(until = "3.6")
+	@SuppressWarnings("deprecation")
 	public void testUpdateShouldAllowMultiplePushAll() {
 
 		DocumentWithMultipleCollections doc = new DocumentWithMultipleCollections();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -118,11 +118,6 @@ import com.mongodb.client.result.UpdateResult;
 @ContextConfiguration("classpath:infrastructure.xml")
 public class MongoTemplateTests {
 
-	private static final org.springframework.data.util.Version TWO_DOT_FOUR = org.springframework.data.util.Version
-			.parse("2.4");
-	private static final org.springframework.data.util.Version THREE_DOT_FOUR = org.springframework.data.util.Version
-			.parse("3.4");
-
 	@Autowired MongoTemplate template;
 	@Autowired MongoDbFactory factory;
 
@@ -2331,9 +2326,8 @@ public class MongoTemplateTests {
 	}
 
 	@Test // DATAMONGO-812
+	@MongoVersion(asOf = "2.4")
 	public void updateMultiShouldAddValuesCorrectlyWhenUsingPushEachWithComplexTypes() {
-
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_FOUR), is(true));
 
 		DocumentWithCollection document = new DocumentWithCollection(Collections.<Model> emptyList());
 		template.save(document);
@@ -2347,9 +2341,8 @@ public class MongoTemplateTests {
 	}
 
 	@Test // DATAMONGO-812
+	@MongoVersion(asOf = "2.4")
 	public void updateMultiShouldAddValuesCorrectlyWhenUsingPushEachWithSimpleTypes() {
-
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_FOUR), is(true));
 
 		DocumentWithCollectionOfSimpleType document = new DocumentWithCollectionOfSimpleType();
 		document.values = Arrays.asList("spring");
@@ -3214,14 +3207,11 @@ public class MongoTemplateTests {
 		assertThat(template.findOne(query, DocumentWithCollection.class), is(equalTo(dwc)));
 	}
 
-	/**
-	 * @see DATAMONGO-1517
-	 */
-	@Test
+	@Test // DATAMONGO-1517
+	@MongoVersion(asOf = "3.4")
 	public void decimal128TypeShouldBeSavedAndLoadedCorrectly()
 			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
 
-		assumeThat(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR), is(true));
 		assumeThat(MongoClientVersion.isMongo34Driver(), is(true));
 
 		Class<?> decimal128Type = ClassUtils.resolveClassName("org.bson.types.Decimal128", null);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -144,6 +144,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		when(mapReduceIterable.iterator()).thenReturn(cursor);
 		when(mapReduceIterable.filter(any())).thenReturn(mapReduceIterable);
 		when(aggregateIterable.collation(any())).thenReturn(aggregateIterable);
+		when(aggregateIterable.allowDiskUse(any())).thenReturn(aggregateIterable);
+		when(aggregateIterable.batchSize(anyInt())).thenReturn(aggregateIterable);
 		when(aggregateIterable.map(any())).thenReturn(aggregateIterable);
 		when(aggregateIterable.into(any())).thenReturn(Collections.emptyList());
 
@@ -762,6 +764,16 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		template.aggregate(aggregation, AutogenerateableId.class, Document.class);
 
 		verify(aggregateIterable).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
+	}
+
+	@Test // DATAMONGO-1824
+	public void aggregateShouldUseBatchSizeWhenPresent() {
+
+		Aggregation aggregation = newAggregation(project("id"))
+				.withOptions(newAggregationOptions().collation(Collation.of("fr")).cursorBatchSize(100).build());
+		template.aggregate(aggregation, AutogenerateableId.class, Document.class);
+
+		verify(aggregateIterable).batchSize(100);
 	}
 
 	@Test // DATAMONGO-1518

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -58,7 +58,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -71,6 +70,7 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.mongodb.core.mapreduce.GroupBy;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
@@ -81,6 +81,7 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
+import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
@@ -111,6 +112,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	@Mock MongoCollection<Document> collection;
 	@Mock MongoCursor<Document> cursor;
 	@Mock FindIterable<Document> findIterable;
+	@Mock AggregateIterable aggregateIterable;
 	@Mock MapReduceIterable mapReduceIterable;
 
 	Document commandResultDocument = new Document();
@@ -130,6 +132,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		when(collection.find(Mockito.any(org.bson.Document.class))).thenReturn(findIterable);
 		when(collection.mapReduce(Mockito.any(), Mockito.any())).thenReturn(mapReduceIterable);
 		when(collection.count(any(Bson.class), any(CountOptions.class))).thenReturn(1L);
+		when(collection.aggregate(any(), any())).thenReturn(aggregateIterable);
+		when(collection.withReadPreference(any())).thenReturn(collection);
 		when(findIterable.projection(Mockito.any())).thenReturn(findIterable);
 		when(findIterable.sort(Mockito.any(org.bson.Document.class))).thenReturn(findIterable);
 		when(findIterable.modifiers(Mockito.any(org.bson.Document.class))).thenReturn(findIterable);
@@ -139,6 +143,9 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		when(mapReduceIterable.sort(Mockito.any())).thenReturn(mapReduceIterable);
 		when(mapReduceIterable.iterator()).thenReturn(cursor);
 		when(mapReduceIterable.filter(any())).thenReturn(mapReduceIterable);
+		when(aggregateIterable.collation(any())).thenReturn(aggregateIterable);
+		when(aggregateIterable.map(any())).thenReturn(aggregateIterable);
+		when(aggregateIterable.into(any())).thenReturn(Collections.emptyList());
 
 		this.mappingContext = new MongoMappingContext();
 		this.converter = new MappingMongoConverter(new DefaultDbRefResolver(factory), mappingContext);
@@ -361,28 +368,22 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		assertThat(captor.getValue(), equalTo(new org.bson.Document("foo", 1)));
 	}
 
-	@Test // DATAMONGO-1166
+	@Test // DATAMONGO-1166, DATAMONGO-1824
 	public void aggregateShouldHonorReadPreferenceWhenSet() {
 
-		when(db.runCommand(Mockito.any(org.bson.Document.class), Mockito.any(ReadPreference.class), eq(Document.class)))
-				.thenReturn(mock(Document.class));
 		template.setReadPreference(ReadPreference.secondary());
 
 		template.aggregate(newAggregation(Aggregation.unwind("foo")), "collection-1", Wrapper.class);
 
-		verify(this.db, times(1)).runCommand(Mockito.any(org.bson.Document.class), eq(ReadPreference.secondary()),
-				eq(Document.class));
+		verify(collection).withReadPreference(eq(ReadPreference.secondary()));
 	}
 
-	@Test // DATAMONGO-1166
+	@Test // DATAMONGO-1166, DATAMONGO-1824
 	public void aggregateShouldIgnoreReadPreferenceWhenNotSet() {
-
-		when(db.runCommand(Mockito.any(org.bson.Document.class), eq(org.bson.Document.class)))
-				.thenReturn(mock(Document.class));
 
 		template.aggregate(newAggregation(Aggregation.unwind("foo")), "collection-1", Wrapper.class);
 
-		verify(this.db, times(1)).runCommand(Mockito.any(org.bson.Document.class), eq(org.bson.Document.class));
+		verify(collection, never()).withReadPreference(any());
 	}
 
 	@Test // DATAMONGO-1166
@@ -483,7 +484,6 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		when(output.filter(any())).thenReturn(output);
 		when(output.iterator()).thenReturn(cursor);
 		when(cursor.hasNext()).thenReturn(false);
-
 
 		when(collection.mapReduce(anyString(), anyString())).thenReturn(output);
 
@@ -754,17 +754,14 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		assertThat(options.getValue().getCollation().getLocale(), is("fr"));
 	}
 
-	@Test // DATAMONGO-1518
+	@Test // DATAMONGO-1518, DATAMONGO-1824
 	public void aggregateShouldUseCollationWhenPresent() {
 
 		Aggregation aggregation = newAggregation(project("id"))
 				.withOptions(newAggregationOptions().collation(Collation.of("fr")).build());
 		template.aggregate(aggregation, AutogenerateableId.class, Document.class);
 
-		ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
-		verify(db).runCommand(cmd.capture(), Mockito.any(Class.class));
-
-		assertThat(cmd.getValue().get("collation", Document.class), equalTo(new Document("locale", "fr")));
+		verify(aggregateIterable).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
 	}
 
 	@Test // DATAMONGO-1518

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -126,6 +126,7 @@ public class AggregationTests {
 	}
 
 	private void cleanDb() {
+
 		mongoTemplate.dropCollection(INPUT_COLLECTION);
 		mongoTemplate.dropCollection(Product.class);
 		mongoTemplate.dropCollection(UserWithLikes.class);
@@ -143,6 +144,7 @@ public class AggregationTests {
 		mongoTemplate.dropCollection(Sales2.class);
 		mongoTemplate.dropCollection(Employee.class);
 		mongoTemplate.dropCollection(Art.class);
+		mongoTemplate.dropCollection("personQueryTemp");
 	}
 
 	/**
@@ -1357,6 +1359,7 @@ public class AggregationTests {
 		Document rawResult = result.getRawResults();
 
 		assertThat(rawResult, is(notNullValue()));
+
 		assertThat(rawResult.containsKey("stages"), is(true));
 	}
 
@@ -1565,7 +1568,7 @@ public class AggregationTests {
 		assertThat(firstItem, isBsonObject().containing("linkedPerson.[0].firstname", "u1"));
 	}
 
-	@Test // DATAMONGO-1418
+	@Test // DATAMONGO-1418, DATAMONGO-1824
 	public void shouldCreateOutputCollection() {
 
 		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
@@ -1579,7 +1582,8 @@ public class AggregationTests {
 				out(tempOutCollection));
 
 		AggregationResults<Document> results = mongoTemplate.aggregate(agg, Document.class);
-		assertThat(results.getMappedResults(), is(empty()));
+
+		assertThat(results.getMappedResults(), hasSize(2));
 
 		List<Document> list = mongoTemplate.findAll(Document.class, tempOutCollection);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.mongodb.core.aggregation;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import static org.springframework.data.domain.Sort.Direction.*;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 import static org.springframework.data.mongodb.core.aggregation.Fields.*;
@@ -66,8 +65,9 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.Person;
+import org.springframework.data.mongodb.test.util.MongoVersion;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
 import org.springframework.data.util.CloseableIterator;
-import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -92,32 +92,19 @@ public class AggregationTests {
 
 	private static final String INPUT_COLLECTION = "aggregation_test_collection";
 	private static final Logger LOGGER = LoggerFactory.getLogger(AggregationTests.class);
-	private static final Version TWO_DOT_FOUR = new Version(2, 4);
-	private static final Version TWO_DOT_SIX = new Version(2, 6);
-	private static final Version THREE_DOT_TWO = new Version(3, 2);
-	private static final Version THREE_DOT_FOUR = new Version(3, 4);
 
 	private static boolean initialized = false;
 
 	@Autowired MongoTemplate mongoTemplate;
 
 	@Rule public ExpectedException exception = ExpectedException.none();
-	private static Version mongoVersion;
+	@Rule public MongoVersionRule mongoVersion = MongoVersionRule.any();
 
 	@Before
 	public void setUp() {
 
-		queryMongoVersionIfNecessary();
 		cleanDb();
 		initSampleDataIfNecessary();
-	}
-
-	private void queryMongoVersionIfNecessary() {
-
-		if (mongoVersion == null) {
-			org.bson.Document result = mongoTemplate.executeCommand("{ buildInfo: 1 }");
-			mongoVersion = Version.parse(result.get("version").toString());
-		}
 	}
 
 	@After
@@ -310,9 +297,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1391
+	@MongoVersion(asOf = "3.2")
 	public void shouldUnwindWithIndex() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		MongoCollection<Document> coll = mongoTemplate.getCollection(INPUT_COLLECTION);
 
@@ -338,9 +324,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1391
+	@MongoVersion(asOf = "3.2")
 	public void shouldUnwindPreserveEmpty() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		MongoCollection<Document> coll = mongoTemplate.getCollection(INPUT_COLLECTION);
 
@@ -957,9 +942,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-774
+	@MongoVersion(asOf = "2.4")
 	public void stringExpressionsInProjectionExample() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_FOUR));
 
 		Product product = new Product("P1", "A", 1.99, 3, 0.05, 0.19);
 		mongoTemplate.insert(product);
@@ -1073,9 +1057,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-774
+	@MongoVersion(asOf = "2.4")
 	public void shouldPerformDateProjectionOperatorsCorrectly() throws ParseException {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_FOUR));
 
 		Data data = new Data();
 		data.stringValue = "ABC";
@@ -1102,9 +1085,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-774
+	@MongoVersion(asOf = "2.4")
 	public void shouldPerformStringProjectionOperatorsCorrectly() throws ParseException {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_FOUR));
 
 		Data data = new Data();
 		data.dateValue = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss.SSSZ").parse("29.08.1983 12:34:56.789+0000");
@@ -1141,9 +1123,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1550
+	@MongoVersion(asOf = "3.4")
 	public void shouldPerformReplaceRootOperatorCorrectly() throws ParseException {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		Data data = new Data();
 		DataItem dataItem = new DataItem();
@@ -1290,9 +1271,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-960
+	@MongoVersion(asOf = "2.6")
 	public void returnFiveMostCommonLikesAggregationFrameworkExampleWithSortOnDiskOptionEnabled() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createUserWithLikesDocuments();
 
@@ -1315,9 +1295,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1637
+	@MongoVersion(asOf = "2.6")
 	public void returnFiveMostCommonLikesAggregationFrameworkExampleWithSortOnDiskOptionEnabledWhileStreaming() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createUserWithLikesDocuments();
 
@@ -1343,9 +1322,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-960
+	@MongoVersion(asOf = "2.6")
 	public void returnFiveMostCommonLikesShouldReturnStageExecutionInformationWithExplainOptionEnabled() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createUserWithLikesDocuments();
 
@@ -1364,9 +1342,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-954
+	@MongoVersion(asOf = "2.6")
 	public void shouldSupportReturningCurrentAggregationRoot() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		mongoTemplate.save(new Person("p1_first", "p1_last", 25));
 		mongoTemplate.save(new Person("p2_first", "p2_last", 32));
@@ -1391,9 +1368,8 @@ public class AggregationTests {
 	 * {@link http://stackoverflow.com/questions/24185987/using-root-inside-spring-data-mongodb-for-retrieving-whole-document}
 	 */
 	@Test // DATAMONGO-954
+	@MongoVersion(asOf = "2.6")
 	public void shouldSupportReturningCurrentAggregationRootInReference() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		mongoTemplate.save(new Reservation("0123", "42", 100));
 		mongoTemplate.save(new Reservation("0360", "43", 200));
@@ -1412,9 +1388,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1549
+	@MongoVersion(asOf = "3.4")
 	public void shouldApplyCountCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		mongoTemplate.save(new Reservation("0123", "42", 100));
 		mongoTemplate.save(new Reservation("0360", "43", 200));
@@ -1526,9 +1501,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1326
+	@MongoVersion(asOf = "3.2")
 	public void shouldLookupPeopleCorectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		createUsersWithReferencedPersons();
 
@@ -1547,9 +1521,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1326
+	@MongoVersion(asOf = "3.2")
 	public void shouldGroupByAndLookupPeopleCorectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		createUsersWithReferencedPersons();
 
@@ -1569,9 +1542,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1418, DATAMONGO-1824
+	@MongoVersion(asOf = "2.6")
 	public void shouldCreateOutputCollection() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createPersonDocuments();
 
@@ -1595,9 +1567,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1637
+	@MongoVersion(asOf = "2.6")
 	public void shouldCreateOutputCollectionWhileStreaming() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createPersonDocuments();
 
@@ -1619,9 +1590,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1637
+	@MongoVersion(asOf = "2.6")
 	public void shouldReturnDocumentsWithOutputCollectionWhileStreaming() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(TWO_DOT_SIX));
 
 		createPersonDocuments();
 
@@ -1661,9 +1631,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1325
+	@MongoVersion(asOf = "3.2")
 	public void shouldApplySampleCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		createUserWithLikesDocuments();
 
@@ -1679,9 +1648,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1457
+	@MongoVersion(asOf = "3.2")
 	public void sliceShouldBeAppliedCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		createUserWithLikesDocuments();
 
@@ -1697,9 +1665,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1491
+	@MongoVersion(asOf = "3.2")
 	public void filterShouldBeAppliedCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		Item item43 = Item.builder().itemId("43").quantity(2).price(2L).build();
 		Item item2 = Item.builder().itemId("2").quantity(1).price(240L).build();
@@ -1730,9 +1697,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1538
+	@MongoVersion(asOf = "3.2")
 	public void letShouldBeAppliedCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_TWO));
 
 		Sales2 sales1 = Sales2.builder().id("1").price(10).tax(0.5F).applyDiscount(true).build();
 		Sales2 sales2 = Sales2.builder().id("2").price(10).tax(0.25F).applyDiscount(false).build();
@@ -1756,9 +1722,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1551
+	@MongoVersion(asOf = "3.4")
 	public void graphLookupShouldBeAppliedCorrectly() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		Employee em1 = Employee.builder().id(1).name("Dev").build();
 		Employee em2 = Employee.builder().id(2).name("Eliot").reportsTo("Dev").build();
@@ -1787,9 +1752,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1552
+	@MongoVersion(asOf = "3.4")
 	public void bucketShouldCollectDocumentsIntoABucket() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		Art a1 = Art.builder().id(1).title("The Pillars of Society").artist("Grosz").year(1926).price(199.99).build();
 		Art a2 = Art.builder().id(2).title("Melancholy III").artist("Munch").year(1902).price(280.00).build();
@@ -1824,9 +1788,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1552
+	@MongoVersion(asOf = "3.4")
 	public void bucketAutoShouldCollectDocumentsIntoABucket() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		Art a1 = Art.builder().id(1).title("The Pillars of Society").artist("Grosz").year(1926).price(199.99).build();
 		Art a2 = Art.builder().id(2).title("Melancholy III").artist("Munch").year(1902).price(280.00).build();
@@ -1858,9 +1821,8 @@ public class AggregationTests {
 	}
 
 	@Test // DATAMONGO-1552
+	@MongoVersion(asOf = "3.4")
 	public void facetShouldCreateFacets() {
-
-		assumeTrue(mongoVersion.isGreaterThanOrEqualTo(THREE_DOT_FOUR));
 
 		Art a1 = Art.builder().id(1).title("The Pillars of Society").artist("Grosz").year(1926).price(199.99).build();
 		Art a2 = Art.builder().id(2).title("Melancholy III").artist("Munch").year(1902).price(280.00).build();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -1337,7 +1337,6 @@ public class AggregationTests {
 		Document rawResult = result.getRawResults();
 
 		assertThat(rawResult, is(notNullValue()));
-
 		assertThat(rawResult.containsKey("stages"), is(true));
 	}
 
@@ -1357,7 +1356,7 @@ public class AggregationTests {
 		AggregationResults<Document> result = mongoTemplate.aggregate(agg, Person.class, Document.class);
 
 		assertThat(result.getMappedResults(), hasSize(3));
-		Document o = (Document) result.getMappedResults().get(2);
+		Document o = result.getMappedResults().get(2);
 
 		assertThat(o.get("_id"), is((Object) 25));
 		assertThat((List<?>) o.get("users"), hasSize(2));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersion.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersion.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * be used along with {@link MongoVersionRule}.
  *
  * @author Christoph Strobl
- * @since 2.0.2
+ * @since 2.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersion.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersion.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.test.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link MongoVersion} allows specifying an version range of mongodb that is applicable for a specific test method. To
+ * be used along with {@link MongoVersionRule}.
+ *
+ * @author Christoph Strobl
+ * @since 2.0.2
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface MongoVersion {
+
+	/**
+	 * Inclusive lower bound of MongoDB server range.
+	 *
+	 * @return {@code 0.0.0} by default.
+	 */
+	String asOf() default "0.0.0";
+
+	/**
+	 * Exclusive upper bound of MongoDB server range.
+	 *
+	 * @return {@code 9999.9999.9999} by default.
+	 */
+	String until() default "9999.9999.9999";
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersionRule.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersionRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.test.util;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.bson.Document;
 import org.junit.AssumptionViolatedException;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -26,17 +27,16 @@ import org.junit.runners.model.Statement;
 import org.springframework.data.util.Version;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.CommandResult;
-import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 /**
  * {@link TestRule} verifying server tests are executed against match a given version. This one can be used as
  * {@link ClassRule} eg. in context depending tests run with {@link SpringJUnit4ClassRunner} when the context would fail
  * to start in case of invalid version, or as simple {@link Rule} on specific tests.
- * 
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.6
  */
 public class MongoVersionRule implements TestRule {
@@ -170,11 +170,11 @@ public class MongoVersionRule implements TestRule {
 
 			MongoClient client;
 			client = new MongoClient(host, port);
-			DB db = client.getDB("test");
-			CommandResult result = db.command(new BasicDBObject().append("buildInfo", 1));
+			MongoDatabase database = client.getDatabase("test");
+			Document result = database.runCommand(new Document("buildInfo", 1));
 			client.close();
 
-			return Version.parse(result.get("version").toString());
+			return Version.parse(result.get("version", String.class));
 		} catch (Exception e) {
 			return ANY;
 		}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -1,6 +1,10 @@
 [[new-features]]
 = New & Noteworthy
 
+[[new-features.2-1-0]]
+== What's new in Spring Data MongoDB 2.1
+* Cursor-based aggregation execution.
+
 [[new-features.2-0-0]]
 == What's new in Spring Data MongoDB 2.0
 * Upgrade to Java 8.

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1410,7 +1410,7 @@ List<Person> results = template.find(query, Person.class);
 ----
 Collation collation = Collation.of("de");
 
-AggregationOptions options = new AggregationOptions.Builder().collation(collation).build();
+AggregationOptions options = AggregationOptions.builder().collation(collation).build();
 
 Aggregation aggregation = newAggregation(
   project("tags"),


### PR DESCRIPTION
We now use the driver native option for `aggregate` instead of a plain command execution. This is necessary as of MongoDB 3.6 the cursor option is required for aggregations changing the return and execution model.

Still we maintain the raw values of `AggregationResult` as we used to do before. However, relying on `executeCommand` to change aggregation behavior in custom code will no longer work.

Along the the way we opened up `Aggregation` itself to expose the `AggregationOptions` in use und deprecated the `$pushAll` option on `Update` since it has been removed in MongoDB 3.6.

---

Tested against MongoDB: 3.6.RC3, 3.4.9 and 3.2.6