### PR TITLE
Match a column with multiple values in findAll() method using Query, Example and Pageable

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
@@ -283,6 +283,26 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		return PageableExecutionUtils.getPage(list, pageable,
 				() -> mongoOperations.count(q, example.getProbeType(), entityInformation.getCollectionName()));
 	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.MongoRepository#findAllByExample(
+org.springframework.data.mongodb.core.query.Query, org.springframework.data.domain.Example, org.springframework.data.domain.Pageable)
+	 */
+	@Override
+	public <S extends T> Page<S> findAll(Query q1, final Example<S> example, Pageable pageable) {
+
+		Assert.notNull(q1, "Query must not be null!");
+		Assert.notNull(example, "Sample must not be null!");
+		Assert.notNull(pageable, "Pageable must not be null!");
+
+		final Query q = q1.addCriteria((new Criteria().alike(example))).with(pageable);
+		
+		List<S> list = mongoOperations.find(q, example.getProbeType(), entityInformation.getCollectionName());
+
+		return PageableExecutionUtils.getPage(list, pageable,
+				() -> mongoOperations.count(q, example.getProbeType(), entityInformation.getCollectionName()));
+	}
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
Add findAll() method which takes Query, Example and Pageable and return appropriate result.

Currently it supports example and pageable type method but after implement above method it will support like custom query with example, query and pageable  at the same time.

For example:- 
There is table called Person.
name:
dob:
age: etc 20 more fields. 

Expected search result is like dob grater than x year and less than y year and name like RAM or Shyam and want to match some other fields.

In this case developer can not use example class for name and dob. Because Example class can match with only one value. But we want to bring data with multiple condition on same field, like name is Ram or Shyam and DOB is gt x and lt Y.

That's why we have introduced above method which will allow them to write custom query and also allow use of example query class with pageable response which will resolve many problem like above example.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
