### PR TITLE
DATAMONGO-1824 - Fix aggregation execution for MongoDB 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
 before_script:
   - mongod --version
 
+services:
+  - mongodb
+
 env:
   matrix:
     - PROFILE=ci
@@ -23,9 +26,7 @@ env:
 addons:
   apt:
     sources:
-      - mongodb-upstart
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
-        key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
+      - mongodb-3.4-precise
     packages:
     - mongodb-org-server
     - mongodb-org-shell
@@ -37,6 +38,8 @@ cache:
   directories:
     - $HOME/.m2
 
-install: true
+install:
+  - |-
+    mongo admin --eval  "db.adminCommand({setFeatureCompatibilityVersion: '3.4'});"
 
 script: "mvn clean dependency:list test -P${PROFILE} -Dsort"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.10.BUILD-SNAPSHOT</version>
+	<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.10.BUILD-SNAPSHOT</version>
+		<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.10.BUILD-SNAPSHOT</version>
+		<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.10.BUILD-SNAPSHOT</version>
+			<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.10.BUILD-SNAPSHOT</version>
+		<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.10.BUILD-SNAPSHOT</version>
+		<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.10.BUILD-SNAPSHOT</version>
+		<version>1.10.10.DATAMONGO-1824-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2550,8 +2550,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 	/**
 	 * {@link BatchAggregationLoader} is a little helper that can process cursor results returned by an aggregation
 	 * command execution. On presence of a {@literal nextBatch} indicated by presence of an {@code id} field in the
-	 * {@code cursor} another {@code getMore} command gets executed reading the next batch of documents until everything
-	 * has been loaded.
+	 * {@code cursor} another {@code getMore} command gets executed reading the next batch of documents until all results
+	 * are been loaded.
 	 *
 	 * @author Christoph Strobl
 	 * @since 1.10
@@ -2561,6 +2561,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 		private static final String CURSOR_FIELD = "cursor";
 		private static final String RESULT_FIELD = "result";
 		private static final String BATCH_SIZE_FIELD = "batchSize";
+		private static final String FIRST_BATCH = "firstBatch";
+		private static final String NEXT_BATCH = "nextBatch";
+		private static final String SERVER_USED = "serverUsed";
+		private static final String OK = "ok";
 
 		private final MongoTemplate template;
 		private final ReadPreference readPreference;
@@ -2573,135 +2577,118 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware {
 			this.batchSize = batchSize;
 		}
 
+		/**
+		 * Run aggregation command and fetch all results.
+		 */
 		DBObject aggregate(String collectionName, Aggregation aggregation, AggregationOperationContext context) {
 
-			DBObject command = AggregationCommandPreparer.INSTANCE.prepareAggregationCommand(collectionName, aggregation,
+			DBObject command = prepareAggregationCommand(collectionName, aggregation,
 					context, batchSize);
 
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug("Executing aggregation: {}", serializeToJsonSafely(command));
 			}
 
-			List<DBObject> results = aggregateBatched(collectionName, batchSize, command);
-			return mergeArregationCommandResults(results);
+			return mergeAggregationResults(aggregateBatched(command, collectionName, batchSize));
 		}
 
-		private DBObject mergeArregationCommandResults(List<DBObject> results) {
+		/**
+		 * Pre process the aggregation command sent to the server by adding {@code cursor} options to match execution on
+		 * different server versions.
+		 */
+		private static DBObject prepareAggregationCommand(String collectionName, Aggregation aggregation,
+				AggregationOperationContext context, int batchSize) {
 
-			DBObject commandResult = new BasicDBObject();
-			if (results.size() == 1) {
-				commandResult = results.iterator().next();
-			} else {
+			AggregationOperationContext rootContext = context == null ? Aggregation.DEFAULT_CONTEXT : context;
+			DBObject command = aggregation.toDbObject(collectionName, rootContext);
 
-				List<Object> allResults = new ArrayList();
-
-				for (DBObject result : results) {
-					Collection foo = (Collection<?>) result.get(RESULT_FIELD);
-					if (!CollectionUtils.isEmpty(foo)) {
-						allResults.addAll(foo);
-					}
-				}
-
-				// take general info from first batch
-				commandResult.put("serverUsed", results.iterator().next().get("serverUsed"));
-				commandResult.put("ok", results.iterator().next().get("ok"));
-
-				// and append the merged results
-				commandResult.put(RESULT_FIELD, allResults);
+			if (!aggregation.getOptions().isExplain()) {
+				command.put(CURSOR_FIELD, new BasicDBObject(BATCH_SIZE_FIELD, batchSize));
 			}
-			return commandResult;
+
+			return command;
 		}
 
-		private List<DBObject> aggregateBatched(String collectionName, int batchSize, DBObject command) {
+		private List<DBObject> aggregateBatched(DBObject command, String collectionName, int batchSize) {
 
 			List<DBObject> results = new ArrayList<DBObject>();
 
-			CommandResult tmp = template.executeCommand(command, readPreference);
-			results.add(AggregationResultPostProcessor.INSTANCE.process(command, tmp));
+			CommandResult commandResult = template.executeCommand(command, readPreference);
+			results.add(postProcessResult(command, commandResult));
 
-			while (hasNext(tmp)) {
+			while (hasNext(commandResult)) {
 
-				DBObject getMore = new BasicDBObject("getMore", getNextBatchId(tmp)) //
+				DBObject getMore = new BasicDBObject("getMore", getNextBatchId(commandResult)) //
 						.append("collection", collectionName) //
-						.append(BATCH_SIZE_FIELD, batchSize); //
+						.append(BATCH_SIZE_FIELD, batchSize);
 
-				tmp = template.executeCommand(getMore, this.readPreference);
-				results.add(AggregationResultPostProcessor.INSTANCE.process(command, tmp));
+				commandResult = template.executeCommand(getMore, this.readPreference);
+				results.add(postProcessResult(command, commandResult));
 			}
 
 			return results;
 		}
 
-		private boolean hasNext(DBObject commandResult) {
+		private static DBObject postProcessResult(DBObject command, CommandResult commandResult) {
+
+			handleCommandError(commandResult, command);
+
+			if (!commandResult.containsField(CURSOR_FIELD)) {
+				return commandResult;
+			}
+
+			DBObject resultObject = new BasicDBObject(SERVER_USED, commandResult.get(SERVER_USED));
+			resultObject.put(OK, commandResult.get(OK));
+
+			DBObject cursor = (DBObject) commandResult.get(CURSOR_FIELD);
+			if (cursor.containsField(FIRST_BATCH)) {
+				resultObject.put(RESULT_FIELD, cursor.get(FIRST_BATCH));
+			} else {
+				resultObject.put(RESULT_FIELD, cursor.get(NEXT_BATCH));
+			}
+
+			return resultObject;
+		}
+
+		private static DBObject mergeAggregationResults(List<DBObject> batchResults) {
+
+			if (batchResults.size() == 1) {
+				return batchResults.iterator().next();
+			}
+
+			DBObject commandResult = new BasicDBObject(3);
+			List<Object> allResults = new ArrayList<Object>();
+
+			for (DBObject batchResult : batchResults) {
+
+				Collection documents = (Collection<?>) batchResult.get(RESULT_FIELD);
+				if (!CollectionUtils.isEmpty(documents)) {
+					allResults.addAll(documents);
+				}
+			}
+
+			// take general info from first batch
+			commandResult.put(SERVER_USED, batchResults.iterator().next().get(SERVER_USED));
+			commandResult.put(OK, batchResults.iterator().next().get(OK));
+
+			// and append the merged batchResults
+			commandResult.put(RESULT_FIELD, allResults);
+
+			return commandResult;
+		}
+
+		private static boolean hasNext(DBObject commandResult) {
 
 			if (!commandResult.containsField(CURSOR_FIELD)) {
 				return false;
 			}
 
 			Object next = getNextBatchId(commandResult);
-			return (next == null || ((Number) next).longValue() == 0L) ? false : true;
+			return next != null && ((Number) next).longValue() != 0L;
 		}
 
-		private Object getNextBatchId(DBObject commandResult) {
+		private static Object getNextBatchId(DBObject commandResult) {
 			return ((DBObject) commandResult.get(CURSOR_FIELD)).get("id");
 		}
-
-		/**
-		 * Helper to pre process the aggregation command sent to the server by adding {@code cursor} options to match
-		 * execution on different server versions.
-		 *
-		 * @author Christoph Strobl
-		 * @since 1.10
-		 */
-		private static enum AggregationCommandPreparer {
-
-			INSTANCE;
-
-			DBObject prepareAggregationCommand(String collectionName, Aggregation aggregation,
-					AggregationOperationContext context, int batchSize) {
-
-				AggregationOperationContext rootContext = context == null ? Aggregation.DEFAULT_CONTEXT : context;
-				DBObject command = aggregation.toDbObject(collectionName, rootContext);
-
-				if (!aggregation.getOptions().isExplain()) {
-					command.put(CURSOR_FIELD, new BasicDBObject(BATCH_SIZE_FIELD, batchSize));
-				}
-
-				return command;
-			}
-		}
-
-		/**
-		 * Helper to post process aggregation command result by copying over required attributes.
-		 *
-		 * @author Christoph Strobl
-		 * @since 1.10
-		 */
-		private static enum AggregationResultPostProcessor {
-
-			INSTANCE;
-
-			DBObject process(DBObject command, CommandResult commandResult) {
-
-				handleCommandError(commandResult, command);
-
-				if (!commandResult.containsField(CURSOR_FIELD)) {
-					return commandResult;
-				}
-
-				DBObject resultObject = new BasicDBObject("serverUsed", commandResult.get("serverUsed"));
-				resultObject.put("ok", commandResult.get("ok"));
-
-				DBObject cursor = (DBObject) commandResult.get(CURSOR_FIELD);
-				if (cursor.containsField("firstBatch")) {
-					resultObject.put(RESULT_FIELD, cursor.get("firstBatch"));
-				} else {
-					resultObject.put(RESULT_FIELD, cursor.get("nextBatch"));
-				}
-
-				return resultObject;
-			}
-		}
 	}
-
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -599,8 +599,8 @@ public class Aggregation {
 	/**
 	 * Get {@link AggregationOptions} to apply.
 	 *
-	 * @return never {@literal null}
-	 * @since 1.10
+	 * @return never {@literal null}.
+	 * @since 1.1.10
 	 */
 	public AggregationOptions getOptions() {
 		return options;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -597,6 +597,16 @@ public class Aggregation {
 	}
 
 	/**
+	 * Get {@link AggregationOptions} to apply.
+	 *
+	 * @return never {@literal null}
+	 * @since 1.10
+	 */
+	public AggregationOptions getOptions() {
+		return options;
+	}
+
+	/**
 	 * Describes the system variables available in MongoDB aggregation framework pipeline expressions.
 	 *
 	 * @author Thomas Darimont

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/BatchAggregationLoaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/BatchAggregationLoaderUnitTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static java.util.Collections.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+
+import java.util.List;
+
+import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mongodb.core.MongoTemplate.BatchAggregationLoader;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.CommandResult;
+import com.mongodb.DBObject;
+import com.mongodb.ReadPreference;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BatchAggregationLoaderUnitTests {
+
+	static final TypedAggregation<Person> AGGREGATION = newAggregation(Person.class,
+			project().and("firstName").as("name"));
+
+	@Mock MongoTemplate template;
+	@Mock CommandResult aggregationResult;
+	@Mock CommandResult getMoreResult;
+
+	BatchAggregationLoader loader;
+
+	DBObject cursorWithoutMore = new BasicDBObject("firstBatch", singletonList(new BasicDBObject("name", "luke")));
+	DBObject cursorWithMore = new BasicDBObject("id", 123).append("firstBatch",
+			singletonList(new BasicDBObject("name", "luke")));
+	DBObject cursorWithNoMore = new BasicDBObject("id", 0).append("nextBatch",
+			singletonList(new BasicDBObject("name", "han")));
+
+	@Before
+	public void setUp() {
+		loader = new BatchAggregationLoader(template, ReadPreference.primary(), 10);
+	}
+
+	@Test // DATAMONGO-1824
+	public void shouldLoadJustOneBatchWhenAlreayDoneWithFirst() {
+
+		when(template.executeCommand(any(DBObject.class), any(ReadPreference.class))).thenReturn(aggregationResult);
+		when(aggregationResult.containsField("cursor")).thenReturn(true);
+		when(aggregationResult.get("cursor")).thenReturn(cursorWithoutMore);
+
+		DBObject result = loader.aggregate("person", AGGREGATION, Aggregation.DEFAULT_CONTEXT);
+		assertThat((List<Object>) result.get("result"),
+				IsCollectionContaining.<Object> hasItem(new BasicDBObject("name", "luke")));
+
+		verify(template).executeCommand(any(DBObject.class), any(ReadPreference.class));
+		verifyNoMoreInteractions(template);
+	}
+
+	@Test // DATAMONGO-1824
+	public void shouldBatchLoadWhenRequired() {
+
+		when(template.executeCommand(any(DBObject.class), any(ReadPreference.class))).thenReturn(aggregationResult)
+				.thenReturn(getMoreResult);
+		when(aggregationResult.containsField("cursor")).thenReturn(true);
+		when(aggregationResult.get("cursor")).thenReturn(cursorWithMore);
+		when(getMoreResult.containsField("cursor")).thenReturn(true);
+		when(getMoreResult.get("cursor")).thenReturn(cursorWithNoMore);
+
+		DBObject result = loader.aggregate("person", AGGREGATION, Aggregation.DEFAULT_CONTEXT);
+		assertThat((List<Object>) result.get("result"),
+				IsCollectionContaining.<Object> hasItems(new BasicDBObject("name", "luke"), new BasicDBObject("name", "han")));
+
+		verify(template, times(2)).executeCommand(any(DBObject.class), any(ReadPreference.class));
+		verifyNoMoreInteractions(template);
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -132,6 +132,8 @@ public class MongoTemplateTests {
 			.parse("2.8");
 	private static final org.springframework.data.util.Version THREE_DOT_FOUR = org.springframework.data.util.Version
 			.parse("3.4");
+	private static final org.springframework.data.util.Version THREE_DOT_SIX = org.springframework.data.util.Version
+			.parse("3.6");
 
 	@Autowired MongoTemplate template;
 	@Autowired MongoDbFactory factory;
@@ -2376,6 +2378,8 @@ public class MongoTemplateTests {
 
 	@Test // DATAMONGO-354
 	public void testUpdateShouldAllowMultiplePushAll() {
+
+		assumeThat(mongoVersion.isLessThan(THREE_DOT_SIX), is(true));
 
 		DocumentWithMultipleCollections doc = new DocumentWithMultipleCollections();
 		doc.id = "1234";


### PR DESCRIPTION
Add `cursor` option to aggregation execution to make sure command works with MongoDB 3.6.

Tested against MongoDB Server `3.2.6`, `3.4.9` and `3.6.0`.

----

Should be forward ported to `2.0.x`. 
`2.1.x` (Lovelace) already contains a different kind of fix using the drivers `aggregate` method instead of executing the command.