### PR TITLE
DATAMONGO-1850 - Guard GridFsResource.getContentType() against absent file metadata.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1850-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsResource.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsResource.java
@@ -18,10 +18,13 @@ package org.springframework.data.mongodb.gridfs;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.data.util.Optionals;
 
+import com.mongodb.MongoGridFSException;
 import com.mongodb.client.gridfs.model.GridFSFile;
 
 /**
@@ -30,6 +33,7 @@ import com.mongodb.client.gridfs.model.GridFSFile;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Hartmut Lang
+ * @author Mark Paluch
  */
 public class GridFsResource extends InputStreamResource {
 
@@ -104,8 +108,11 @@ public class GridFsResource extends InputStreamResource {
 	@SuppressWarnings("deprecation")
 	public String getContentType() {
 
-		String contentType = file.getMetadata().get(CONTENT_TYPE_FIELD, String.class);
 
-		return contentType != null ? contentType : file.getContentType();
+		return Optionals
+				.firstNonEmpty(
+						() -> Optional.ofNullable(file.getMetadata()).map(it -> it.get(CONTENT_TYPE_FIELD, String.class)),
+						() -> Optional.ofNullable(file.getContentType()))
+				.orElseThrow(() -> new MongoGridFSException("No contentType data for this GridFS file"));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsResourceUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsResourceUnitTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
+
+import org.bson.BsonObjectId;
+import org.bson.Document;
+import org.junit.Test;
+
+import com.mongodb.MongoGridFSException;
+import com.mongodb.client.gridfs.model.GridFSFile;
+
+/**
+ * Unit tests for {@link GridFsResource}.
+ *
+ * @author Mark Paluch
+ */
+public class GridFsResourceUnitTests {
+
+	@Test // DATAMONGO-1850
+	public void shouldReadContentTypeCorrectly() {
+
+		Document metadata = new Document(GridFsResource.CONTENT_TYPE_FIELD, "text/plain");
+		GridFSFile file = new GridFSFile(new BsonObjectId(), "foo", 0, 0, new Date(), "foo", metadata);
+		GridFsResource resource = new GridFsResource(file);
+
+		assertThat(resource.getContentType()).isEqualTo("text/plain");
+	}
+
+	@Test // DATAMONGO-1850
+	public void shouldThrowExceptionOnEmptyContentType() {
+
+		GridFSFile file = new GridFSFile(new BsonObjectId(), "foo", 0, 0, new Date(), "foo", null);
+		GridFsResource resource = new GridFsResource(file);
+
+		assertThatThrownBy(resource::getContentType).isInstanceOf(MongoGridFSException.class);
+	}
+}


### PR DESCRIPTION
We now consider fall back to GridFS.getContentType() if GridFS metadata is absent to prevent `null` dereference.

---

Related ticket: [DATAMONGO-1850](https://jira.spring.io/browse/DATAMONGO-1850).