### PR TITLE
DATAMONGO-1860 - Retrieve result count via QuerydslMongoPredicateExecutor only for paging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
@@ -115,7 +115,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 		Assert.notNull(predicate, "Predicate must not be null!");
 
-		return createQueryFor(predicate).fetchResults().getResults();
+		return createQueryFor(predicate).fetch();
 	}
 
 	/*
@@ -128,7 +128,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 		Assert.notNull(predicate, "Predicate must not be null!");
 		Assert.notNull(orders, "Order specifiers must not be null!");
 
-		return createQueryFor(predicate).orderBy(orders).fetchResults().getResults();
+		return createQueryFor(predicate).orderBy(orders).fetch();
 	}
 
 	/*
@@ -141,7 +141,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 		Assert.notNull(predicate, "Predicate must not be null!");
 		Assert.notNull(sort, "Sort must not be null!");
 
-		return applySorting(createQueryFor(predicate), sort).fetchResults().getResults();
+		return applySorting(createQueryFor(predicate), sort).fetch();
 	}
 
 	/*
@@ -153,7 +153,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 		Assert.notNull(orders, "Order specifiers must not be null!");
 
-		return createQuery().orderBy(orders).fetchResults().getResults();
+		return createQuery().orderBy(orders).fetch();
 	}
 
 	/*
@@ -168,8 +168,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 		AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> query = createQueryFor(predicate);
 
-		return PageableExecutionUtils.getPage(applyPagination(query, pageable).fetchResults().getResults(), pageable,
-				() -> createQueryFor(predicate).fetchCount());
+		return PageableExecutionUtils.getPage(applyPagination(query, pageable).fetch(), pageable, query::fetchCount);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslMongoPredicateExecutor.java
@@ -59,7 +59,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/**
 	 * Creates a new {@link QuerydslMongoPredicateExecutor} for the given {@link MongoEntityInformation} and
-	 * {@link MongoTemplate}. Uses the {@link SimpleEntityPathResolver} to create an {@link EntityPath} for the given
+	 * {@link MongoOperations}. Uses the {@link SimpleEntityPathResolver} to create an {@link EntityPath} for the given
 	 * domain class.
 	 *
 	 * @param entityInformation must not be {@literal null}.
@@ -72,7 +72,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/**
 	 * Creates a new {@link QuerydslMongoPredicateExecutor} for the given {@link MongoEntityInformation},
-	 * {@link MongoTemplate} and {@link EntityPathResolver}.
+	 * {@link MongoOperations} and {@link EntityPathResolver}.
 	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param mongoOperations must not be {@literal null}.
@@ -108,7 +108,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public List<T> findAll(Predicate predicate) {
@@ -120,7 +120,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, com.mysema.query.types.OrderSpecifier<?>[])
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, com.querydsl.core.types.OrderSpecifier<?>[])
 	 */
 	@Override
 	public List<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
@@ -133,7 +133,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, org.springframework.data.domain.Sort)
 	 */
 	@Override
 	public List<T> findAll(Predicate predicate, Sort sort) {
@@ -146,7 +146,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.OrderSpecifier[])
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.OrderSpecifier[])
 	 */
 	@Override
 	public Iterable<T> findAll(OrderSpecifier<?>... orders) {
@@ -158,7 +158,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Pageable)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, org.springframework.data.domain.Pageable)
 	 */
 	@Override
 	public Page<T> findAll(Predicate predicate, Pageable pageable) {
@@ -173,7 +173,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public long count(Predicate predicate) {
@@ -185,7 +185,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public boolean exists(Predicate predicate) {
@@ -196,7 +196,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 	}
 
 	/**
-	 * Creates a {@link MongodbQuery} for the given {@link Predicate}.
+	 * Creates a {@link AbstractMongodbQuery} for the given {@link Predicate}.
 	 *
 	 * @param predicate
 	 * @return
@@ -206,12 +206,12 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 	}
 
 	/**
-	 * Creates a {@link MongodbQuery}.
+	 * Creates a {@link AbstractMongodbQuery}.
 	 *
 	 * @return
 	 */
 	private AbstractMongodbQuery<T, SpringDataMongodbQuery<T>> createQuery() {
-		return new SpringDataMongodbQuery<T>(mongoOperations, entityInformation.getJavaType());
+		return new SpringDataMongodbQuery<>(mongoOperations, entityInformation.getJavaType());
 	}
 
 	/**
@@ -247,7 +247,7 @@ public class QuerydslMongoPredicateExecutor<T> implements QuerydslPredicateExecu
 			return query;
 		}
 
-		sort.stream().map(this::toOrder).forEach(it -> query.orderBy(it));
+		sort.stream().map(this::toOrder).forEach(query::orderBy);
 
 		return query;
 	}


### PR DESCRIPTION
We now use` AbstractMongodbQuery.fetch() `instead of `AbstractMongodbQuery.fetchResults()` to execute MongoDB queries. `fetchResults()` executes a `find(…)` and a `count(…)` query. Retrieving the record count is an expensive operation in MongoDB and the count is not always required. For regular `find(…)` method, the count is ignored, for paging, the `count(…)` is only required in certain result/request scenarios.

---

Related ticket: [DATAMONGO-1860](https://jira.spring.io/browse/DATAMONGO-1860).