### PR TITLE
AddFieldsOperation support [DATAMONGO-1887]

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperation.java
@@ -1,0 +1,31 @@
+package org.springframework.data.mongodb.core.aggregation;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AddFieldsOperation implements AggregationOperation {
+
+    private Map<String, Object> fields = new LinkedHashMap<>();
+
+    public AddFieldsOperation (String field, Object value) {
+        fields.put(field, value);
+    }
+
+    @Override
+    public Document toDocument(AggregationOperationContext context) {
+        Document doc = new Document();
+        fields.forEach(doc::append);
+
+        return new Document("$addFields", doc);
+    }
+
+    public AddFieldsOperation addField(String field, Object value) {
+        this.fields.put(field, value);
+        return this;
+    }
+}
+ 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -400,6 +400,17 @@ public class Aggregation {
 	public static SkipOperation skip(long elementsToSkip) {
 		return new SkipOperation(elementsToSkip);
 	}
+	
+	/**
+	 * Creates a new {@link AddFieldsOperation} adding the expressions to the fields.
+	 *
+	 * @param field must not be null.
+	 * @param value must not be null.
+	 * @return
+	 */
+	public static AddFieldsOperation addFields(String field, Object value) {
+		return new AddFieldsOperation(field, value);
+	}
 
 	/**
 	 * Creates a new {@link LimitOperation} limiting the result to the given number of elements.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperationTests.java
@@ -1,0 +1,51 @@
+package org.springframework.data.mongodb.core.aggregation;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.mongodb.core.DocumentTestUtils.*;
+
+import org.bson.Document;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AddFieldsOperation}.
+ *
+ * @author Vadzim Parafianiuk
+ */
+public class AddFieldsOperationTests {
+
+    @Test
+    public void createDocumentForAddFieldsWithInnerDocumentCorrectly() {
+        AddFieldsOperation operation = new AddFieldsOperation("foo", new Document("$size", "$someArray"));
+        Document result = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
+
+        Document addFieldsValue = getAsDocument(result, "$addFields");
+        assertThat(addFieldsValue, is(notNullValue()));
+        assertThat(addFieldsValue.get("foo"), is(new Document("$size", "$someArray")));
+    }
+
+    @Test
+    public void createDocumentForAddFieldsCorrectly() {
+        AddFieldsOperation operation = new AddFieldsOperation("foo", "bar");
+        Document result = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
+
+        Document addFieldsValue = getAsDocument(result, "$addFields");
+        assertThat(addFieldsValue, is(notNullValue()));
+        assertThat(addFieldsValue.get("foo"), is("bar"));
+    }
+
+    @Test
+    public void createMultiFieldAddFieldsOperation() {
+        AddFieldsOperation operation =
+                new AddFieldsOperation("foo", "bar")
+                .addField("counter", new Document("$size", "$arrayWithPicturesWithCats"));
+
+        Document result = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
+
+        Document addFieldsValue = getAsDocument(result, "$addFields");
+        assertThat(addFieldsValue.get("counter"), is(new Document("$size", "$arrayWithPicturesWithCats")));
+        assertThat(addFieldsValue.get("foo"), is("bar"));
+    }
+
+
+}


### PR DESCRIPTION
Encapsulates the $addFields operation.

I've used it as:
```
Aggregation agg = newAggregation(
                addFields("tagsCount", new Document("$size", "$tags")),
                match(Criteria.where("tagsCount").gte(4).lte(5))
        );
```

Sorry for not creating test and docs, it's my first PL and I really don't have enough time to provide it.
