### PR TITLE
DATAMONGO-1893 - Allow exclusion of fields other than _id in aggregation $project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1893-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
@@ -59,7 +59,7 @@ class AggregationOperationRenderer {
 				FieldsExposingAggregationOperation exposedFieldsOperation = (FieldsExposingAggregationOperation) operation;
 				ExposedFields fields = exposedFieldsOperation.getFields();
 
-				if (operation instanceof InheritsFieldsAggregationOperation) {
+				if (operation instanceof InheritsFieldsAggregationOperation || exposedFieldsOperation.inheritsFields()) {
 					contextToUse = new InheritingExposedFieldsAggregationOperationContext(fields, contextToUse);
 				} else {
 					contextToUse = fields.exposesNoFields() ? DEFAULT_CONTEXT

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/FieldsExposingAggregationOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/FieldsExposingAggregationOperation.java
@@ -34,8 +34,25 @@ public interface FieldsExposingAggregationOperation extends AggregationOperation
 	ExposedFields getFields();
 
 	/**
+	 * @return {@literal true} to conditionally inherit fields from previous operations.
+	 * @since 2.0.6
+	 */
+	default boolean inheritsFields() {
+		return false;
+	}
+
+	/**
 	 * Marker interface for {@link AggregationOperation} that inherits fields from previous operations.
 	 */
-	interface InheritsFieldsAggregationOperation extends FieldsExposingAggregationOperation {}
+	interface InheritsFieldsAggregationOperation extends FieldsExposingAggregationOperation {
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.aggregation.FieldsExposingAggregationOperation#inheritsFields()
+		 */
+		@Override
+		default boolean inheritsFields() {
+			return true;
+		}
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -140,11 +140,6 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 	 */
 	public ProjectionOperation andExclude(String... fieldNames) {
 
-		for (String fieldName : fieldNames) {
-			Assert.isTrue(Fields.UNDERSCORE_ID.equals(fieldName),
-					String.format(EXCLUSION_ERROR, fieldName, Fields.UNDERSCORE_ID));
-		}
-
 		List<FieldProjection> excludeProjections = FieldProjection.from(Fields.fields(fieldNames), false);
 		return new ProjectionOperation(this.projections, excludeProjections);
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -185,6 +185,18 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.FieldsExposingAggregationOperation#inheritsFields()
+	 */
+	@Override
+	public boolean inheritsFields() {
+
+		return projections.stream().filter(FieldProjection.class::isInstance) //
+				.map(FieldProjection.class::cast) //
+				.anyMatch(FieldProjection::isExcluded);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperation#toDocument(org.springframework.data.mongodb.core.aggregation.AggregationOperationContext)
 	 */
 	@Override
@@ -1337,6 +1349,13 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 				}
 
 				return projections;
+			}
+
+			/**
+			 * @return {@literal true} if this field is excluded.
+			 */
+			public boolean isExcluded() {
+				return Boolean.FALSE.equals(value);
 			}
 
 			/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -203,7 +203,17 @@ public class ProjectionOperationUnitTests {
 		ProjectionOperation projectionOp = new ProjectionOperation().andExclude("foo");
 		Document document = projectionOp.toDocument(Aggregation.DEFAULT_CONTEXT);
 		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
+
+		assertThat(projectionOp.inheritsFields()).isTrue();
 		assertThat((Integer) projectClause.get("foo")).isEqualTo(0);
+	}
+
+	@Test // DATAMONGO-1893
+	public void includeShouldNotInheritFields() {
+
+		ProjectionOperation projectionOp = new ProjectionOperation().andInclude("foo");
+
+		assertThat(projectionOp.inheritsFields()).isFalse();
 	}
 
 	@Test // DATAMONGO-758

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -197,10 +197,13 @@ public class ProjectionOperationUnitTests {
 		assertThat(oper.get(MOD)).isEqualTo((Object) Arrays.<Object> asList("$a", 3));
 	}
 
-	@Test(expected = IllegalArgumentException.class) // DATAMONGO-758
-	public void excludeShouldThrowExceptionForFieldsOtherThanUnderscoreId() {
+	@Test // DATAMONGO-758, DATAMONGO-1893
+	public void excludeShouldAllowExclusionOfFieldsOtherThanUnderscoreId/* since MongoDB 3.4 */() {
 
-		new ProjectionOperation().andExclude("foo");
+		ProjectionOperation projectionOp = new ProjectionOperation().andExclude("foo");
+		Document document = projectionOp.toDocument(Aggregation.DEFAULT_CONTEXT);
+		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
+		assertThat((Integer) projectClause.get("foo")).isEqualTo(0);
 	}
 
 	@Test // DATAMONGO-758


### PR DESCRIPTION
As of MongoDB 3.4 exclusion of fields other than `_id` is allowed, so we removed the limitation in our code.

----

Should be back ported to `2.0.x` and `1.10.x`.