### PR TITLE
DATAMONGO-1912 - Propagate autogenerated Id to persistent top-level Maps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1912-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2536,15 +2536,18 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @param savedObject
 	 * @param id
 	 */
+	@SuppressWarnings("unchecked")
 	protected void populateIdIfNecessary(Object savedObject, Object id) {
 
 		if (id == null) {
 			return;
 		}
 
-		if (savedObject instanceof Document) {
-			Document document = (Document) savedObject;
-			document.put(ID_FIELD, id);
+		if (savedObject instanceof Map) {
+
+			Map<String, Object> map = (Map<String, Object>) savedObject;
+			map.put(ID_FIELD, id);
+
 			return;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2224,15 +2224,18 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 * @param savedObject
 	 * @param id
 	 */
+	@SuppressWarnings("unchecked")
 	private void populateIdIfNecessary(Object savedObject, @Nullable Object id) {
 
 		if (id == null) {
 			return;
 		}
 
-		if (savedObject instanceof Document) {
-			Document Document = (Document) savedObject;
-			Document.put(ID_FIELD, id);
+		if (savedObject instanceof Map) {
+
+			Map<String, Object> map = (Map<String, Object>) savedObject;
+			map.put(ID_FIELD, id);
+
 			return;
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -26,7 +26,9 @@ import lombok.Data;
 
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -216,6 +218,19 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		template.save(entity);
 
 		assertThat(entity.id, is(notNullValue()));
+	}
+
+	@Test // DATAMONGO-1912
+	public void autogeneratesIdForMap() {
+
+		MongoTemplate template = spy(this.template);
+		doReturn(new ObjectId()).when(template).saveDocument(Mockito.any(String.class), Mockito.any(Document.class),
+				Mockito.any(Class.class));
+
+		Map<String, String> entity = new LinkedHashMap<>();
+		template.save(entity, "foo");
+
+		assertThat(entity, hasKey("_id"));
 	}
 
 	@Test // DATAMONGO-374


### PR DESCRIPTION
We now set autogenerated Ids in Maps that are used as top-level entities. This allows transparent and persistent Map usage without requiring to use Document in application code. Previously, we only set autogenerated Ids in Document and persistent entity types.

```java
Map<String, Object> entity = new LinkedHashMap<>();
entity.put("firstname", "Walter");
entity.put("lastname", "White");
template.save(entity, "my_collection");

ObjectId id = (ObjectId) entity.get("_id");
```

---

Related ticket: [DATAMONGO-1912](https://jira.spring.io/browse/DATAMONGO-1912).