### PR TITLE
DATAMONGO-1890 - Add support for mapReduce to ReactiveMongoOperations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1890-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -33,6 +33,7 @@ import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.index.ReactiveIndexOperations;
+import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.NearQuery;
@@ -1225,6 +1226,213 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 */
 	<T> Flux<ChangeStreamEvent<T>> changeStream(List<Document> filter, Class<T> resultType, ChangeStreamOptions options,
 			String collectionName);
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param resultType the mapping target of the operations result documents. Also used to determine the input
+	 *          collection mame. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Class<T> resultType, String mapFunction, String reduceFunction) {
+		return mapReduce(resultType, resultType, mapFunction, reduceFunction);
+	}
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param domainType source type used to determine the input collection name. Must not be {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Class<?> domainType, Class<T> resultType, String mapFunction, String reduceFunction) {
+		return mapReduce(new Query(), domainType, resultType, mapFunction, reduceFunction, MapReduceOptions.options());
+	}
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Also used to determine the input
+	 *          collection mame. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Query filterQuery, Class<T> resultType, String mapFunction, String reduceFunction) {
+		return mapReduce(filterQuery, resultType, resultType, mapFunction, reduceFunction);
+	}
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param domainType source type used to determine the input collection name and map the filter {@link Query} against.
+	 *          Must not be {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Query filterQuery, Class<?> domainType, Class<T> resultType, String mapFunction,
+			String reduceFunction) {
+
+		return mapReduce(filterQuery, domainType, resultType, mapFunction, reduceFunction, MapReduceOptions.options());
+	}
+
+	/**
+	 * Execute a map-reduce operation. Use {@link MapReduceOptions} to optionally specify an output collection and other
+	 * args.
+	 *
+	 * @param resultType he mapping target of the operations result documents. Also used to determine the input collection
+	 *          mame. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @param options additional options like output collection. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Class<T> resultType, String mapFunction, String reduceFunction,
+			MapReduceOptions options) {
+
+		return mapReduce(new Query(), resultType, mapFunction, reduceFunction, options);
+	}
+
+	/**
+	 * Execute a map-reduce operation. Use {@link MapReduceOptions} to optionally specify an output collection and other
+	 * args.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param resultType he mapping target of the operations result documents. Also used to determine the input collection
+	 *          mame. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @param options additional options like output collection. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Query filterQuery, Class<T> resultType, String mapFunction, String reduceFunction,
+			MapReduceOptions options) {
+
+		return mapReduce(filterQuery, resultType, resultType, mapFunction, reduceFunction, options);
+	}
+
+	/**
+	 * Execute a map-reduce operation. Use {@link MapReduceOptions} to optionally specify an output collection and other
+	 * args.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param domainType source type used to determine the input collection name and map the filter {@link Query} against.
+	 *          Must not be {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @param options additional options like output collection. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	<T> Flux<T> mapReduce(Query filterQuery, Class<?> domainType, Class<T> resultType, String mapFunction,
+			String reduceFunction, MapReduceOptions options);
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param collectionName the input collection.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Class<T> resultType, String collectionName, String mapFunction, String reduceFunction) {
+		return mapReduce(new Query(), resultType, collectionName, mapFunction, reduceFunction);
+	}
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param collectionName the input collection.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Query filterQuery, Class<T> resultType, String collectionName, String mapFunction,
+			String reduceFunction) {
+
+		return mapReduce(filterQuery, resultType, resultType, collectionName, mapFunction, reduceFunction);
+	}
+
+	/**
+	 * Execute an inline map-reduce operation returning the operation result without storing it in an collection.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param domainType source type used to map the filter {@link Query} against. Must not be {@literal null}.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param collectionName the input collection.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Query filterQuery, Class<?> domainType, Class<T> resultType, String collectionName,
+			String mapFunction, String reduceFunction) {
+
+		return mapReduce(filterQuery, domainType, collectionName, resultType, mapFunction, reduceFunction,
+				MapReduceOptions.options());
+	}
+
+	/**
+	 * Execute a map-reduce operation. Use {@link MapReduceOptions} to optionally specify an output collection and other
+	 * args.
+	 *
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param collectionName the input collection.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @param options additional options like output collection. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	default <T> Flux<T> mapReduce(Class<T> resultType, String collectionName, String mapFunction, String reduceFunction,
+			MapReduceOptions options) {
+
+		return mapReduce(new Query(), resultType, collectionName, resultType, mapFunction, reduceFunction, options);
+	}
+
+	/**
+	 * Execute a map-reduce operation. Use {@link MapReduceOptions} to optionally specify an output collection and other
+	 * args.
+	 *
+	 * @param filterQuery the selection criteria for the documents going input to the map function. Must not be
+	 *          {@literal null}.
+	 * @param domainType source type used to map the filter {@link Query} against. Must not be {@literal null}.
+	 * @param inputCollectionName the input collection.
+	 * @param resultType the mapping target of the operations result documents. Must not be {@literal null}.
+	 * @param mapFunction the JavaScript map function. Must not be {@literal null}.
+	 * @param reduceFunction the JavaScript reduce function. Must not be {@literal null}.
+	 * @param options additional options like output collection. Must not be {@literal null}.
+	 * @return a {@link Flux} emitting the result document sequence. Never {@literal null}.
+	 * @since 2.1
+	 */
+	<T> Flux<T> mapReduce(Query filterQuery, Class<?> domainType, String inputCollectionName, Class<T> resultType,
+			String mapFunction, String reduceFunction, MapReduceOptions options);
 
 	/**
 	 * Returns the underlying {@link MongoConverter}.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/ReactiveMapReduceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/ReactiveMapReduceTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapreduce;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import lombok.Data;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.Success;
+
+/**
+ * @author Christoph Strobl
+ * @currentRead Beyond the Shadows - Brent Weeks
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:reactive-infrastructure.xml")
+public class ReactiveMapReduceTests {
+
+	@Autowired SimpleReactiveMongoDatabaseFactory factory;
+	@Autowired ReactiveMongoTemplate template;
+
+	private String mapFunction = "function(){ for ( var i=0; i<this.x.length; i++ ){ emit( this.x[i] , 1 ); } }";
+	private String reduceFunction = "function(key,values){ var sum=0; for( var i=0; i<values.length; i++ ) sum += values[i]; return sum;}";
+
+	@Before
+	public void setUp() {
+
+		StepVerifier
+				.create(template.dropCollection(ValueObject.class) //
+						.mergeWith(template.dropCollection("jmr1")) //
+						.mergeWith(template.dropCollection("jmr1_out"))) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-1890
+	public void mapReduceWithInlineResult() {
+
+		createMapReduceData();
+
+		StepVerifier
+				.create(template.mapReduce(new Query(), null, "jmr1", ValueObject.class, mapFunction, reduceFunction,
+						MapReduceOptions.options()).buffer(4)) //
+				.consumeNextWith(result -> {
+					assertThat(result).containsExactlyInAnyOrder(new ValueObject("a", 1), new ValueObject("b", 2),
+							new ValueObject("c", 2), new ValueObject("d", 1));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-1890
+	public void mapReduceWithInlineAndFilterQuery() {
+
+		createMapReduceData();
+
+		StepVerifier
+				.create(template.mapReduce(query(where("x").ne(new String[] { "a", "b" })), ValueObject.class, "jmr1",
+						ValueObject.class, mapFunction, reduceFunction, MapReduceOptions.options()).buffer(4)) //
+				.consumeNextWith(result -> {
+					assertThat(result).containsExactlyInAnyOrder(new ValueObject("b", 1), new ValueObject("c", 2),
+							new ValueObject("d", 1));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-1890
+	public void mapReduceWithOutputCollection() {
+
+		createMapReduceData();
+
+		StepVerifier
+				.create(template.mapReduce(new Query(), ValueObject.class, "jmr1", ValueObject.class, mapFunction,
+						reduceFunction, MapReduceOptions.options().outputCollection("jmr1_out")))
+				.expectNextCount(4).verifyComplete();
+
+		StepVerifier.create(template.find(new Query(), ValueObject.class, "jmr1_out").buffer(4)) //
+				.consumeNextWith(result -> {
+					assertThat(result).containsExactlyInAnyOrder(new ValueObject("a", 1), new ValueObject("b", 2),
+							new ValueObject("c", 2), new ValueObject("d", 1));
+				}) //
+				.verifyComplete();
+
+	}
+
+	@Test // DATAMONGO-1890
+	public void mapReduceWithInlineAndMappedFilterQuery() {
+
+		createMapReduceData();
+
+		StepVerifier
+				.create(template.mapReduce(query(where("values").ne(new String[] { "a", "b" })), MappedFieldsValueObject.class,
+						"jmr1", ValueObject.class, mapFunction, reduceFunction, MapReduceOptions.options()).buffer(4)) //
+				.consumeNextWith(result -> {
+					assertThat(result).containsExactlyInAnyOrder(new ValueObject("b", 1), new ValueObject("c", 2),
+							new ValueObject("d", 1));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-1890
+	public void mapReduceWithInlineFilterQueryAndExtractedCollection() {
+
+		createMapReduceData();
+
+		StepVerifier
+				.create(template.mapReduce(query(where("values").ne(new String[] { "a", "b" })), MappedFieldsValueObject.class,
+						ValueObject.class, mapFunction, reduceFunction, MapReduceOptions.options()).buffer(4)) //
+				.consumeNextWith(result -> {
+					assertThat(result).containsExactlyInAnyOrder(new ValueObject("b", 1), new ValueObject("c", 2),
+							new ValueObject("d", 1));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-1890
+	public void throwsExceptionWhenTryingToLoadFunctionsFromDisk() {
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> template.mapReduce(new Query(), null,
+				"foo", ValueObject.class, "classpath:map.js", "classpath:reduce.js", null))
+				.withMessageContaining("classpath:map.js");
+	}
+
+	private void createMapReduceData() {
+
+		MongoCollection<Document> collection = factory.getMongoDatabase().getCollection("jmr1", Document.class);
+
+		StepVerifier
+				.create(collection.insertMany(Arrays.asList(new Document("x", Arrays.asList("a", "b")),
+						new Document("x", Arrays.asList("b", "c")), new Document("x", Arrays.asList("c", "d")))))
+				.expectNext(Success.SUCCESS).verifyComplete();
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document("jmr1")
+	@Data
+	static class MappedFieldsValueObject {
+
+		@Field("x") String[] values;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/ValueObject.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/ValueObject.java
@@ -1,22 +1,37 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.mongodb.core.mapreduce;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Mark Pollack
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ValueObject {
 
 	private String id;
 
-	public String getId() {
-		return id;
-	}
-
 	private float value;
-
-	public float getValue() {
-		return value;
-	}
-
-	public void setValue(float value) {
-		this.value = value;
-	}
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
We now support `mapReduce` via `ReactiveMongoTemplate`.