### PR TITLE
DATAMONGO-1928 - Use non-blocking index creation through ReactiveMongoTemplate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1928-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
@@ -16,6 +16,8 @@
 package org.springframework.data.mongodb.core.index;
 
 /**
+ * Provider interface to obtain {@link IndexOperations} by MongoDB collection name.
+ *
  * @author Mark Paluch
  * @author Jens Schauder
  * @since 2.0
@@ -26,6 +28,7 @@ public interface IndexOperationsProvider {
 	/**
 	 * Returns the operations that can be performed on indexes
 	 *
+	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
 	 * @return index operations on the named collection
 	 */
 	IndexOperations indexOps(String collectionName);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoMappingEventPublisher.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoMappingEventPublisher.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core.index;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationListener;
 import org.springframework.data.mapping.context.MappingContextEvent;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
@@ -38,7 +39,19 @@ import org.springframework.util.Assert;
  */
 public class MongoMappingEventPublisher implements ApplicationEventPublisher {
 
-	private final MongoPersistentEntityIndexCreator indexCreator;
+	private final ApplicationListener<MappingContextEvent<?, ?>> indexCreator;
+
+	/**
+	 * Creates a new {@link MongoMappingEventPublisher} for the given {@link ApplicationListener}.
+	 *
+	 * @param indexCreator must not be {@literal null}.
+	 * @since 2.1
+	 */
+	public MongoMappingEventPublisher(ApplicationListener<MappingContextEvent<?, ?>> indexCreator) {
+
+		Assert.notNull(indexCreator, "ApplicationListener must not be null!");
+		this.indexCreator = indexCreator;
+	}
 
 	/**
 	 * Creates a new {@link MongoMappingEventPublisher} for the given {@link MongoPersistentEntityIndexCreator}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoMappingEventPublisher.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoMappingEventPublisher.java
@@ -50,6 +50,7 @@ public class MongoMappingEventPublisher implements ApplicationEventPublisher {
 	public MongoMappingEventPublisher(ApplicationListener<MappingContextEvent<?, ?>> indexCreator) {
 
 		Assert.notNull(indexCreator, "ApplicationListener must not be null!");
+
 		this.indexCreator = indexCreator;
 	}
 
@@ -61,6 +62,7 @@ public class MongoMappingEventPublisher implements ApplicationEventPublisher {
 	public MongoMappingEventPublisher(MongoPersistentEntityIndexCreator indexCreator) {
 
 		Assert.notNull(indexCreator, "MongoPersistentEntityIndexCreator must not be null!");
+
 		this.indexCreator = indexCreator;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/ReactiveIndexOperationsProvider.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/ReactiveIndexOperationsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,19 @@
 package org.springframework.data.mongodb.core.index;
 
 /**
+ * Provider interface to obtain {@link ReactiveIndexOperations} by MongoDB collection name.
+ *
  * @author Mark Paluch
- * @author Jens Schauder
- * @since 2.0
+ * @since 2.1
  */
 @FunctionalInterface
-public interface IndexOperationsProvider {
+public interface ReactiveIndexOperationsProvider {
 
 	/**
-	 * Returns the operations that can be performed on indexes
+	 * Returns the operations that can be performed on indexes.
 	 *
+	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
 	 * @return index operations on the named collection
 	 */
-	IndexOperations indexOps(String collectionName);
+	ReactiveIndexOperations indexOps(String collectionName);
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/ReactiveMongoPersistentEntityIndexCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/ReactiveMongoPersistentEntityIndexCreator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver.IndexDefinitionHolder;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
+import org.springframework.data.mongodb.util.MongoDbErrorCodes;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import com.mongodb.MongoException;
+
+/**
+ * Component that inspects {@link MongoPersistentEntity} instances contained in the given {@link MongoMappingContext}
+ * for indexing metadata and ensures the indexes to be available using reactive infrastructure.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class ReactiveMongoPersistentEntityIndexCreator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveMongoPersistentEntityIndexCreator.class);
+
+	private final Map<Class<?>, Boolean> classesSeen = new ConcurrentHashMap<Class<?>, Boolean>();
+	private final MongoMappingContext mappingContext;
+	private final ReactiveIndexOperationsProvider operationsProvider;
+	private final IndexResolver indexResolver;
+
+	/**
+	 * Creates a new {@link ReactiveMongoPersistentEntityIndexCreator} for the given {@link MongoMappingContext},
+	 * {@link ReactiveIndexOperationsProvider}.
+	 *
+	 * @param mappingContext must not be {@literal null}.
+	 * @param operationsProvider must not be {@literal null}.
+	 */
+	public ReactiveMongoPersistentEntityIndexCreator(MongoMappingContext mappingContext,
+			ReactiveIndexOperationsProvider operationsProvider) {
+		this(mappingContext, operationsProvider, new MongoPersistentEntityIndexResolver(mappingContext));
+	}
+
+	/**
+	 * Creates a new {@link ReactiveMongoPersistentEntityIndexCreator} for the given {@link MongoMappingContext},
+	 * {@link ReactiveIndexOperationsProvider}, and {@link IndexResolver}.
+	 *
+	 * @param mappingContext must not be {@literal null}.
+	 * @param operationsProvider must not be {@literal null}.
+	 * @param indexResolver must not be {@literal null}.
+	 */
+	public ReactiveMongoPersistentEntityIndexCreator(MongoMappingContext mappingContext,
+			ReactiveIndexOperationsProvider operationsProvider, IndexResolver indexResolver) {
+
+		Assert.notNull(mappingContext, "MongoMappingContext must not be null!");
+		Assert.notNull(operationsProvider, "ReactiveIndexOperations must not be null!");
+		Assert.notNull(indexResolver, "IndexResolver must not be null!");
+
+		this.mappingContext = mappingContext;
+		this.operationsProvider = operationsProvider;
+		this.indexResolver = indexResolver;
+	}
+
+	/**
+	 * Returns whether the current index creator was registered for the given {@link MappingContext}.
+	 *
+	 * @param context
+	 * @return
+	 */
+	public boolean isIndexCreatorFor(MappingContext<?, ?> context) {
+		return this.mappingContext.equals(context);
+	}
+
+	/**
+	 * Inspect entities for index creation.
+	 *
+	 * @return a {@link Mono} that completes without value after indexes were created.
+	 */
+	public Mono<Void> checkForIndexes(MongoPersistentEntity<?> entity) {
+
+		Class<?> type = entity.getType();
+
+		if (!classesSeen.containsKey(type)) {
+
+			if (this.classesSeen.put(type, Boolean.TRUE) == null) {
+
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Analyzing class " + type + " for index information.");
+				}
+
+				return checkForAndCreateIndexes(entity);
+			}
+		}
+
+		return Mono.empty();
+	}
+
+	private Mono<Void> checkForAndCreateIndexes(MongoPersistentEntity<?> entity) {
+
+		List<Mono<?>> publishers = new ArrayList<>();
+
+		if (entity.isAnnotationPresent(Document.class)) {
+			for (IndexDefinitionHolder indexToCreate : indexResolver.resolveIndexFor(entity.getTypeInformation())) {
+				publishers.add(createIndex(indexToCreate));
+			}
+		}
+
+		return publishers.isEmpty() ? Mono.empty() : Flux.merge(publishers).then();
+	}
+
+	Mono<String> createIndex(IndexDefinitionHolder indexDefinition) {
+
+		return operationsProvider.indexOps(indexDefinition.getCollection()).ensureIndex(indexDefinition) //
+				.onErrorResume(ReactiveMongoPersistentEntityIndexCreator::isDataIntegrityViolation,
+						e -> translateException(e, indexDefinition));
+
+	}
+
+	private Mono<? extends String> translateException(Throwable e, IndexDefinitionHolder indexDefinition) {
+
+		Mono<IndexInfo> existingIndex = fetchIndexInformation(indexDefinition);
+
+		Mono<String> defaultError = Mono.error(new DataIntegrityViolationException(
+				String.format("Cannot create index for '%s' in collection '%s' with keys '%s' and options '%s'.",
+						indexDefinition.getPath(), indexDefinition.getCollection(), indexDefinition.getIndexKeys(),
+						indexDefinition.getIndexOptions()),
+				e.getCause()));
+
+		return existingIndex.flatMap(it -> {
+			return Mono.<String> error(new DataIntegrityViolationException(
+					String.format("Index already defined as '%s'.", indexDefinition.getPath()), e.getCause()));
+		}).switchIfEmpty(defaultError);
+	}
+
+	private Mono<IndexInfo> fetchIndexInformation(IndexDefinitionHolder indexDefinition) {
+
+		Object indexNameToLookUp = indexDefinition.getIndexOptions().get("name");
+
+		Flux<IndexInfo> existingIndexes = operationsProvider.indexOps(indexDefinition.getCollection()).getIndexInfo();
+
+		return existingIndexes //
+				.filter(indexInfo -> ObjectUtils.nullSafeEquals(indexNameToLookUp, indexInfo.getName())) //
+				.next() //
+				.doOnError(e -> {
+					LOGGER.debug(
+							String.format("Failed to load index information for collection '%s'.", indexDefinition.getCollection()),
+							e);
+				});
+	}
+
+	private static boolean isDataIntegrityViolation(Throwable t) {
+
+		if (t instanceof UncategorizedMongoDbException) {
+
+			return t.getCause() instanceof MongoException
+					&& MongoDbErrorCodes.isDataIntegrityViolationCode(((MongoException) t.getCause()).getCode());
+		}
+
+		return false;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/ReactiveMongoPersistentEntityIndexCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/ReactiveMongoPersistentEntityIndexCreatorUnitTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoExceptionTranslator;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+
+/**
+ * Unit tests for {@link ReactiveMongoPersistentEntityIndexCreator}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReactiveMongoPersistentEntityIndexCreatorUnitTests {
+
+	ReactiveIndexOperations indexOperations;
+
+	@Mock ReactiveMongoDatabaseFactory factory;
+	@Mock MongoDatabase db;
+	@Mock MongoCollection<org.bson.Document> collection;
+
+	ArgumentCaptor<org.bson.Document> keysCaptor;
+	ArgumentCaptor<IndexOptions> optionsCaptor;
+	ArgumentCaptor<String> collectionCaptor;
+
+	@Before
+	@SuppressWarnings("unchecked")
+	public void setUp() {
+
+		when(factory.getExceptionTranslator()).thenReturn(new MongoExceptionTranslator());
+		when(factory.getMongoDatabase()).thenReturn(db);
+		when(db.getCollection(any(), any(Class.class))).thenReturn(collection);
+
+		indexOperations = new ReactiveMongoTemplate(factory).indexOps("foo");
+
+		keysCaptor = ArgumentCaptor.forClass(org.bson.Document.class);
+		optionsCaptor = ArgumentCaptor.forClass(IndexOptions.class);
+		collectionCaptor = ArgumentCaptor.forClass(String.class);
+
+		when(collection.createIndex(keysCaptor.capture(), optionsCaptor.capture())).thenReturn(Mono.just("OK"));
+	}
+
+	@Test // DATAMONGO-1928
+	public void buildsIndexDefinitionUsingFieldName() {
+
+		MongoMappingContext mappingContext = prepareMappingContext(Person.class);
+
+		Mono<Void> publisher = checkForIndexes(mappingContext);
+
+		verifyZeroInteractions(collection);
+
+		publisher.as(StepVerifier::create).verifyComplete();
+
+		assertThat(keysCaptor.getValue()).isNotNull().containsKey("fieldname");
+		assertThat(optionsCaptor.getValue().getName()).isEqualTo("indexName");
+		assertThat(optionsCaptor.getValue().isBackground()).isFalse();
+		assertThat(optionsCaptor.getValue().getExpireAfter(TimeUnit.SECONDS)).isNull();
+	}
+
+	@Test // DATAMONGO-1928
+	public void createIndexShouldUsePersistenceExceptionTranslatorForNonDataIntegrityConcerns() {
+
+		when(collection.createIndex(any(org.bson.Document.class), any(IndexOptions.class)))
+				.thenReturn(Mono.error(new MongoException(6, "HostUnreachable")));
+
+		MongoMappingContext mappingContext = prepareMappingContext(Person.class);
+
+		Mono<Void> publisher = checkForIndexes(mappingContext);
+
+		publisher.as(StepVerifier::create).expectError(DataAccessResourceFailureException.class).verify();
+	}
+
+	@Test // DATAMONGO-1928
+	public void createIndexShouldNotConvertUnknownExceptionTypes() {
+
+		when(collection.createIndex(any(org.bson.Document.class), any(IndexOptions.class)))
+				.thenReturn(Mono.error(new ClassCastException("o_O")));
+
+		MongoMappingContext mappingContext = prepareMappingContext(Person.class);
+
+		Mono<Void> publisher = checkForIndexes(mappingContext);
+
+		publisher.as(StepVerifier::create).expectError(ClassCastException.class).verify();
+	}
+
+	private static MongoMappingContext prepareMappingContext(Class<?> type) {
+
+		MongoMappingContext mappingContext = new MongoMappingContext();
+		mappingContext.setInitialEntitySet(Collections.singleton(type));
+		mappingContext.initialize();
+
+		return mappingContext;
+	}
+
+	private Mono<Void> checkForIndexes(MongoMappingContext mappingContext) {
+
+		return new ReactiveMongoPersistentEntityIndexCreator(mappingContext, it -> indexOperations)
+				.checkForIndexes(mappingContext.getRequiredPersistentEntity(Person.class));
+	}
+
+	@Document
+	static class Person {
+
+		@Indexed(name = "indexName") //
+		@Field("fieldname") //
+		String field;
+
+	}
+}


### PR DESCRIPTION
We now use `ReactiveIndexOperationsProvider` to inspect and create indexes for MongoDB collections without using blocking methods. Indexes are created for initial entities and whenever a `MongoPersistentEntity` is registered in `MongoMappingContext`.

Index creation is now decoupled from the actual `ReactiveMongoTemplate` call causing indexes to be created asynchronously. Mongo commands no longer depend on the completion of index creation commands. Decoupling also comes with the aspect that `ReactiveMongoTemplate` creation/command invocation no longer fails if the actual index creation fails. The previous usage of blocking index creation caused the actual `ReactiveMongoTemplate` call to fail.

`ReactiveMongoTemplate` objects can be created with a `Consumer<Throwable>` callback that is notified if an index creation fails.

---

Related ticket: [DATAMONGO-1928](https://jira.spring.io/browse/DATAMONGO-1928).