### PR TITLE
DATAMONGO-1963 - Allow DateOperatorFactory to be subclassed

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
@@ -192,10 +192,10 @@ public class DateOperators {
 	 */
 	public static class DateOperatorFactory {
 
-		private final @Nullable String fieldReference;
-		private final @Nullable Object dateValue;
-		private final @Nullable AggregationExpression expression;
-		private final Timezone timezone;
+		protected final @Nullable String fieldReference;
+		protected final @Nullable Object dateValue;
+		protected final @Nullable AggregationExpression expression;
+		protected final Timezone timezone;
 
 		/**
 		 * @param fieldReference
@@ -204,7 +204,7 @@ public class DateOperators {
 		 * @param timezone
 		 * @since 2.1
 		 */
-		private DateOperatorFactory(@Nullable String fieldReference, @Nullable AggregationExpression expression,
+		protected DateOperatorFactory(@Nullable String fieldReference, @Nullable AggregationExpression expression,
 				@Nullable Object value, Timezone timezone) {
 
 			this.fieldReference = fieldReference;


### PR DESCRIPTION
This class prevents any type of subclassing because of the private constructor and fields which prevents people from creating their own operations on Mongo dates.  Requesting change of visibility to protected.

Adding additional pull request for 1.10.x branch as well.
