### PR TITLE
Allow DateOperatorFactory to be subclassed

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
@@ -189,10 +189,10 @@ public class DateOperators {
 	 */
 	public static class DateOperatorFactory {
 
-		private final String fieldReference;
-		private final Object dateValue;
-		private final AggregationExpression expression;
-		private final Timezone timezone;
+		protected final String fieldReference;
+		protected final Object dateValue;
+		protected final AggregationExpression expression;
+		protected final Timezone timezone;
 
 		/**
 		 * @param fieldReference
@@ -201,7 +201,7 @@ public class DateOperators {
 		 * @param timezone
 		 * @since 2.1
 		 */
-		private DateOperatorFactory(String fieldReference, AggregationExpression expression, Object value,
+		protected DateOperatorFactory(String fieldReference, AggregationExpression expression, Object value,
 				Timezone timezone) {
 
 			this.fieldReference = fieldReference;


### PR DESCRIPTION
This class prevents any type of subclassing because of the private constructor and fields which prevents people from creating their own operations on Mongo dates.  Requesting change of visibility to protected.

See other pull request to master:
https://github.com/spring-projects/spring-data-mongodb/pull/552/commits