### PR TITLE
DATAMONGO-1968 - Add configuration support for com.mongodb.client.MongoClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
 		<springdata.commons>2.1.0.BUILD-SNAPSHOT</springdata.commons>
-		<mongo>3.6.3</mongo>
-		<mongo.reactivestreams>1.7.1</mongo.reactivestreams>
+		<mongo>3.7.0</mongo>
+		<mongo.reactivestreams>1.8.0</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>
 	</properties>
 

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1968-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoDbFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoDbFactory.java
@@ -58,6 +58,11 @@ public interface MongoDbFactory extends CodecRegistryProvider {
 	 */
 	PersistenceExceptionTranslator getExceptionTranslator();
 
+	/**
+	 * Get the legacy database entry point. Please consider {@link #getDb()} instead.
+	 *
+	 * @return
+	 */
 	DB getLegacyDb();
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
@@ -26,24 +27,17 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.lang.Nullable;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 
 /**
- * Base class for Spring Data MongoDB configuration using JavaConfig with {@link com.mongodb.MongoClient}.
- * <p />
- * <strong>INFO:</strong>In case you want to use {@link com.mongodb.client.MongoClients} for configuration please refer
- * to {@link AbstractMongoClientConfiguration}.
+ * Base class for Spring Data MongoDB configuration using JavaConfig with {@link com.mongodb.client.MongoClient}.
  *
- * @author Mark Pollack
- * @author Oliver Gierke
- * @author Thomas Darimont
- * @author Ryan Tenney
  * @author Christoph Strobl
- * @author Mark Paluch
  * @see MongoConfigurationSupport
+ * @since 2.1
  */
 @Configuration
-public abstract class AbstractMongoConfiguration extends MongoConfigurationSupport {
+public abstract class AbstractMongoClientConfiguration extends MongoConfigurationSupport {
 
 	/**
 	 * Return the {@link MongoClient} instance to connect to. Annotate with {@link Bean} in case you want to expose a
@@ -73,13 +67,13 @@ public abstract class AbstractMongoConfiguration extends MongoConfigurationSuppo
 	 */
 	@Bean
 	public MongoDbFactory mongoDbFactory() {
-		return new SimpleMongoDbFactory(mongoClient(), getDatabaseName());
+		return new SimpleMongoClientDbFactory(mongoClient(), getDatabaseName());
 	}
 
 	/**
 	 * Return the base package to scan for mapped {@link Document}s. Will return the package name of the configuration
 	 * class' (the concrete class, not this one here) by default. So if you have a {@code com.acme.AppConfig} extending
-	 * {@link AbstractMongoConfiguration} the base package will be considered {@code com.acme} unless the method is
+	 * {@link AbstractMongoClientConfiguration} the base package will be considered {@code com.acme} unless the method is
 	 * overridden to implement alternate behavior.
 	 *
 	 * @return the base package to scan for mapped {@link Document} classes or {@literal null} to not enable scanning for

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbFactoryBase.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbFactoryBase.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import lombok.Value;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.SessionAwareMethodInterceptor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.DB;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.session.ClientSession;
+
+/**
+ * Common base class for usage with both {@link com.mongodb.client.MongoClients} and {@link com.mongodb.MongoClient}.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+abstract class MongoDbFactoryBase<T> implements MongoDbFactory {
+
+	private final T mongoClient;
+	private final String databaseName;
+	private final boolean mongoInstanceCreated;
+	private final PersistenceExceptionTranslator exceptionTranslator;
+
+	private @Nullable WriteConcern writeConcern;
+
+	protected MongoDbFactoryBase(T mongoClient, String databaseName, boolean mongoInstanceCreated,
+			PersistenceExceptionTranslator exceptionTranslator) {
+
+		Assert.notNull(mongoClient, "MongoClient must not be null!");
+		Assert.hasText(databaseName, "Database name must not be empty!");
+		Assert.isTrue(databaseName.matches("[^/\\\\.$\"\\s]+"),
+				"Database name must not contain slashes, dots, spaces, quotes, or dollar signs!");
+
+		this.mongoClient = mongoClient;
+		this.databaseName = databaseName;
+		this.mongoInstanceCreated = mongoInstanceCreated;
+		this.exceptionTranslator = exceptionTranslator;
+	}
+
+	/**
+	 * Configures the {@link WriteConcern} to be used on the {@link DB} instance being created.
+	 *
+	 * @param writeConcern the writeConcern to set
+	 */
+	public void setWriteConcern(WriteConcern writeConcern) {
+		this.writeConcern = writeConcern;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#getDb()
+	 */
+	public MongoDatabase getDb() throws DataAccessException {
+		return getDb(databaseName);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#getDb(java.lang.String)
+	 */
+	@Override
+	public MongoDatabase getDb(String dbName) throws DataAccessException {
+
+		Assert.hasText(dbName, "Database name must not be empty.");
+
+		MongoDatabase db = doGetMongoDatabase(dbName);
+
+		if (writeConcern == null) {
+			return db;
+		}
+
+		return db.withWriteConcern(writeConcern);
+	}
+
+	public void destroy() throws Exception {
+		if (mongoInstanceCreated) {
+			closeClient();
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#getExceptionTranslator()
+	 */
+	public PersistenceExceptionTranslator getExceptionTranslator() {
+		return this.exceptionTranslator;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#withSession(com.mongodb.session.Session)
+	 */
+	public MongoDbFactory withSession(ClientSession session) {
+		return new MongoDbFactoryBase.ClientSessionBoundMongoDbFactory(session, this);
+	}
+
+	protected abstract void closeClient();
+
+	protected abstract MongoDatabase doGetMongoDatabase(String dbName);
+
+	protected T getMongoClient() {
+		return mongoClient;
+	}
+
+	protected String getDefaultDatabaseName() {
+		return databaseName;
+	}
+
+	/**
+	 * {@link ClientSession} bound {@link MongoDbFactory} decorating the database with a
+	 * {@link SessionAwareMethodInterceptor}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.1
+	 */
+	@Value
+	static class ClientSessionBoundMongoDbFactory implements MongoDbFactory {
+
+		ClientSession session;
+		MongoDbFactory delegate;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#getDb()
+		 */
+		@Override
+		public MongoDatabase getDb() throws DataAccessException {
+			return proxyMongoDatabase(delegate.getDb());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#getDb(java.lang.String)
+		 */
+		@Override
+		public MongoDatabase getDb(String dbName) throws DataAccessException {
+			return proxyMongoDatabase(delegate.getDb(dbName));
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#getExceptionTranslator()
+		 */
+		@Override
+		public PersistenceExceptionTranslator getExceptionTranslator() {
+			return delegate.getExceptionTranslator();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#getLegacyDb()
+		 */
+		@Override
+		public DB getLegacyDb() {
+			return delegate.getLegacyDb();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#getSession(com.mongodb.ClientSessionOptions)
+		 */
+		@Override
+		public ClientSession getSession(ClientSessionOptions options) {
+			return delegate.getSession(options);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.MongoDbFactory#withSession(com.mongodb.session.ClientSession)
+		 */
+		@Override
+		public MongoDbFactory withSession(ClientSession session) {
+			return delegate.withSession(session);
+		}
+
+		private MongoDatabase proxyMongoDatabase(MongoDatabase database) {
+			return createProxyInstance(session, database, MongoDatabase.class);
+		}
+
+		private MongoDatabase proxyDatabase(ClientSession session, MongoDatabase database) {
+			return createProxyInstance(session, database, MongoDatabase.class);
+		}
+
+		private MongoCollection proxyCollection(ClientSession session, MongoCollection collection) {
+			return createProxyInstance(session, collection, MongoCollection.class);
+		}
+
+		private <T> T createProxyInstance(ClientSession session, T target, Class<T> targetType) {
+
+			ProxyFactory factory = new ProxyFactory();
+			factory.setTarget(target);
+			factory.setInterfaces(targetType);
+			factory.setOpaque(true);
+
+			factory.addAdvice(new SessionAwareMethodInterceptor<>(session, target, MongoDatabase.class, this::proxyDatabase,
+					MongoCollection.class, this::proxyCollection));
+
+			return targetType.cast(factory.getProxy());
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleMongoClientDbFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleMongoClientDbFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.springframework.beans.factory.DisposableBean;
+
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.ConnectionString;
+import com.mongodb.DB;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.session.ClientSession;
+
+/**
+ * Factory to create {@link MongoDatabase} instances from a {@link MongoClient} instance.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+public class SimpleMongoClientDbFactory extends MongoDbFactoryBase<MongoClient> implements DisposableBean {
+
+	/**
+	 * Creates a new {@link SimpleMongoClientDbFactory} instance for the given {@code connectionString}.
+	 *
+	 * @param connectionString must not be {@literal null}.
+	 * @see <a href="https://docs.mongodb.com/manual/reference/connection-string/">MongoDB Connection String reference</a>
+	 */
+	public SimpleMongoClientDbFactory(String connectionString) {
+		this(new ConnectionString(connectionString));
+	}
+
+	/**
+	 * Creates a new {@link SimpleMongoClientDbFactory} instance from the given {@link MongoClient}.
+	 *
+	 * @param connectionString must not be {@literal null}.
+	 */
+	public SimpleMongoClientDbFactory(ConnectionString connectionString) {
+		this(MongoClients.create(connectionString), connectionString.getDatabase(), true);
+	}
+
+	/**
+	 * Creates a new {@link SimpleMongoClientDbFactory} instance from the given {@link MongoClient}.
+	 *
+	 * @param mongoClient must not be {@literal null}.
+	 * @param databaseName must not be {@literal null}.
+	 */
+	public SimpleMongoClientDbFactory(MongoClient mongoClient, String databaseName) {
+		this(mongoClient, databaseName, false);
+	}
+
+	/**
+	 * Creates a new {@link SimpleMongoClientDbFactory} instance from the given {@link MongoClient}.
+	 *
+	 * @param mongoClient must not be {@literal null}.
+	 * @param databaseName must not be {@literal null}.
+	 * @param mongoInstanceCreated
+	 */
+	private SimpleMongoClientDbFactory(MongoClient mongoClient, String databaseName, boolean mongoInstanceCreated) {
+		super(mongoClient, databaseName, mongoInstanceCreated, new MongoExceptionTranslator());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#getLegacyDb()
+	 */
+	@Override
+	public DB getLegacyDb() {
+
+		throw new UnsupportedOperationException(String.format(
+				"%s does not support legacy DBObject API! Please " + "consider using SimpleMongoDbFactory for that purpose.",
+				MongoClient.class));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.MongoDbFactory#getSession(com.mongodb.ClientSessionOptions)
+	 */
+	@Override
+	public ClientSession getSession(ClientSessionOptions options) {
+		return getMongoClient().startSession(options);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.MongoDbFactoryBase#closeClient()
+	 */
+	@Override
+	protected void closeClient() {
+		getMongoClient().close();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.MongoDbFactoryBase#doGetMongoDatabase(java.lang.String)
+	 */
+	@Override
+	protected MongoDatabase doGetMongoDatabase(String dbName) {
+		return getMongoClient().getDatabase(dbName);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleMongoDbFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleMongoDbFactory.java
@@ -15,23 +15,12 @@
  */
 package org.springframework.data.mongodb.core;
 
-import lombok.Value;
-
-import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.support.PersistenceExceptionTranslator;
-import org.springframework.data.mongodb.MongoDbFactory;
-import org.springframework.data.mongodb.SessionAwareMethodInterceptor;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
-import com.mongodb.WriteConcern;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.session.ClientSession;
 
@@ -45,14 +34,7 @@ import com.mongodb.session.ClientSession;
  * @author George Moraitis
  * @author Mark Paluch
  */
-public class SimpleMongoDbFactory implements DisposableBean, MongoDbFactory {
-
-	private final MongoClient mongoClient;
-	private final String databaseName;
-	private final boolean mongoInstanceCreated;
-	private final PersistenceExceptionTranslator exceptionTranslator;
-
-	private @Nullable WriteConcern writeConcern;
+public class SimpleMongoDbFactory extends MongoDbFactoryBase<MongoClient> implements DisposableBean {
 
 	/**
 	 * Creates a new {@link SimpleMongoDbFactory} instance from the given {@link MongoClientURI}.
@@ -82,76 +64,12 @@ public class SimpleMongoDbFactory implements DisposableBean, MongoDbFactory {
 	 * @since 1.7
 	 */
 	private SimpleMongoDbFactory(MongoClient mongoClient, String databaseName, boolean mongoInstanceCreated) {
-
-		Assert.notNull(mongoClient, "MongoClient must not be null!");
-		Assert.hasText(databaseName, "Database name must not be empty!");
-		Assert.isTrue(databaseName.matches("[^/\\\\.$\"\\s]+"),
-				"Database name must not contain slashes, dots, spaces, quotes, or dollar signs!");
-
-		this.mongoClient = mongoClient;
-		this.databaseName = databaseName;
-		this.mongoInstanceCreated = mongoInstanceCreated;
-		this.exceptionTranslator = new MongoExceptionTranslator();
+		super(mongoClient, databaseName, mongoInstanceCreated, new MongoExceptionTranslator());
 	}
 
-	/**
-	 * Configures the {@link WriteConcern} to be used on the {@link DB} instance being created.
-	 *
-	 * @param writeConcern the writeConcern to set
-	 */
-	public void setWriteConcern(WriteConcern writeConcern) {
-		this.writeConcern = writeConcern;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.MongoDbFactory#getDb()
-	 */
-	public MongoDatabase getDb() throws DataAccessException {
-		return getDb(databaseName);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.MongoDbFactory#getDb(java.lang.String)
-	 */
-	public MongoDatabase getDb(String dbName) throws DataAccessException {
-
-		Assert.hasText(dbName, "Database name must not be empty.");
-
-		MongoDatabase db = mongoClient.getDatabase(dbName);
-
-		if (writeConcern == null) {
-			return db;
-		}
-
-		return db.withWriteConcern(writeConcern);
-	}
-
-	/**
-	 * Clean up the Mongo instance if it was created by the factory itself.
-	 *
-	 * @see DisposableBean#destroy()
-	 */
-	public void destroy() throws Exception {
-		if (mongoInstanceCreated) {
-			mongoClient.close();
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.MongoDbFactory#getExceptionTranslator()
-	 */
-	@Override
-	public PersistenceExceptionTranslator getExceptionTranslator() {
-		return this.exceptionTranslator;
-	}
-
-	@SuppressWarnings("deprecation")
 	@Override
 	public DB getLegacyDb() {
-		return mongoClient.getDB(databaseName);
+		return getMongoClient().getDB(getDefaultDatabaseName());
 	}
 
 	/*
@@ -160,108 +78,16 @@ public class SimpleMongoDbFactory implements DisposableBean, MongoDbFactory {
 	 */
 	@Override
 	public ClientSession getSession(ClientSessionOptions options) {
-		return mongoClient.startSession(options);
+		return getMongoClient().startSession(options);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.MongoDbFactory#withSession(com.mongodb.session.ClientSession)
-	 */
 	@Override
-	public MongoDbFactory withSession(ClientSession session) {
-		return new ClientSessionBoundMongoDbFactory(session, this);
+	protected void closeClient() {
+		getMongoClient().close();
 	}
 
-	/**
-	 * {@link ClientSession} bound {@link MongoDbFactory} decorating the database with a
-	 * {@link SessionAwareMethodInterceptor}.
-	 *
-	 * @author Christoph Strobl
-	 * @since 2.1
-	 */
-	@Value
-	static class ClientSessionBoundMongoDbFactory implements MongoDbFactory {
-
-		ClientSession session;
-		MongoDbFactory delegate;
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#getDb()
-		 */
-		@Override
-		public MongoDatabase getDb() throws DataAccessException {
-			return proxyMongoDatabase(delegate.getDb());
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#getDb(java.lang.String)
-		 */
-		@Override
-		public MongoDatabase getDb(String dbName) throws DataAccessException {
-			return proxyMongoDatabase(delegate.getDb(dbName));
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#getExceptionTranslator()
-		 */
-		@Override
-		public PersistenceExceptionTranslator getExceptionTranslator() {
-			return delegate.getExceptionTranslator();
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#getLegacyDb()
-		 */
-		@Override
-		public DB getLegacyDb() {
-			return delegate.getLegacyDb();
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#getSession(com.mongodb.ClientSessionOptions)
-		 */
-		@Override
-		public ClientSession getSession(ClientSessionOptions options) {
-			return delegate.getSession(options);
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.MongoDbFactory#withSession(com.mongodb.session.ClientSession)
-		 */
-		@Override
-		public MongoDbFactory withSession(ClientSession session) {
-			return delegate.withSession(session);
-		}
-
-		private MongoDatabase proxyMongoDatabase(MongoDatabase database) {
-			return createProxyInstance(session, database, MongoDatabase.class);
-		}
-
-		private MongoDatabase proxyDatabase(ClientSession session, MongoDatabase database) {
-			return createProxyInstance(session, database, MongoDatabase.class);
-		}
-
-		private MongoCollection proxyCollection(ClientSession session, MongoCollection collection) {
-			return createProxyInstance(session, collection, MongoCollection.class);
-		}
-
-		private <T> T createProxyInstance(ClientSession session, T target, Class<T> targetType) {
-
-			ProxyFactory factory = new ProxyFactory();
-			factory.setTarget(target);
-			factory.setInterfaces(targetType);
-			factory.setOpaque(true);
-
-			factory.addAdvice(new SessionAwareMethodInterceptor<>(session, target, MongoDatabase.class, this::proxyDatabase,
-					MongoCollection.class, this::proxyCollection));
-
-			return targetType.cast(factory.getProxy());
-		}
+	@Override
+	protected MongoDatabase doGetMongoDatabase(String dbName) {
+		return getMongoClient().getDatabase(dbName);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractIntegrationTests.java
@@ -30,9 +30,9 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 
 /**
@@ -43,7 +43,7 @@ import com.mongodb.client.MongoCollection;
 public abstract class AbstractIntegrationTests {
 
 	@Configuration
-	static class TestConfig extends AbstractMongoConfiguration {
+	static class TestConfig extends AbstractMongoClientConfiguration {
 
 		@Override
 		protected String getDatabaseName() {
@@ -52,7 +52,7 @@ public abstract class AbstractIntegrationTests {
 
 		@Override
 		public MongoClient mongoClient() {
-			return new MongoClient();
+			return MongoClients.create();
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -233,7 +233,7 @@ public class ReactiveMongoTemplateUnitTests {
 	@Test // DATAMONGO-1518
 	public void replaceOneShouldUseCollationWhenPresent() {
 
-		when(collection.replaceOne(any(Bson.class), any(), any())).thenReturn(Mono.empty());
+		when(collection.replaceOne(any(Bson.class), any(), any(UpdateOptions.class))).thenReturn(Mono.empty());
 
 		template.updateFirst(new BasicQuery("{}").collation(Collation.of("fr")), new Update(), AutogenerateableId.class)
 				.subscribe();

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -366,6 +366,28 @@ NOTE: Username/password credentials used in XML configuration must be URL encode
 Example: `m0ng0@dmin:mo_res:bw6},Qsdxx@admin@database` -> `m0ng0%40dmin:mo_res%3Abw6%7D%2CQsdxx%40admin@database`
 See https://tools.ietf.org/html/rfc3986#section-2.2[section 2.2 of RFC 3986] for further details.
 
+As of MongoDB java driver 3.7.0 there is an alternative entry point to `MongoClient` via the http://search.maven
+.org/#search%7Cgav%7C1%7Cg%3A%22org.mongodb%22%20AND%20a%3A%22mongodb-driver-sync%22[mongodb-driver-sync] artifact.
+`com.mongodb.client.MongoClient` is *not* compatible with `com.mongodb.MongoClient` and does not longer support
+the legacy `DBObject` codec. Therefore it cannot be used with `Querydsl` and requires a different configuration.
+You may use `AbstractMongoClientConfiguration` to leverage the new `MongoClients` builder API.
+
+[source,java]
+----
+@Configuration
+public class MongoClientConfiguration extends AbstractMongoClientConfiguration {
+
+	@Override
+	protected String getDatabaseName() {
+		return "database";
+	}
+
+	@Override
+	public MongoClient mongoClient() {
+		return MongoClients.create("mongodb://localhost:27017/?replicaSet=rs0&w=majority");
+	}
+}
+----
 
 [[mongo.mongo-db-factory-xml]]
 === Registering a MongoDbFactory instance using XML based metadata


### PR DESCRIPTION
As of MongoDB java driver 3.7.0 there is an alternative entry point to `MongoClient` via the `mongodb-driver-sync` artifact.
`com.mongodb.client.MongoClient` is *not* compatible with `com.mongodb.MongoClient` and does not longer support the legacy `DBObject` codec. Therefore it cannot be used with `Querydsl` and requires a different configuration.
You may use `AbstractMongoClientConfiguration` to leverage the new `MongoClients` builder API.