### PR TITLE
DATAMONGO-1986 - Fix unmapped objects in aggregation pipeline.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1986-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
@@ -41,7 +41,7 @@ class AggregationOperationRenderer {
 	 * {@link Document} representation.
 	 *
 	 * @param operations must not be {@literal null}.
-	 * @param context must not be {@literal null}.
+	 * @param rootContext must not be {@literal null}.
 	 * @return the {@link List} of {@link Document}.
 	 */
 	static List<Document> toDocument(List<AggregationOperation> operations, AggregationOperationContext rootContext) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
@@ -664,10 +664,10 @@ public class ReactiveMongoTemplateTests {
 	@Test // DATAMONGO-1444
 	public void geoNear() {
 
-		List<Venue> venues = Arrays.asList(new Venue("Penn Station", -73.99408, 40.75057), //
-				new Venue("10gen Office", -73.99171, 40.738868), //
-				new Venue("Flatiron Building", -73.988135, 40.741404), //
-				new Venue("Maplewood, NJ", -74.2713, 40.73137));
+		List<Venue> venues = Arrays.asList(TestEntities.geolocation().pennStation(), //
+				TestEntities.geolocation().tenGenOffice(), //
+				TestEntities.geolocation().flatironBuilding(), //
+				TestEntities.geolocation().maplewoodNJ());
 
 		StepVerifier.create(template.insertAll(venues)).expectNextCount(4).verifyComplete();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/TestEntities.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/TestEntities.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A simple collection of grouped test entities used throughout the test suite.
+ *
+ * @author Christoph Strobl
+ */
+public class TestEntities {
+
+	private static final GeoEntities GEO = new GeoEntities();
+
+	public static GeoEntities geolocation() {
+		return GEO;
+	}
+
+	public static class GeoEntities {
+
+		/**
+		 * <pre>
+		 * X: -73.99408
+		 * Y: 40.75057
+		 * </pre>
+		 *
+		 * @return new {@link Venue}
+		 */
+		public Venue pennStation() {
+			return new Venue("Penn Station", -73.99408, 40.75057);
+		}
+
+		/**
+		 * <pre>
+		 * X: -73.99171
+		 * Y: 40.738868
+		 * </pre>
+		 *
+		 * @return new {@link Venue}
+		 */
+
+		public Venue tenGenOffice() {
+			return new Venue("10gen Office", -73.99171, 40.738868);
+		}
+
+		/**
+		 * <pre>
+		 * X: -73.988135
+		 * Y: 40.741404
+		 * </pre>
+		 *
+		 * @return new {@link Venue}
+		 */
+		public Venue flatironBuilding() {
+			return new Venue("Flatiron Building", -73.988135, 40.741404);
+		}
+
+		/**
+		 * <pre>
+		 * X: -74.2713
+		 * Y: 40.73137
+		 * </pre>
+		 *
+		 * @return new {@link Venue}
+		 */
+		public Venue maplewoodNJ() {
+			return new Venue("Maplewood, NJ", -74.2713, 40.73137);
+		}
+
+		public List<Venue> newYork() {
+
+			List<Venue> venues = new ArrayList<>();
+
+			venues.add(pennStation());
+			venues.add(tenGenOffice());
+			venues.add(flatironBuilding());
+			venues.add(new Venue("Players Club", -73.997812, 40.739128));
+			venues.add(new Venue("City Bakery ", -73.992491, 40.738673));
+			venues.add(new Venue("Splash Bar", -73.992491, 40.738673));
+			venues.add(new Venue("Momofuku Milk Bar", -73.985839, 40.731698));
+			venues.add(new Venue("Shake Shack", -73.98820, 40.74164));
+			venues.add(new Venue("Penn Station", -73.99408, 40.75057));
+			venues.add(new Venue("Empire State Building", -73.98602, 40.74894));
+			venues.add(new Venue("Ulaanbaatar, Mongolia", 106.9154, 47.9245));
+			venues.add(maplewoodNJ());
+
+			return venues;
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -52,10 +52,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mongodb.core.CollectionCallback;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.TestEntities;
 import org.springframework.data.mongodb.core.Venue;
 import org.springframework.data.mongodb.core.aggregation.AggregationTests.CarDescriptor.Entry;
 import org.springframework.data.mongodb.core.aggregation.BucketAutoOperation.Granularities;
@@ -132,6 +135,7 @@ public class AggregationTests {
 		mongoTemplate.dropCollection(Employee.class);
 		mongoTemplate.dropCollection(Art.class);
 		mongoTemplate.dropCollection("personQueryTemp");
+		mongoTemplate.dropCollection(Venue.class);
 	}
 
 	/**
@@ -513,7 +517,7 @@ public class AggregationTests {
 		/*
 		 //complex mongodb aggregation framework example from
 		 https://docs.mongodb.org/manual/tutorial/aggregation-examples/#largest-and-smallest-cities-by-state
-
+		
 		 db.zipcodes.aggregate(
 			 	{
 				   $group: {
@@ -1461,9 +1465,8 @@ public class AggregationTests {
 	@Test // DATAMONGO-1127
 	public void shouldSupportGeoNearQueriesForAggregationWithDistanceField() {
 
-		mongoTemplate.insert(new Venue("Penn Station", -73.99408, 40.75057));
-		mongoTemplate.insert(new Venue("10gen Office", -73.99171, 40.738868));
-		mongoTemplate.insert(new Venue("Flatiron Building", -73.988135, 40.741404));
+		mongoTemplate.insertAll(Arrays.asList(TestEntities.geolocation().pennStation(),
+				TestEntities.geolocation().tenGenOffice(), TestEntities.geolocation().flatironBuilding()));
 
 		mongoTemplate.indexOps(Venue.class).ensureIndex(new GeospatialIndex("location"));
 
@@ -1861,6 +1864,36 @@ public class AggregationTests {
 		// { "_id" : { "min" : 1925-2018 , "max" : 1926} , "count" : 2}]
 		List<Object> categorizeByYear = (List<Object>) mappedResult.get("categorizeByYear");
 		assertThat(categorizeByYear, hasSize(3));
+	}
+
+	@Test // DATAMONGO-1986
+	public void runMatchOperationCriteriaThroughQueryMapperForTypedAggregation() {
+
+		mongoTemplate.insertAll(TestEntities.geolocation().newYork());
+
+		Aggregation aggregation = newAggregation(Venue.class,
+				match(Criteria.where("location")
+						.within(new Box(new Point(-73.99756, 40.73083), new Point(-73.988135, 40.741404)))),
+				project("id", "location", "name"));
+
+		AggregationResults<Document> groupResults = mongoTemplate.aggregate(aggregation, "newyork", Document.class);
+
+		assertThat(groupResults.getMappedResults().size(), is(4));
+	}
+
+	@Test // DATAMONGO-1986
+	public void runMatchOperationCriteriaThroughQueryMapperForUntypedAggregation() {
+
+		mongoTemplate.insertAll(TestEntities.geolocation().newYork());
+
+		Aggregation aggregation = newAggregation(
+				match(Criteria.where("location")
+						.within(new Box(new Point(-73.99756, 40.73083), new Point(-73.988135, 40.741404)))),
+				project("id", "location", "name"));
+
+		AggregationResults<Document> groupResults = mongoTemplate.aggregate(aggregation, "newyork", Document.class);
+
+		assertThat(groupResults.getMappedResults().size(), is(4));
 	}
 
 	private void createUsersWithReferencedPersons() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ReactiveAggregationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ReactiveAggregationUnitTests.java
@@ -62,7 +62,6 @@ public class ReactiveAggregationUnitTests {
 		when(db.getCollection(eq(INPUT_COLLECTION), any(Class.class))).thenReturn(collection);
 		when(collection.aggregate(anyList(), any(Class.class))).thenReturn(publisher);
 		when(publisher.allowDiskUse(any())).thenReturn(publisher);
-		when(publisher.useCursor(any())).thenReturn(publisher);
 		when(publisher.collation(any())).thenReturn(publisher);
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/AbstractGeoSpatialTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/AbstractGeoSpatialTests.java
@@ -38,13 +38,13 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.TestEntities;
 import org.springframework.data.mongodb.core.Venue;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.WriteConcern;
 
@@ -103,19 +103,7 @@ public abstract class AbstractGeoSpatialTests {
 	}
 
 	protected void addVenues() {
-
-		template.insert(new Venue("Penn Station", -73.99408, 40.75057));
-		template.insert(new Venue("10gen Office", -73.99171, 40.738868));
-		template.insert(new Venue("Flatiron Building", -73.988135, 40.741404));
-		template.insert(new Venue("Players Club", -73.997812, 40.739128));
-		template.insert(new Venue("City Bakery ", -73.992491, 40.738673));
-		template.insert(new Venue("Splash Bar", -73.992491, 40.738673));
-		template.insert(new Venue("Momofuku Milk Bar", -73.985839, 40.731698));
-		template.insert(new Venue("Shake Shack", -73.98820, 40.74164));
-		template.insert(new Venue("Penn Station", -73.99408, 40.75057));
-		template.insert(new Venue("Empire State Building", -73.98602, 40.74894));
-		template.insert(new Venue("Ulaanbaatar, Mongolia", 106.9154, 47.9245));
-		template.insert(new Venue("Maplewood, NJ", -74.2713, 40.73137));
+		template.insertAll(TestEntities.geolocation().newYork());
 	}
 
 	@Test


### PR DESCRIPTION
We now initialize a `TypeBasedAggregationOperationContext` for ``TypedAggregation``s no matter what. This makes sure that potential `Criteria` objects are run trough the `QueryMapper`.
In case the default context is used we now also make sure to at least run the aggregation pipeline through the `QueryMapper` to avoid passing on non MongoDB simple types to the drive