### PR TITLE
DATAMONGO-1979 - Add support for @Query(sort = "… 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1979-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
@@ -77,4 +77,22 @@ public @interface Query {
 	 * @return
 	 */
 	boolean delete() default false;
+
+	/**
+	 * Defines a default sort order for the given query.<br />
+	 * <strong>NOTE</strong> The so set defaults can be altered / overwritten via an explicit
+	 * {@link org.springframework.data.domain.Sort} argument of the query method.
+	 *
+	 * <pre>
+	 * <code>
+	 *     
+	 * 		&#64;Query(sort = "{ age : -1 }") // order by age descending
+	 * 		List<Person> findByFirstname(String firstname); 	 
+	 * </code>
+	 * </pre>
+	 *
+	 * @return
+	 * @since 2.1
+	 */
+	String sort() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.query;
 
+import org.bson.Document;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -109,6 +110,7 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 		Query query = createQuery(new ConvertingParameterAccessor(operations.getConverter(), parameterAccessor));
 
 		applyQueryMetaAttributesWhenPresent(query);
+		query = applyAnnotatedDefaultSortIfPresent(query);
 
 		ResultProcessor processor = method.getResultProcessor().withDynamicProjection(parameterAccessor);
 		Class<?> typeToRead = processor.getReturnedType().getTypeToRead();
@@ -175,6 +177,23 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 		}
 
 		return query;
+	}
+
+	/**
+	 * Add a default sort derived from {@link org.springframework.data.mongodb.repository.Query#sort()} to the given
+	 * {@link Query} if present.
+	 *
+	 * @param query the {@link Query} to potentially apply the sort to.
+	 * @return the query with potential default sort applied.
+	 * @since 2.1
+	 */
+	Query applyAnnotatedDefaultSortIfPresent(Query query) {
+
+		if (!method.hasAnnotatedSort()) {
+			return query;
+		}
+
+		return QueryUtils.sneakInDefaultSort(query, Document.parse(method.getAnnotatedSort()));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/QueryUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/QueryUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.query;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.bson.Document;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.data.mongodb.core.query.Query;
+
+/**
+ * Internal utility class to help avoid duplicate code required in both the reactive and the sync {@link Query} support
+ * offered by repositories.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ * @currentRead Assassin's Apprentice - Robin Hobb
+ */
+class QueryUtils {
+
+	/**
+	 * Add a default sort expression to the given Query. Attributes of the given {@code sort} may be overwritten by the
+	 * sort explicitly defined by the {@link Query} itself.
+	 *
+	 * @param query the {@link Query} to decorate.
+	 * @param defaultSort the default sort expression to apply to the query.
+	 * @return the query having the given {@code sort} applied.
+	 */
+	static Query sneakInDefaultSort(Query query, Document defaultSort) {
+
+		if (defaultSort.isEmpty()) {
+			return query;
+		}
+
+		ProxyFactory factory = new ProxyFactory(query);
+		factory.addAdvice((MethodInterceptor) invocation -> {
+
+			if (!invocation.getMethod().getName().equals("getSortObject")) {
+				return invocation.proceed();
+			}
+
+			Document combinedSort = new Document(defaultSort);
+			combinedSort.putAll((Document) invocation.proceed());
+			return combinedSort;
+		});
+
+		return (Query) factory.getProxy();
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -1205,4 +1205,15 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	public void findOptionalSingleEntityThrowsErrorWhenNotUnique() {
 		repository.findOptionalPersonByLastnameLike(dave.getLastname());
 	}
+
+	@Test // DATAMONGO-1979
+	public void findAppliesAnnotatedSort() {
+		assertThat(repository.findByAgeGreaterThan(40)).containsExactly(carter, boyd, dave, leroi);
+	}
+
+	@Test // DATAMONGO-1979
+	public void findWithSortOverwritesAnnotatedSort() {
+		assertThat(repository.findByAgeGreaterThan(40, Sort.by(Direction.ASC, "age"))).containsExactly(leroi, dave, boyd,
+				carter);
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -347,4 +347,10 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 
 	// DATAMONGO-1752
 	Iterable<PersonSummary> findClosedProjectionBy();
+
+	@Query(sort = "{ age : -1 }")
+	List<Person> findByAgeGreaterThan(int age);
+
+	@Query(sort = "{ age : -1 }")
+	List<Person> findByAgeGreaterThan(int age, Sort sort);
 }

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -395,6 +395,36 @@ public interface PersonRepository extends MongoRepository<Person, String>
 
 The query in the preceding example returns only the `firstname`, `lastname` and `Id` properties of the `Person` objects. The `age` property, a `java.lang.Integer`, is not set and its value is therefore null.
 
+[[mongodb.repositories.queries.sort]]
+=== Sorting Query Method results
+
+When it comes to sorting MongoDB query results via the repository interface there are several options as listed below.
+
+.Sorting query results
+====
+[source,java]
+----
+public interface PersonRepository extends MongoRepository<Person, String> {
+
+  List<Person> findByFirstnameSortByAgeDesc(String firstname); <1>
+
+  List<Person> findByFirstname(String firstname, Sort sort);   <2>
+
+  @Query(sort = "{ age : -1 }")
+  List<Person> findByFirstname(String firstname);              <3>
+
+  @Query(sort = "{ age : -1 }")
+  List<Person> findByLastname(String lastname, Sort sort);     <4>
+}
+----
+<1> Fixed sorting derived from method name. `SortByAgeDesc` results in `{ age : -1 }` sort parameter.
+<2> Dynamic sorting via method argument. `Sort.by(DESC, "age")` creates a `{ age : -1 }` sort parameter.
+<3> Fixed sorting via `Query` annotation. Sort parameter applied as stated in the `sort` attribute.
+<4> Default sorting via `Query` annotation combined with dynamic one via method argument. `Sort.unsorted()`
+results in `{ age : -1 }`. Using `Sort.by(ASC, "age")` overrides the defaults and creates `{ age : 1 }`. `Sort.by
+(ASC, "firstname")` alters the default and results in `{ age : -1, firstname : 1 }`.
+====
+
 [[mongodb.repositories.queries.json-spel]]
 === JSON-based Queries with SpEL Expressions
 


### PR DESCRIPTION
We now allow to set a default sort for repository query methods via the `@Query` annotation.

```java
@Query(sort = "{ age : -1 }")
List<Person> findByFirstname(String firstname);
```

Using an explicit `Sort` parameter along with the annotated one allows to alter the defaults set via the annotation. Method argument sort parameters add to / override the annotated defaults.

```java
@Query(sort = "{ age : -1 }")
List<Person> findByFirstname(String firstname, Sort sort);
```