### PR TITLE
DATAMONGO-2001 - Count within session should return only the total count of documents visible to the specific session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ before_install:
   - |-
     downloads/mongodb-linux-x86_64-ubuntu1604-${MONGO_VERSION}/bin/mongo --eval "rs.initiate({_id: 'rs0', members:[{_id: 0, host: '127.0.0.1:27017'}]});"
     sleep 15
-    
+
 env:
   matrix:
     - PROFILE=ci
   global:
-    - MONGO_VERSION=4.0.0-rc3
+    - MONGO_VERSION=4.0.0-rc4
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     - PROFILE=ci
   global:
-    - MONGO_VERSION=4.0.0-rc0
+    - MONGO_VERSION=4.0.0-rc3
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2001-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -67,11 +67,9 @@ import org.springframework.data.mongodb.SessionSynchronization;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.DefaultBulkOperations.BulkOperationContext;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.CountOperation;
 import org.springframework.data.mongodb.core.aggregation.Fields;
 import org.springframework.data.mongodb.core.aggregation.TypeBasedAggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
@@ -107,7 +105,6 @@ import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceResults;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
@@ -3542,49 +3539,25 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		 * @see org.springframework.data.mongodb.core.MongoTemplate#count(org.springframework.data.mongodb.core.query.Query, java.lang.Class, java.lang.String)
 		 */
 		@Override
-		public long count(Query query, @Nullable Class<?> entityClass, String collection) {
+		@SuppressWarnings("unchecked")
+		public long count(Query query, @Nullable Class<?> entityClass, String collectionName) {
 
 			if (!session.hasActiveTransaction()) {
-				return super.count(query, entityClass, collection);
+				return super.count(query, entityClass, collectionName);
 			}
 
-			List<AggregationOperation> pipeline = computeCountAggregationPipeline(query, entityClass);
+			AggregationUtil aggregationUtil = new AggregationUtil(delegate.queryMapper, delegate.mappingContext);
+			Aggregation aggregation = aggregationUtil.createCountAggregation(query, entityClass);
+			AggregationResults<Document> aggregationResults = aggregate(aggregation, collectionName, Document.class);
 
-			Aggregation aggregation = entityClass != null ? Aggregation.newAggregation(entityClass, pipeline)
-					: Aggregation.newAggregation(pipeline);
-			aggregation.withOptions(AggregationOptions.builder().collation(query.getCollation().orElse(null)).build());
+			List<Document> result = (List<Document>) aggregationResults.getRawResults().getOrDefault("results",
+					Collections.singletonList(new Document("totalEntityCount", 0)));
 
-			AggregationResults<Document> aggregationResults = aggregate(aggregation, collection, Document.class);
-			return ((List<Document>) aggregationResults.getRawResults().getOrDefault("results",
-					Collections.singletonList(new Document("totalEntityCount", 0)))).get(0).get("totalEntityCount", Number.class)
-							.longValue();
-		}
-
-		private List<AggregationOperation> computeCountAggregationPipeline(Query query, @Nullable Class<?> entityType) {
-
-			CountOperation count = Aggregation.count().as("totalEntityCount");
-			if (query.getQueryObject().isEmpty()) {
-				return Arrays.asList(count);
+			if (result.isEmpty()) {
+				return 0;
 			}
 
-			Document mappedQuery = delegate.queryMapper.getMappedObject(query.getQueryObject(),
-					delegate.getPersistentEntity(entityType));
-
-			CriteriaDefinition criteria = new CriteriaDefinition() {
-
-				@Override
-				public Document getCriteriaObject() {
-					return mappedQuery;
-				}
-
-				@Nullable
-				@Override
-				public String getKey() {
-					return null;
-				}
-			};
-
-			return Arrays.asList(Aggregation.match(criteria), count);
+			return result.get(0).get("totalEntityCount", Number.class).longValue();
 		}
 	}
 }

--- a/src/main/asciidoc/reference/client-session-transactions.adoc
+++ b/src/main/asciidoc/reference/client-session-transactions.adoc
@@ -127,7 +127,6 @@ template.withSession(session)
             session.abortTransaction();                                 <4>
         }
     }, ClientSession::close)                                            <5>
-    .subscribe();
 ----
 <1> Obtain a new `ClientSession`.
 <2> Start the transaction.
@@ -155,16 +154,16 @@ TransactionTemplate txTemplate = new TransactionTemplate(anyTxManager);         
 
 txTemplate.execute(new TransactionCallbackWithoutResult() {
 
-	@Override
-	protected void doInTransactionWithoutResult(TransactionStatus status) {     <3>
+    @Override
+    protected void doInTransactionWithoutResult(TransactionStatus status) {     <3>
 
-		Step step = // ...;
-		template.insert(step);
+        Step step = // ...;
+        template.insert(step);
 
-		process(step);
+        process(step);
 
-		template.update(Step.class).apply(Update.set("state", // ...
-	};
+    template.update(Step.class).apply(Update.set("state", // ...
+    };
 });
 ----
 <1> Enable transaction synchronization during Template API configuration.
@@ -186,26 +185,26 @@ The `MongoTransactionManager` binds a `ClientSession` to the thread. `MongoTempl
 @Configuration
 static class Config extends AbstractMongoConfiguration {
 
-	@Bean
-	MongoTransactionManager transactionManager(MongoDbFactory dbFactory) {  <1>
-		return new MongoTransactionManager(dbFactory);
-	}
+    @Bean
+    MongoTransactionManager transactionManager(MongoDbFactory dbFactory) {  <1>
+        return new MongoTransactionManager(dbFactory);
+    }
 
-	// ...
+    // ...
 }
 
 @Component
 public class StateService {
 
-	@Transactional
-	void someBusinessFunction(Step step) {                                  <2>
+    @Transactional
+    void someBusinessFunction(Step step) {                                  <2>
 
-		template.insert(step);
+        template.insert(step);
 
-		process(step);
+        process(step);
 
-		template.update(Step.class).apply(Update.set("state", // ...
-	};
+        template.update(Step.class).apply(Update.set("state", // ...
+    };
 });
 
 ----
@@ -230,18 +229,18 @@ Using the plain MongoDB reactive driver API a `delete` within a transactional fl
 [source,java]
 ----
 Mono<DeleteResult> result = Mono
-      .from(client.startSession())                                                              <1>
+    .from(client.startSession())                                                             <1>
 
-      .flatMap(session -> {
-         session.startTransaction();                                                            <2>
+    .flatMap(session -> {
+        session.startTransaction();                                                          <2>
 
-         return Mono.from(collection.deleteMany(session, ...))                                  <3>
+        return Mono.from(collection.deleteMany(session, ...))                                <3>
 
-               .onErrorResume(e -> Mono.from(session.abortTransaction()).then(Mono.error(e)))   <4>
+            .onErrorResume(e -> Mono.from(session.abortTransaction()).then(Mono.error(e)))   <4>
 
-               .flatMap(val -> Mono.from(session.commitTransaction()).then(Mono.just(val)))     <5>
+            .flatMap(val -> Mono.from(session.commitTransaction()).then(Mono.just(val)))     <5>
 
-               .doFinally(signal -> session.close());                                           <6>
+            .doFinally(signal -> session.close());                                           <6>
       });
 ----
 <1> First we obviously need to initiate the session.
@@ -263,9 +262,9 @@ accordingly. This allows you to express the above flow simply as the following:
 ====
 [source,java]
 ----
-Mono<DeleteResult> result = template.inTransaction()                                        <1>
+Mono<DeleteResult> result = template.inTransaction()                                      <1>
 
-      .execute(action -> action.remove(query(where("id").is("step-1")), Step.class));       <2>
+    .execute(action -> action.remove(query(where("id").is("step-1")), Step.class));       <2>
 ----
 <1> Initiate the transaction.
 <2> Operate within the `ClientSession`. Each `execute(…)` unit of work callback initiates a new transaction in the scope of the same `ClientSession`.
@@ -280,20 +279,77 @@ reactive flow of `execute(…)` that are not propagated to outside of the callba
 ====
 [source,java]
 ----
-template.inTransaction()                                                                    <1>
+template.inTransaction()                                                            <1>
 
-	.execute(action -> action.find(query(where("state").is("active")), Step.class)
-	                     .flatMap(step -> action.update(Step.class)
-			                                    .matching(query(where("id").is(step.id)))
-			                                    .apply(update("state", "paused"))
-			                                    .all()))                                    <2>
+    .execute(action -> action.find(query(where("state").is("active")), Step.class)
+        .flatMap(step -> action.update(Step.class)
+            .matching(query(where("id").is(step.id)))
+            .apply(update("state", "paused"))
+            .all()))                                                                <2>
 
-	.flatMap(updated -> {
-		// Exception could happen here                                                      <3>
-	});
+    .flatMap(updated -> {
+        // Exception could happen here                                              <3>
+    });
 ----
 <1> Initiate the managed transaction.
 <2> Operate within the `ClientSession`. The transaction is committed after this is done or rolled back if an
 error occurs here.
 <3> An error outside the transaction flow has no affect on the previous transactional execution.
+====
+
+== Special behavior inside transactions
+
+Inside transactions MongoDB server has a slightly different behavior.
+
+*Connection Settings*
+
+The MongoDB drivers offer a dedicated replica set name configuration option turing the driver into an auto detection
+mode. This option helps identifying replica set master nodes and command routing during a transaction.
+
+INFO: Make sure to add `replicaSet` to the MongoDB Uri. Please refer to https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options[connection string options] for further details.
+
+*Collection Operations*
+
+MongoDB does *not* support collection operations, such as collection creation, within a transaction. This also
+affects the on the fly collection creation that happens on first usage. Therefore make sure to have all required
+structures in place.
+
+*Count*
+
+MongoDB `count` operates upon collection statistics which may not reflect the actual situation within a transaction.
+The server responds with _error 50851_ when issuing a `count` command inside of a multi-document transaction.
+Once `MongoTemplate` detects an active transaction, all exposed `count()` methods are converted and delegated to the
+aggregation framework using `$match` and `$count` operators, preserving `Query` settings, such as `collation`.
+
+====
+The following snippet of `count` inside the session bound closure
+
+[source,javascript]
+----
+session.startTransaction();
+
+template.withSession(session)
+    .execute(action -> {
+        action.count(query(where("state").is("active")), Step.class)
+        ...
+----
+
+runs:
+
+[source,javascript]
+----
+db.collection.aggregate(
+   [
+      { $match: { state: "active" } },
+      { $group: { _id: null, count: { $sum: 1 } } }
+   ]
+)
+----
+
+instead of:
+
+[source,javascript]
+----
+db.collection.find( { state: "active" } ).count()
+----
 ====

--- a/src/main/asciidoc/reference/client-session-transactions.adoc
+++ b/src/main/asciidoc/reference/client-session-transactions.adoc
@@ -215,7 +215,7 @@ public class StateService {
 NOTE: `@Transactional(readOnly = true)` advises `MongoTransactionManager` to also start a transaction that adds the
  `ClientSession` to outgoing requests.
 
-== Reactive transactions
+== Reactive Transactions
 
 Same as with the reactive `ClientSession` support, the `ReactiveMongoTemplate` offers dedicated methods for operating
 within a transaction without having to worry about the commit/abort actions depending on the operations outcome.
@@ -299,14 +299,14 @@ error occurs here.
 
 == Special behavior inside transactions
 
-Inside transactions MongoDB server has a slightly different behavior.
+Inside transactions, MongoDB server has a slightly different behavior.
 
 *Connection Settings*
 
-The MongoDB drivers offer a dedicated replica set name configuration option turing the driver into an auto detection
+The MongoDB drivers offer a dedicated replica set name configuration option turing the driver into auto detection
 mode. This option helps identifying replica set master nodes and command routing during a transaction.
 
-INFO: Make sure to add `replicaSet` to the MongoDB Uri. Please refer to https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options[connection string options] for further details.
+NOTE: Make sure to add `replicaSet` to the MongoDB URI. Please refer to https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options[connection string options] for further details.
 
 *Collection Operations*
 
@@ -321,9 +321,9 @@ The server responds with _error 50851_ when issuing a `count` command inside of 
 Once `MongoTemplate` detects an active transaction, all exposed `count()` methods are converted and delegated to the
 aggregation framework using `$match` and `$count` operators, preserving `Query` settings, such as `collation`.
 
-====
-The following snippet of `count` inside the session bound closure
+The following snippet shows `count` usage inside the session-bound closure:
 
+====
 [source,javascript]
 ----
 session.startTransaction();
@@ -333,21 +333,25 @@ template.withSession(session)
         action.count(query(where("state").is("active")), Step.class)
         ...
 ----
+====
 
-runs:
+The snippet above materializes in the following command:
 
+====
 [source,javascript]
 ----
 db.collection.aggregate(
    [
       { $match: { state: "active" } },
-      { $group: { _id: null, count: { $sum: 1 } } }
+      { $count: "totalEntityCount" }
    ]
 )
 ----
+====
 
 instead of:
 
+====
 [source,javascript]
 ----
 db.collection.find( { state: "active" } ).count()


### PR DESCRIPTION
MongoDB `count` operates upon collection statistics which may not reflect the actual situation within a transaction. Therefore the server (as of _4.0.0-rc3_) responds with _error 50851_ when issuing a `count` command inside of a multi-document transaction.
Once `MongoTemplate` detects an active transaction, all exposed `count(...)` methods delegate to the aggregation framework using `$match` and `$count` operators, preserving `Query` settings, such as `collation`.

The following snippet of `count` inside the session bound closure

```java
session.startTransaction();

template.withSession(session)
    .execute(action -> {
        action.count(query(where("state").is("active")), Step.class)
        ...
```
runs:
```javascript
db.collection.aggregate(
   [
      { $match: { state: "active" } },
      { $group: { _id: null, count: { $sum: 1 } } }
   ]
)
```
instead of:
```javascript
db.collection.find( { state: "active" } ).count()
``` 