### PR TITLE
DATAMONGO-1827 - Add support for findAndReplace.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-1827-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
@@ -54,26 +54,6 @@ public interface ExecutableRemoveOperation {
 	<T> ExecutableRemove<T> remove(Class<T> domainType);
 
 	/**
-	 * Collection override (optional).
-	 *
-	 * @param <T>
-	 * @author Christoph Strobl
-	 * @since 2.0
-	 */
-	interface RemoveWithCollection<T> extends RemoveWithQuery<T> {
-
-		/**
-		 * Explicitly set the name of the collection to perform the query on. <br />
-		 * Skip this step to use the default collection derived from the domain type.
-		 *
-		 * @param collection must not be {@literal null} nor {@literal empty}.
-		 * @return new instance of {@link RemoveWithCollection}.
-		 * @throws IllegalArgumentException if collection is {@literal null}.
-		 */
-		RemoveWithQuery<T> inCollection(String collection);
-	}
-
-	/**
 	 * @author Christoph Strobl
 	 * @since 2.0
 	 */
@@ -103,6 +83,27 @@ public interface ExecutableRemoveOperation {
 		 */
 		List<T> findAndRemove();
 	}
+
+	/**
+	 * Collection override (optional).
+	 *
+	 * @param <T>
+	 * @author Christoph Strobl
+	 * @since 2.0
+	 */
+	interface RemoveWithCollection<T> extends RemoveWithQuery<T> {
+
+		/**
+		 * Explicitly set the name of the collection to perform the query on. <br />
+		 * Skip this step to use the default collection derived from the domain type.
+		 *
+		 * @param collection must not be {@literal null} nor {@literal empty}.
+		 * @return new instance of {@link RemoveWithCollection}.
+		 * @throws IllegalArgumentException if collection is {@literal null}.
+		 */
+		RemoveWithQuery<T> inCollection(String collection);
+	}
+
 
 	/**
 	 * @author Christoph Strobl

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
@@ -19,12 +19,12 @@ import java.util.Optional;
 
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
-
-import com.mongodb.client.result.UpdateResult;
 import org.springframework.lang.Nullable;
 
+import com.mongodb.client.result.UpdateResult;
+
 /**
- * {@link ExecutableUpdateOperation} allows creation and execution of MongoDB update / findAndModify operations in a
+ * {@link ExecutableUpdateOperation} allows creation and execution of MongoDB update / findAndModify / findAndReplace operations in a
  * fluent API style. <br />
  * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching}, as well as
  * the {@link Update} via {@code apply} into the MongoDB specific representations. The collection to operate on is by
@@ -73,6 +73,16 @@ public interface ExecutableUpdateOperation {
 		 * @throws IllegalArgumentException if update is {@literal null}.
 		 */
 		TerminatingUpdate<T> apply(Update update);
+
+		/**
+		 * Specify {@code replacement} object.
+		 *
+		 * @param replacement must not be {@literal null}.
+		 * @return new instance of {@link FindAndReplaceOptions}.
+		 * @throws IllegalArgumentException if options is {@literal null}.
+		 * 2.1
+		 */
+		FindAndReplaceWithOptions<T> replaceWith(T replacement);
 	}
 
 	/**
@@ -151,6 +161,47 @@ public interface ExecutableUpdateOperation {
 		 */
 		@Nullable
 		T findAndModifyValue();
+	}
+
+	/**
+	 * Define {@link FindAndReplaceOptions}.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	interface FindAndReplaceWithOptions<T> extends TerminatingFindAndReplace<T> {
+
+		/**
+		 * Explicitly define {@link FindAndReplaceOptions} for the {@link Update}.
+		 *
+		 * @param options must not be {@literal null}.
+		 * @return new instance of {@link FindAndReplaceOptions}.
+		 * @throws IllegalArgumentException if options is {@literal null}.
+		 */
+		TerminatingFindAndReplace<T> withOptions(FindAndReplaceOptions options);
+	}
+
+	/**
+	 * Trigger findAndReplace execution by calling one of the terminating methods.
+	 */
+	interface TerminatingFindAndReplace<T> {
+
+		/**
+		 * Find, replace and return the first matching document.
+		 *
+		 * @return {@link Optional#empty()} if nothing found.
+		 */
+		default Optional<T> findAndReplace() {
+			return Optional.ofNullable(findAndReplaceValue());
+		}
+
+		/**
+		 * Find, replace and return the first matching document.
+		 *
+		 * @return {@literal null} if nothing found.
+		 */
+		@Nullable
+		T findAndReplaceValue();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
@@ -58,6 +58,82 @@ public interface ExecutableUpdateOperation {
 	<T> ExecutableUpdate<T> update(Class<T> domainType);
 
 	/**
+	 * Trigger findAndModify execution by calling one of the terminating methods.
+	 */
+	interface TerminatingFindAndModify<T> {
+
+		/**
+		 * Find, modify and return the first matching document.
+		 *
+		 * @return {@link Optional#empty()} if nothing found.
+		 */
+		default Optional<T> findAndModify() {
+			return Optional.ofNullable(findAndModifyValue());
+		}
+
+		/**
+		 * Find, modify and return the first matching document.
+		 *
+		 * @return {@literal null} if nothing found.
+		 */
+		@Nullable
+		T findAndModifyValue();
+	}
+
+	/**
+	 * Trigger findAndReplace execution by calling one of the terminating methods.
+	 */
+	interface TerminatingFindAndReplace<T> {
+
+		/**
+		 * Find, replace and return the first matching document.
+		 *
+		 * @return {@link Optional#empty()} if nothing found.
+		 */
+		default Optional<T> findAndReplace() {
+			return Optional.ofNullable(findAndReplaceValue());
+		}
+
+		/**
+		 * Find, replace and return the first matching document.
+		 *
+		 * @return {@literal null} if nothing found.
+		 */
+		@Nullable
+		T findAndReplaceValue();
+	}
+
+	/**
+	 * Trigger update execution by calling one of the terminating methods.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.0
+	 */
+	interface TerminatingUpdate<T> extends TerminatingFindAndModify<T>, FindAndModifyWithOptions<T> {
+
+		/**
+		 * Update all matching documents in the collection.
+		 *
+		 * @return never {@literal null}.
+		 */
+		UpdateResult all();
+
+		/**
+		 * Update the first document in the collection.
+		 *
+		 * @return never {@literal null}.
+		 */
+		UpdateResult first();
+
+		/**
+		 * Creates a new document if no documents match the filter query or updates the matching ones.
+		 *
+		 * @return never {@literal null}.
+		 */
+		UpdateResult upsert();
+	}
+
+	/**
 	 * Declare the {@link Update} to apply.
 	 *
 	 * @author Christoph Strobl
@@ -80,7 +156,7 @@ public interface ExecutableUpdateOperation {
 		 * @param replacement must not be {@literal null}.
 		 * @return new instance of {@link FindAndReplaceOptions}.
 		 * @throws IllegalArgumentException if options is {@literal null}.
-		 * 2.1
+		 * @since 2.1
 		 */
 		FindAndReplaceWithOptions<T> replaceWith(T replacement);
 	}
@@ -141,29 +217,6 @@ public interface ExecutableUpdateOperation {
 	}
 
 	/**
-	 * Trigger findAndModify execution by calling one of the terminating methods.
-	 */
-	interface TerminatingFindAndModify<T> {
-
-		/**
-		 * Find, modify and return the first matching document.
-		 *
-		 * @return {@link Optional#empty()} if nothing found.
-		 */
-		default Optional<T> findAndModify() {
-			return Optional.ofNullable(findAndModifyValue());
-		}
-
-		/**
-		 * Find, modify and return the first matching document.
-		 *
-		 * @return {@literal null} if nothing found.
-		 */
-		@Nullable
-		T findAndModifyValue();
-	}
-
-	/**
 	 * Define {@link FindAndReplaceOptions}.
 	 *
 	 * @author Mark Paluch
@@ -179,59 +232,6 @@ public interface ExecutableUpdateOperation {
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 */
 		TerminatingFindAndReplace<T> withOptions(FindAndReplaceOptions options);
-	}
-
-	/**
-	 * Trigger findAndReplace execution by calling one of the terminating methods.
-	 */
-	interface TerminatingFindAndReplace<T> {
-
-		/**
-		 * Find, replace and return the first matching document.
-		 *
-		 * @return {@link Optional#empty()} if nothing found.
-		 */
-		default Optional<T> findAndReplace() {
-			return Optional.ofNullable(findAndReplaceValue());
-		}
-
-		/**
-		 * Find, replace and return the first matching document.
-		 *
-		 * @return {@literal null} if nothing found.
-		 */
-		@Nullable
-		T findAndReplaceValue();
-	}
-
-	/**
-	 * Trigger update execution by calling one of the terminating methods.
-	 *
-	 * @author Christoph Strobl
-	 * @since 2.0
-	 */
-	interface TerminatingUpdate<T> extends TerminatingFindAndModify<T>, FindAndModifyWithOptions<T> {
-
-		/**
-		 * Update all matching documents in the collection.
-		 *
-		 * @return never {@literal null}.
-		 */
-		UpdateResult all();
-
-		/**
-		 * Update the first document in the collection.
-		 *
-		 * @return never {@literal null}.
-		 */
-		UpdateResult first();
-
-		/**
-		 * Creates a new document if no documents match the filter query or updates the matching ones.
-		 *
-		 * @return never {@literal null}.
-		 */
-		UpdateResult upsert();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
@@ -24,8 +24,8 @@ import org.springframework.lang.Nullable;
 import com.mongodb.client.result.UpdateResult;
 
 /**
- * {@link ExecutableUpdateOperation} allows creation and execution of MongoDB update / findAndModify / findAndReplace operations in a
- * fluent API style. <br />
+ * {@link ExecutableUpdateOperation} allows creation and execution of MongoDB update / findAndModify / findAndReplace
+ * operations in a fluent API style. <br />
  * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching}, as well as
  * the {@link Update} via {@code apply} into the MongoDB specific representations. The collection to operate on is by
  * default derived from the initial {@literal domainType} and can be defined there via
@@ -59,6 +59,10 @@ public interface ExecutableUpdateOperation {
 
 	/**
 	 * Trigger findAndModify execution by calling one of the terminating methods.
+	 *
+	 * @author Christoph Strobl
+	 * @author Mark Paluch
+	 * @since 2.0
 	 */
 	interface TerminatingFindAndModify<T> {
 
@@ -81,7 +85,12 @@ public interface ExecutableUpdateOperation {
 	}
 
 	/**
-	 * Trigger findAndReplace execution by calling one of the terminating methods.
+	 * Trigger
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * execution by calling one of the terminating methods.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.1
 	 */
 	interface TerminatingFindAndReplace<T> {
 
@@ -158,7 +167,7 @@ public interface ExecutableUpdateOperation {
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 * @since 2.1
 		 */
-		FindAndReplaceWithOptions<T> replaceWith(T replacement);
+		FindAndReplaceWithProjection<T> replaceWith(T replacement);
 	}
 
 	/**
@@ -220,6 +229,7 @@ public interface ExecutableUpdateOperation {
 	 * Define {@link FindAndReplaceOptions}.
 	 *
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 * @since 2.1
 	 */
 	interface FindAndReplaceWithOptions<T> extends TerminatingFindAndReplace<T> {
@@ -231,7 +241,28 @@ public interface ExecutableUpdateOperation {
 		 * @return new instance of {@link FindAndReplaceOptions}.
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 */
-		TerminatingFindAndReplace<T> withOptions(FindAndReplaceOptions options);
+		FindAndReplaceWithProjection<T> withOptions(FindAndReplaceOptions options);
+	}
+
+	/**
+	 * Result type override (Optional).
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.1
+	 */
+	interface FindAndReplaceWithProjection<T> extends FindAndReplaceWithOptions<T> {
+
+		/**
+		 * Define the target type fields should be mapped to. <br />
+		 * Skip this step if you are anyway only interested in the original domain type.
+		 *
+		 * @param resultType must not be {@literal null}.
+		 * @param <R> result type.
+		 * @return new instance of {@link FindAndReplaceWithProjection}.
+		 * @throws IllegalArgumentException if resultType is {@literal null}.
+		 */
+		<R> FindAndReplaceWithOptions<R> as(Class<R> resultType);
+
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndModifyOptions.java
@@ -36,15 +36,17 @@ public class FindAndModifyOptions {
 	/**
 	 * Static factory method to create a FindAndModifyOptions instance
 	 *
-	 * @return a new instance
+	 * @return new instance of {@link FindAndModifyOptions}.
 	 */
 	public static FindAndModifyOptions options() {
 		return new FindAndModifyOptions();
 	}
 
 	/**
-	 * @param options
-	 * @return
+	 * Create new {@link FindAndModifyOptions} based on option of given {@litearl source}.
+	 * 
+	 * @param source can be {@literal null}.
+	 * @return new instance of {@link FindAndModifyOptions}.
 	 * @since 2.0
 	 */
 	public static FindAndModifyOptions of(@Nullable FindAndModifyOptions source) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndReplaceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndReplaceOptions.java
@@ -15,16 +15,20 @@
  */
 package org.springframework.data.mongodb.core;
 
-import java.util.Optional;
-
-import org.springframework.data.mongodb.core.query.Collation;
-import org.springframework.lang.Nullable;
-
 /**
  * Options for
  * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>.
+ * <br />
+ * Defaults to
+ * <dl>
+ * <dt>returnNew</dt>
+ * <dd>false</dd>
+ * <dt>upsert</dt>
+ * <dd>false</dd>
+ * </dl>
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  */
 public class FindAndReplaceOptions {
@@ -32,73 +36,74 @@ public class FindAndReplaceOptions {
 	private boolean returnNew;
 	private boolean upsert;
 
-	private @Nullable Collation collation;
-
 	/**
 	 * Static factory method to create a {@link FindAndReplaceOptions} instance.
+	 * <dl>
+	 * <dt>returnNew</dt>
+	 * <dd>false</dd>
+	 * <dt>upsert</dt>
+	 * <dd>false</dd>
+	 * </dl>
 	 *
-	 * @return a new instance
+	 * @return new instance of {@link FindAndReplaceOptions}.
 	 */
 	public static FindAndReplaceOptions options() {
 		return new FindAndReplaceOptions();
 	}
 
 	/**
-	 * @param options
-	 * @return
+	 * Static factory method to create a {@link FindAndReplaceOptions} instance with
+	 * <dl>
+	 * <dt>returnNew</dt>
+	 * <dd>false</dd>
+	 * <dt>upsert</dt>
+	 * <dd>false</dd>
+	 * </dl>
+	 *
+	 * @return new instance of {@link FindAndReplaceOptions}.
 	 */
-	public static FindAndReplaceOptions of(@Nullable FindAndReplaceOptions source) {
-
-		FindAndReplaceOptions options = new FindAndReplaceOptions();
-
-		if (source == null) {
-			return options;
-		}
-
-		options.returnNew = source.returnNew;
-		options.upsert = source.upsert;
-		options.collation = source.collation;
-
-		return options;
+	public static FindAndReplaceOptions empty() {
+		return new FindAndReplaceOptions();
 	}
 
-	public FindAndReplaceOptions returnNew(boolean returnNew) {
-		this.returnNew = returnNew;
-		return this;
-	}
+	/**
+	 * Return the replacement document.
+	 *
+	 * @return this.
+	 */
+	public FindAndReplaceOptions returnNew() {
 
-	public FindAndReplaceOptions upsert(boolean upsert) {
-		this.upsert = upsert;
+		this.returnNew = true;
 		return this;
 	}
 
 	/**
-	 * Define the {@link Collation} specifying language-specific rules for string comparison.
+	 * Insert a new document if not exists.
 	 *
-	 * @param collation
-	 * @return
+	 * @return this.
 	 */
-	public FindAndReplaceOptions collation(@Nullable Collation collation) {
+	public FindAndReplaceOptions upsert() {
 
-		this.collation = collation;
+		this.upsert = true;
 		return this;
 	}
 
+	/**
+	 * Get the bit indicating to return the replacement document.
+	 *
+	 * @return
+	 */
 	public boolean isReturnNew() {
 		return returnNew;
 	}
 
-	public boolean isUpsert() {
-		return upsert;
-	}
-
 	/**
-	 * Get the {@link Collation} specifying language-specific rules for string comparison.
+	 * Get the bit indicating if to create a new document if not exists.
 	 *
 	 * @return
 	 */
-	public Optional<Collation> getCollation() {
-		return Optional.ofNullable(collation);
+	public boolean isUpsert() {
+		return upsert;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndReplaceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/FindAndReplaceOptions.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.lang.Nullable;
+
+/**
+ * Options for
+ * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class FindAndReplaceOptions {
+
+	private boolean returnNew;
+	private boolean upsert;
+
+	private @Nullable Collation collation;
+
+	/**
+	 * Static factory method to create a {@link FindAndReplaceOptions} instance.
+	 *
+	 * @return a new instance
+	 */
+	public static FindAndReplaceOptions options() {
+		return new FindAndReplaceOptions();
+	}
+
+	/**
+	 * @param options
+	 * @return
+	 */
+	public static FindAndReplaceOptions of(@Nullable FindAndReplaceOptions source) {
+
+		FindAndReplaceOptions options = new FindAndReplaceOptions();
+
+		if (source == null) {
+			return options;
+		}
+
+		options.returnNew = source.returnNew;
+		options.upsert = source.upsert;
+		options.collation = source.collation;
+
+		return options;
+	}
+
+	public FindAndReplaceOptions returnNew(boolean returnNew) {
+		this.returnNew = returnNew;
+		return this;
+	}
+
+	public FindAndReplaceOptions upsert(boolean upsert) {
+		this.upsert = upsert;
+		return this;
+	}
+
+	/**
+	 * Define the {@link Collation} specifying language-specific rules for string comparison.
+	 *
+	 * @param collation
+	 * @return
+	 */
+	public FindAndReplaceOptions collation(@Nullable Collation collation) {
+
+		this.collation = collation;
+		return this;
+	}
+
+	public boolean isReturnNew() {
+		return returnNew;
+	}
+
+	public boolean isUpsert() {
+		return upsert;
+	}
+
+	/**
+	 * Get the {@link Collation} specifying language-specific rules for string comparison.
+	 *
+	 * @return
+	 */
+	public Optional<Collation> getCollation() {
+		return Optional.ofNullable(collation);
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -895,6 +895,98 @@ public interface MongoOperations extends FluentMongoOperations {
 			String collectionName);
 
 	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@literal null}, if not found.
+	 * @since 2.1
+	 */
+	@Nullable
+	default <T> T findAndReplace(Query query, T replacement) {
+		return findAndReplace(query, replacement, FindAndReplaceOptions.options());
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@literal null}, if not found.
+	 * @since 2.1
+	 */
+	@Nullable
+	default <T> T findAndReplace(Query query, T replacement, String collectionName) {
+		return findAndReplace(query, replacement, FindAndReplaceOptions.options(), collectionName);
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@literal null}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	@Nullable
+	<T> T findAndReplace(Query query, T replacement, FindAndReplaceOptions options);
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@literal null}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	@Nullable
+	<T> T findAndReplace(Query query, T replacement, FindAndReplaceOptions options, String collectionName);
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @param entityClass the parametrized type. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@literal null}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	@Nullable
+	<T> T findAndReplace(Query query, T replacement, FindAndReplaceOptions options, Class<T> entityClass,
+			String collectionName);
+
+	/**
 	 * Map the results of an ad-hoc query on the collection for the entity type to a single instance of an object of the
 	 * specified type. The first document that matches the query is returned and also removed from the collection in the
 	 * database.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -182,7 +182,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 	static {
 
-		Set<String> iterableClasses = new HashSet<String>();
+		Set<String> iterableClasses = new HashSet<>();
 		iterableClasses.add(List.class.getName());
 		iterableClasses.add(Collection.class.getName());
 		iterableClasses.add(Iterator.class.getName());
@@ -418,7 +418,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				FindIterable<Document> cursor = new QueryCursorPreparer(query, entityType)
 						.prepare(collection.find(mappedQuery, Document.class).projection(mappedFields));
 
-				return new CloseableIterableCursorAdapter<T>(cursor, exceptionTranslator,
+				return new CloseableIterableCursorAdapter<>(cursor, exceptionTranslator,
 						new ProjectingReadCallback<>(mongoConverter, entityType, returnType, collectionName));
 			}
 		});
@@ -998,9 +998,9 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		List<Object> results = (List<Object>) commandResult.get("results");
 		results = results == null ? Collections.emptyList() : results;
 
-		DocumentCallback<GeoResult<T>> callback = new GeoNearResultDocumentCallback<T>(
+		DocumentCallback<GeoResult<T>> callback = new GeoNearResultDocumentCallback<>(
 				new ProjectingReadCallback<>(mongoConverter, domainType, returnType, collectionName), near.getMetric());
-		List<GeoResult<T>> result = new ArrayList<GeoResult<T>>(results.size());
+		List<GeoResult<T>> result = new ArrayList<>(results.size());
 
 		int index = 0;
 		long elementsToSkip = near.getSkip() != null ? near.getSkip() : 0;
@@ -1021,11 +1021,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (elementsToSkip > 0) {
 			// as we skipped some elements we have to calculate the averageDistance ourselves:
-			return new GeoResults<T>(result, near.getMetric());
+			return new GeoResults<>(result, near.getMetric());
 		}
 
 		GeoCommandStatistics stats = GeoCommandStatistics.from(commandResult);
-		return new GeoResults<T>(result, new Distance(stats.getAverageDistance(), near.getMetric()));
+		return new GeoResults<>(result, new Distance(stats.getAverageDistance(), near.getMetric()));
 	}
 
 	@Nullable
@@ -1261,16 +1261,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	protected <T> void doInsert(String collectionName, T objectToSave, MongoWriter<T> writer) {
 
 		initializeVersionProperty(objectToSave);
-		maybeEmitEvent(new BeforeConvertEvent<T>(objectToSave, collectionName));
+		maybeEmitEvent(new BeforeConvertEvent<>(objectToSave, collectionName));
 		assertUpdateableIdIfNotSet(objectToSave);
 
 		Document dbDoc = toDocument(objectToSave, writer);
 
-		maybeEmitEvent(new BeforeSaveEvent<T>(objectToSave, dbDoc, collectionName));
+		maybeEmitEvent(new BeforeSaveEvent<>(objectToSave, dbDoc, collectionName));
 		Object id = insertDocument(collectionName, dbDoc, objectToSave.getClass());
 
 		populateIdIfNecessary(objectToSave, id);
-		maybeEmitEvent(new AfterSaveEvent<T>(objectToSave, dbDoc, collectionName));
+		maybeEmitEvent(new AfterSaveEvent<>(objectToSave, dbDoc, collectionName));
 	}
 
 	/**
@@ -1343,7 +1343,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 	protected <T> void doInsertAll(Collection<? extends T> listToSave, MongoWriter<T> writer) {
 
-		Map<String, List<T>> elementsByCollection = new HashMap<String, List<T>>();
+		Map<String, List<T>> elementsByCollection = new HashMap<>();
 
 		for (T element : listToSave) {
 
@@ -1357,7 +1357,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			List<T> collectionElements = elementsByCollection.get(collection);
 
 			if (null == collectionElements) {
-				collectionElements = new ArrayList<T>();
+				collectionElements = new ArrayList<>();
 				elementsByCollection.put(collection, collectionElements);
 			}
 
@@ -1373,15 +1373,15 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Assert.notNull(writer, "MongoWriter must not be null!");
 
-		List<Document> documentList = new ArrayList<Document>();
+		List<Document> documentList = new ArrayList<>();
 		for (T o : batchToSave) {
 
 			initializeVersionProperty(o);
-			maybeEmitEvent(new BeforeConvertEvent<T>(o, collectionName));
+			maybeEmitEvent(new BeforeConvertEvent<>(o, collectionName));
 
 			Document document = toDocument(o, writer);
 
-			maybeEmitEvent(new BeforeSaveEvent<T>(o, document, collectionName));
+			maybeEmitEvent(new BeforeSaveEvent<>(o, document, collectionName));
 			documentList.add(document);
 		}
 
@@ -1391,7 +1391,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		for (T obj : batchToSave) {
 			if (i < ids.size()) {
 				populateIdIfNecessary(obj, ids.get(i));
-				maybeEmitEvent(new AfterSaveEvent<T>(obj, documentList.get(i), collectionName));
+				maybeEmitEvent(new AfterSaveEvent<>(obj, documentList.get(i), collectionName));
 			}
 			i++;
 		}
@@ -1433,14 +1433,14 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			// Bump version number
 			convertingAccessor.setProperty(property, number.longValue() + 1);
 
-			maybeEmitEvent(new BeforeConvertEvent<T>(objectToSave, collectionName));
+			maybeEmitEvent(new BeforeConvertEvent<>(objectToSave, collectionName));
 			assertUpdateableIdIfNotSet(objectToSave);
 
 			Document document = new Document();
 
 			this.mongoConverter.write(objectToSave, document);
 
-			maybeEmitEvent(new BeforeSaveEvent<T>(objectToSave, document, collectionName));
+			maybeEmitEvent(new BeforeSaveEvent<>(objectToSave, document, collectionName));
 			Update update = Update.fromDocument(document, ID_FIELD);
 
 			// Create query for entity with the id and old version
@@ -1455,7 +1455,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 						String.format("Cannot save entity %s with version %s to collection %s. Has it been modified meanwhile?", id,
 								number, collectionName));
 			}
-			maybeEmitEvent(new AfterSaveEvent<T>(objectToSave, document, collectionName));
+			maybeEmitEvent(new AfterSaveEvent<>(objectToSave, document, collectionName));
 
 			return objectToSave;
 		}
@@ -1466,16 +1466,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 	protected <T> T doSave(String collectionName, T objectToSave, MongoWriter<T> writer) {
 
-		maybeEmitEvent(new BeforeConvertEvent<T>(objectToSave, collectionName));
+		maybeEmitEvent(new BeforeConvertEvent<>(objectToSave, collectionName));
 		assertUpdateableIdIfNotSet(objectToSave);
 
 		Document dbDoc = toDocument(objectToSave, writer);
 
-		maybeEmitEvent(new BeforeSaveEvent<T>(objectToSave, dbDoc, collectionName));
+		maybeEmitEvent(new BeforeSaveEvent<>(objectToSave, dbDoc, collectionName));
 		Object id = saveDocument(collectionName, dbDoc, objectToSave.getClass());
 
 		populateIdIfNecessary(objectToSave, id);
-		maybeEmitEvent(new AfterSaveEvent<T>(objectToSave, dbDoc, collectionName));
+		maybeEmitEvent(new AfterSaveEvent<>(objectToSave, dbDoc, collectionName));
 
 		return objectToSave;
 	}
@@ -1757,7 +1757,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Iterator<?> it = objects.iterator();
 		Pair<String, Object> pair = extractIdPropertyAndValue(it.next());
 
-		ArrayList<Object> ids = new ArrayList<Object>(objects.size());
+		ArrayList<Object> ids = new ArrayList<>(objects.size());
 		ids.add(pair.getSecond());
 
 		while (it.hasNext()) {
@@ -1819,7 +1819,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			public DeleteResult doInCollection(MongoCollection<Document> collection)
 					throws MongoException, DataAccessException {
 
-				maybeEmitEvent(new BeforeDeleteEvent<T>(queryObject, entityClass, collectionName));
+				maybeEmitEvent(new BeforeDeleteEvent<>(queryObject, entityClass, collectionName));
 
 				Document removeQuery = queryObject;
 
@@ -1855,7 +1855,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				DeleteResult result = multi ? collectionToUse.deleteMany(removeQuery, options)
 						: collection.deleteOne(removeQuery, options);
 
-				maybeEmitEvent(new AfterDeleteEvent<T>(queryObject, entityClass, collectionName));
+				maybeEmitEvent(new AfterDeleteEvent<>(queryObject, entityClass, collectionName));
 
 				return result;
 			}
@@ -1870,7 +1870,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	@Override
 	public <T> List<T> findAll(Class<T> entityClass, String collectionName) {
 		return executeFindMultiInternal(new FindCallback(new Document(), new Document()), null,
-				new ReadDocumentCallback<T>(mongoConverter, entityClass, collectionName), collectionName);
+				new ReadDocumentCallback<>(mongoConverter, entityClass, collectionName), collectionName);
 	}
 
 	@Override
@@ -2032,14 +2032,14 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		@SuppressWarnings("unchecked")
 		Iterable<Document> resultSet = (Iterable<Document>) commandResult.get("retval");
-		List<T> mappedResults = new ArrayList<T>();
-		DocumentCallback<T> callback = new ReadDocumentCallback<T>(mongoConverter, entityClass, inputCollectionName);
+		List<T> mappedResults = new ArrayList<>();
+		DocumentCallback<T> callback = new ReadDocumentCallback<>(mongoConverter, entityClass, inputCollectionName);
 
 		for (Document resultDocument : resultSet) {
 			mappedResults.add(callback.doWith(resultDocument));
 		}
 
-		return new GroupByResults<T>(mappedResults, commandResult);
+		return new GroupByResults<>(mappedResults, commandResult);
 	}
 
 	/* (non-Javadoc)
@@ -2359,7 +2359,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	public Set<String> getCollectionNames() {
 		return execute(new DbCallback<Set<String>>() {
 			public Set<String> doInDB(MongoDatabase db) throws MongoException, DataAccessException {
-				Set<String> result = new LinkedHashSet<String>();
+				Set<String> result = new LinkedHashSet<>();
 				for (String name : db.listCollectionNames()) {
 					result.add(name);
 				}
@@ -2465,7 +2465,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		}
 
 		return executeFindOneInternal(new FindOneCallback(mappedQuery, mappedFields),
-				new ReadDocumentCallback<T>(this.mongoConverter, entityClass, collectionName), collectionName);
+				new ReadDocumentCallback<>(this.mongoConverter, entityClass, collectionName), collectionName);
 	}
 
 	/**
@@ -2480,7 +2480,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 */
 	protected <T> List<T> doFind(String collectionName, Document query, Document fields, Class<T> entityClass) {
 		return doFind(collectionName, query, fields, entityClass, null,
-				new ReadDocumentCallback<T>(this.mongoConverter, entityClass, collectionName));
+				new ReadDocumentCallback<>(this.mongoConverter, entityClass, collectionName));
 	}
 
 	/**
@@ -2499,7 +2499,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	protected <T> List<T> doFind(String collectionName, Document query, Document fields, Class<T> entityClass,
 			CursorPreparer preparer) {
 		return doFind(collectionName, query, fields, entityClass, preparer,
-				new ReadDocumentCallback<T>(mongoConverter, entityClass, collectionName));
+				new ReadDocumentCallback<>(mongoConverter, entityClass, collectionName));
 	}
 
 	protected <S, T> List<T> doFind(String collectionName, Document query, Document fields, Class<S> entityClass,
@@ -2631,7 +2631,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		return executeFindOneInternal(
 				new FindAndRemoveCallback(queryMapper.getMappedObject(query, entity), fields, sort, collation),
-				new ReadDocumentCallback<T>(readerToUse, entityClass, collectionName), collectionName);
+				new ReadDocumentCallback<>(readerToUse, entityClass, collectionName), collectionName);
 	}
 
 	protected <T> T doFindAndModify(String collectionName, Document query, Document fields, Document sort,
@@ -2658,7 +2658,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		}
 
 		return executeFindOneInternal(new FindAndModifyCallback(mappedQuery, fields, sort, mappedUpdate, options),
-				new ReadDocumentCallback<T>(readerToUse, entityClass, collectionName), collectionName);
+				new ReadDocumentCallback<>(readerToUse, entityClass, collectionName), collectionName);
 	}
 
 	protected <T> T doFindAndReplace(String collectionName, Document query, Document fields, Document sort,
@@ -2684,7 +2684,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		maybeEmitEvent(new BeforeSaveEvent<>(replacement, dbDoc, collectionName));
 
 		return executeFindOneInternal(new FindAndReplaceCallback(mappedQuery, fields, sort, dbDoc, options),
-				new ReadDocumentCallback<T>(readerToUse, entityClass, collectionName), collectionName);
+				new ReadDocumentCallback<>(readerToUse, entityClass, collectionName), collectionName);
 	}
 
 	/**
@@ -2795,7 +2795,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 				cursor = iterable.iterator();
 
-				List<T> result = new ArrayList<T>();
+				List<T> result = new ArrayList<>();
 
 				while (cursor.hasNext()) {
 					Document object = cursor.next();
@@ -3168,13 +3168,13 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		public T doWith(@Nullable Document object) {
 
 			if (null != object) {
-				maybeEmitEvent(new AfterLoadEvent<T>(object, type, collectionName));
+				maybeEmitEvent(new AfterLoadEvent<>(object, type, collectionName));
 			}
 
 			T source = reader.read(type, object);
 
 			if (null != source) {
-				maybeEmitEvent(new AfterConvertEvent<T>(object, source, collectionName));
+				maybeEmitEvent(new AfterConvertEvent<>(object, source, collectionName));
 			}
 
 			return source;
@@ -3213,7 +3213,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					: targetType;
 
 			if (null != object) {
-				maybeEmitEvent(new AfterLoadEvent<T>(object, targetType, collectionName));
+				maybeEmitEvent(new AfterLoadEvent<>(object, targetType, collectionName));
 			}
 
 			Object source = reader.read(typeToRead, object);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -689,6 +689,93 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 			String collectionName);
 
 	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@link Mono#empty()}, if not found.
+	 * @since 2.1
+	 */
+	default <T> Mono<T> findAndReplace(Query query, T replacement) {
+		return findAndReplace(query, replacement, FindAndReplaceOptions.options());
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@link Mono#empty()}, if not found.
+	 * @since 2.1
+	 */
+	default <T> Mono<T> findAndReplace(Query query, T replacement, String collectionName) {
+		return findAndReplace(query, replacement, FindAndReplaceOptions.options(), collectionName);
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@link Mono#empty()}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	<T> Mono<T> findAndReplace(Query query, T replacement, FindAndReplaceOptions options);
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@link Mono#empty()}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	<T> Mono<T> findAndReplace(Query query, T replacement, FindAndReplaceOptions options, String collectionName);
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/">findOneAndReplace<a/>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link FindAndReplaceOptions} into account.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @param entityClass the parametrized type. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the converted object that was updated or {@link Mono#empty()}, if not found. Depending on the value of
+	 *         {@link FindAndReplaceOptions#isReturnNew()} this will either be the object as it was before the update or
+	 *         as it is after the update.
+	 * @since 2.1
+	 */
+	<T> Mono<T> findAndReplace(Query query, T replacement, FindAndReplaceOptions options, Class<T> entityClass,
+			String collectionName);
+
+	/**
 	 * Map the results of an ad-hoc query on the collection for the entity type to a single instance of an object of the
 	 * specified type. The first document that matches the query is returned and also removed from the collection in the
 	 * database.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
@@ -72,6 +72,7 @@ public interface ReactiveUpdateOperation {
 	/**
 	 * Compose findAndReplace execution by calling one of the terminating methods.
 	 *
+	 * @author Mark Paluch
 	 * @since 2.1
 	 */
 	interface TerminatingFindAndReplace<T> {
@@ -133,7 +134,7 @@ public interface ReactiveUpdateOperation {
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 * @since 2.1
 		 */
-		FindAndReplaceWithOptions<T> replaceWith(T replacement);
+		FindAndReplaceWithProjection<T> replaceWith(T replacement);
 	}
 
 	/**
@@ -187,6 +188,7 @@ public interface ReactiveUpdateOperation {
 	 * Define {@link FindAndReplaceOptions}.
 	 *
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 * @since 2.1
 	 */
 	interface FindAndReplaceWithOptions<T> extends TerminatingFindAndReplace<T> {
@@ -198,7 +200,28 @@ public interface ReactiveUpdateOperation {
 		 * @return new instance of {@link FindAndReplaceOptions}.
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 */
-		TerminatingFindAndReplace<T> withOptions(FindAndReplaceOptions options);
+		FindAndReplaceWithProjection<T> withOptions(FindAndReplaceOptions options);
+	}
+
+	/**
+	 * Result type override (Optional).
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.1
+	 */
+	interface FindAndReplaceWithProjection<T> extends FindAndReplaceWithOptions<T> {
+
+		/**
+		 * Define the target type fields should be mapped to. <br />
+		 * Skip this step if you are anyway only interested in the original domain type.
+		 *
+		 * @param resultType must not be {@literal null}.
+		 * @param <R> result type.
+		 * @return new instance of {@link FindAndReplaceWithProjection}.
+		 * @throws IllegalArgumentException if resultType is {@literal null}.
+		 */
+		<R> FindAndReplaceWithOptions<R> as(Class<R> resultType);
+
 	}
 
 	interface ReactiveUpdate<T> extends UpdateWithCollection<T>, UpdateWithQuery<T>, UpdateWithUpdate<T> {}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
@@ -18,12 +18,13 @@ package org.springframework.data.mongodb.core;
 import reactor.core.publisher.Mono;
 
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 
 import com.mongodb.client.result.UpdateResult;
 
 /**
- * {@link ReactiveUpdateOperation} allows creation and execution of reactive MongoDB update / findAndModify operations
- * in a fluent API style. <br />
+ * {@link ReactiveUpdateOperation} allows creation and execution of reactive MongoDB update / findAndModify /
+ * findAndReplace operations in a fluent API style. <br />
  * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching}, as well as
  * the {@link org.springframework.data.mongodb.core.query.Update} via {@code apply} into the MongoDB specific
  * representations. The collection to operate on is by default derived from the initial {@literal domainType} and can be
@@ -69,6 +70,21 @@ public interface ReactiveUpdateOperation {
 	}
 
 	/**
+	 * Compose findAndReplace execution by calling one of the terminating methods.
+	 *
+	 * @since 2.1
+	 */
+	interface TerminatingFindAndReplace<T> {
+
+		/**
+		 * Find, replace and return the first matching document.
+		 *
+		 * @return {@link Mono#empty()} if nothing found. Never {@literal null}.
+		 */
+		Mono<T> findAndReplace();
+	}
+
+	/**
 	 * Compose update execution by calling one of the terminating methods.
 	 */
 	interface TerminatingUpdate<T> extends TerminatingFindAndModify<T>, FindAndModifyWithOptions<T> {
@@ -108,6 +124,16 @@ public interface ReactiveUpdateOperation {
 		 * @throws IllegalArgumentException if update is {@literal null}.
 		 */
 		TerminatingUpdate<T> apply(org.springframework.data.mongodb.core.query.Update update);
+
+		/**
+		 * Specify {@code replacement} object.
+		 *
+		 * @param replacement must not be {@literal null}.
+		 * @return new instance of {@link FindAndReplaceOptions}.
+		 * @throws IllegalArgumentException if options is {@literal null}.
+		 * @since 2.1
+		 */
+		FindAndReplaceWithOptions<T> replaceWith(T replacement);
 	}
 
 	/**
@@ -155,6 +181,24 @@ public interface ReactiveUpdateOperation {
 		 * @throws IllegalArgumentException if options is {@literal null}.
 		 */
 		TerminatingFindAndModify<T> withOptions(FindAndModifyOptions options);
+	}
+
+	/**
+	 * Define {@link FindAndReplaceOptions}.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	interface FindAndReplaceWithOptions<T> extends TerminatingFindAndReplace<T> {
+
+		/**
+		 * Explicitly define {@link FindAndReplaceOptions} for the {@link Update}.
+		 *
+		 * @param options must not be {@literal null}.
+		 * @return new instance of {@link FindAndReplaceOptions}.
+		 * @throws IllegalArgumentException if options is {@literal null}.
+		 */
+		TerminatingFindAndReplace<T> withOptions(FindAndReplaceOptions options);
 	}
 
 	interface ReactiveUpdate<T> extends UpdateWithCollection<T>, UpdateWithQuery<T>, UpdateWithUpdate<T> {}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -179,6 +179,58 @@ public class ExecutableUpdateOperationSupportTests {
 		assertThat(result.getUpsertedId()).isEqualTo(new BsonString("id-3"));
 	}
 
+	@Test // DATAMONGO-1827
+	public void findAndReplaceValue() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		Person result = template.update(Person.class).matching(queryHan()).replaceWith(luke).findAndReplaceValue();
+
+		assertThat(result).isEqualTo(han);
+		assertThat(template.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
+				"Luke");
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplace() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		Optional<Person> result = template.update(Person.class).matching(queryHan()).replaceWith(luke).findAndReplace();
+
+		assertThat(result).contains(han);
+		assertThat(template.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
+				"Luke");
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplaceWithCollection() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		Optional<Person> result = template.update(Person.class).inCollection(STAR_WARS).matching(queryHan())
+				.replaceWith(luke).findAndReplace();
+
+		assertThat(result).contains(han);
+		assertThat(template.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
+				"Luke");
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplaceWithOptions() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		Person result = template.update(Person.class).matching(queryHan()).replaceWith(luke)
+				.withOptions(FindAndReplaceOptions.options().returnNew(true)).findAndReplaceValue();
+
+		assertThat(result).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");
+	}
+
 	private Query queryHan() {
 		return query(where("id").is(han.getId()));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -226,9 +226,21 @@ public class ExecutableUpdateOperationSupportTests {
 		luke.firstname = "Luke";
 
 		Person result = template.update(Person.class).matching(queryHan()).replaceWith(luke)
-				.withOptions(FindAndReplaceOptions.options().returnNew(true)).findAndReplaceValue();
+				.withOptions(FindAndReplaceOptions.options().returnNew()).findAndReplaceValue();
 
 		assertThat(result).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplaceWithProjection() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		Jedi result = template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class)
+				.findAndReplaceValue();
+
+		assertThat(result.getName()).isEqualTo(han.firstname);
 	}
 
 	private Query queryHan() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 import static org.springframework.data.mongodb.core.query.Query.*;
+import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 import lombok.Data;
 import reactor.core.Disposable;
@@ -119,7 +118,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.insert(person)).expectNextCount(1).verifyComplete();
 
-		assertThat(person.getId(), is(notNullValue()));
+		assertThat(person.getId()).isNotNull();
 	}
 
 	@Test // DATAMONGO-1444
@@ -129,7 +128,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.insertAll(Collections.singleton(person))).expectNextCount(1).verifyComplete();
 
-		assertThat(person.getId(), is(notNullValue()));
+		assertThat(person.getId()).isNotNull();
 	}
 
 	@Test // DATAMONGO-1444
@@ -140,7 +139,7 @@ public class ReactiveMongoTemplateTests {
 		StepVerifier.create(template.insert(Collections.singleton(person), PersonWithAList.class)).expectNextCount(1)
 				.verifyComplete();
 
-		assertThat(person.getId(), is(notNullValue()));
+		assertThat(person.getId()).isNotNull();
 	}
 
 	@Test // DATAMONGO-1444
@@ -151,7 +150,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.save(person)).expectNextCount(1).verifyComplete();
 
-		assertThat(person.getId(), is(notNullValue()));
+		assertThat(person.getId()).isNotNull();
 	}
 
 	@Test // DATAMONGO-1444
@@ -244,7 +243,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.findOne(query, PersonWithAList.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.getWishList().size(), is(0));
+			assertThat(actual.getWishList()).isEmpty();
 		}).verifyComplete();
 
 		person.addToWishList("please work!");
@@ -253,7 +252,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.findOne(query, PersonWithAList.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.getWishList().size(), is(1));
+			assertThat(actual.getWishList()).hasSize(1);
 		}).verifyComplete();
 
 		Friend friend = new Friend();
@@ -265,8 +264,8 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.findOne(query, PersonWithAList.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.getWishList().size(), is(1));
-			assertThat(actual.getFriends().size(), is(1));
+			assertThat(actual.getWishList()).hasSize(1);
+			assertThat(actual.getFriends()).hasSize(1);
 		}).verifyComplete();
 	}
 
@@ -285,7 +284,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.findOne(query, PersonWithAList.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.getFirstName(), is("Mark"));
+			assertThat(actual.getFirstName()).isEqualTo("Mark");
 		}).verifyComplete();
 	}
 
@@ -315,7 +314,7 @@ public class ReactiveMongoTemplateTests {
 						.flatMapMany(p -> template.find(new Query(where("age").is(25)), Person.class)))
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.getFirstName(), is(equalTo("Sven")));
+					assertThat(actual.getFirstName()).isEqualTo("Sven");
 				}).verifyComplete();
 	}
 
@@ -329,7 +328,7 @@ public class ReactiveMongoTemplateTests {
 						.flatMapMany(p -> template.find(new Query(where("age").is(25)), Person.class, "people")))
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.getFirstName(), is(equalTo("Sven")));
+					assertThat(actual.getFirstName()).isEqualTo("Sven");
 				}).verifyComplete();
 	}
 
@@ -431,29 +430,29 @@ public class ReactiveMongoTemplateTests {
 		Update update = new Update().inc("age", 1);
 
 		Person p = template.findAndModify(query, update, Person.class).block(); // return old
-		assertThat(p.getFirstName(), is("Harry"));
-		assertThat(p.getAge(), is(23));
+		assertThat(p.getFirstName()).isEqualTo("Harry");
+		assertThat(p.getAge()).isEqualTo(23);
 		p = template.findOne(query, Person.class).block();
-		assertThat(p.getAge(), is(24));
+		assertThat(p.getAge()).isEqualTo(24);
 
 		p = template.findAndModify(query, update, Person.class, "person").block();
-		assertThat(p.getAge(), is(24));
+		assertThat(p.getAge()).isEqualTo(24);
 		p = template.findOne(query, Person.class).block();
-		assertThat(p.getAge(), is(25));
+		assertThat(p.getAge()).isEqualTo(25);
 
 		p = template.findAndModify(query, update, new FindAndModifyOptions().returnNew(true), Person.class).block();
-		assertThat(p.getAge(), is(26));
+		assertThat(p.getAge()).isEqualTo(26);
 
 		p = template.findAndModify(query, update, null, Person.class, "person").block();
-		assertThat(p.getAge(), is(26));
+		assertThat(p.getAge()).isEqualTo(26);
 		p = template.findOne(query, Person.class).block();
-		assertThat(p.getAge(), is(27));
+		assertThat(p.getAge()).isEqualTo(27);
 
 		Query query2 = new Query(where("firstName").is("Mary"));
 		p = template.findAndModify(query2, update, new FindAndModifyOptions().returnNew(true).upsert(true), Person.class)
 				.block();
-		assertThat(p.getFirstName(), is("Mary"));
-		assertThat(p.getAge(), is(1));
+		assertThat(p.getFirstName()).isEqualTo("Mary");
+		assertThat(p.getAge()).isEqualTo(1);
 	}
 
 	@Test // DATAMONGO-1827
@@ -468,7 +467,7 @@ public class ReactiveMongoTemplateTests {
 						org.bson.Document.class, "findandreplace") //
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
-					assertThat(actual, hasEntry("foo", "bar"));
+					assertThat(actual).containsEntry("foo", "bar");
 				}).verifyComplete();
 
 		template.findOne(query(where("foo").is("baz")), org.bson.Document.class, "findandreplace") //
@@ -486,7 +485,7 @@ public class ReactiveMongoTemplateTests {
 		template.findAndReplace(query(where("name").is("Walter")), new MyPerson("Heisenberg")) //
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
-					assertThat(actual.getName(), is("Walter"));
+					assertThat(actual.getName()).isEqualTo("Walter");
 				}).verifyComplete();
 
 		template.findOne(query(where("name").is("Heisenberg")), MyPerson.class) //
@@ -504,7 +503,7 @@ public class ReactiveMongoTemplateTests {
 						FindAndReplaceOptions.options().returnNew(true))
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
-					assertThat(actual.getName(), is("Heisenberg"));
+					assertThat(actual.getName()).isEqualTo("Heisenberg");
 				}).verifyComplete();
 	}
 
@@ -617,7 +616,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.findAll(PersonWithVersionPropertyOfTypeInteger.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.version, is(0));
+			assertThat(actual.version).isZero();
 		}).verifyComplete();
 
 		StepVerifier.create(template.findAll(PersonWithVersionPropertyOfTypeInteger.class).flatMap(p -> {
@@ -627,11 +626,11 @@ public class ReactiveMongoTemplateTests {
 			return template.save(person);
 		})).expectNextCount(1).verifyComplete();
 
-		assertThat(person.version, is(1));
+		assertThat(person.version).isOne();
 
 		StepVerifier.create(template.findAll(PersonWithVersionPropertyOfTypeInteger.class)).consumeNextWith(actual -> {
 
-			assertThat(actual.version, is(1));
+			assertThat(actual.version).isOne();
 		}).verifyComplete();
 
 		// Optimistic lock exception
@@ -697,7 +696,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.save(dbObject, "collection")).expectNextCount(1).verifyComplete();
 
-		assertThat(dbObject.containsKey("_id"), is(true));
+		assertThat(dbObject.containsKey("_id")).isTrue();
 	}
 
 	@Test(expected = MappingException.class) // DATAMONGO-1444, DATAMONGO-1730
@@ -721,8 +720,8 @@ public class ReactiveMongoTemplateTests {
 		StepVerifier.create(template.findById(dbObject.get("_id"), Document.class, "collection")) //
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.get("foo"), is(dbObject.get("foo")));
-					assertThat(actual.get("_id"), is(dbObject.get("_id")));
+					assertThat(actual.get("foo")).isEqualTo(dbObject.get("foo"));
+					assertThat(actual.get("_id")).isEqualTo(dbObject.get("_id"));
 				}).verifyComplete();
 	}
 
@@ -776,7 +775,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.insert(person)).expectNextCount(1).verifyComplete();
 
-		assertThat(person.version, is(0));
+		assertThat(person.version).isZero();
 	}
 
 	@Test // DATAMONGO-1444
@@ -787,7 +786,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.insertAll(Collections.singleton(person))).expectNextCount(1).verifyComplete();
 
-		assertThat(person.version, is(0));
+		assertThat(person.version).isZero();
 	}
 
 	@Test // DATAMONGO-1444
@@ -805,10 +804,10 @@ public class ReactiveMongoTemplateTests {
 		person.firstName = "Dave";
 
 		StepVerifier.create(template.save(person, "personX")).expectNextCount(1).verifyComplete();
-		assertThat(person.version, is(0));
+		assertThat(person.version).isZero();
 
 		StepVerifier.create(template.save(person, "personX")).expectNextCount(1).verifyComplete();
-		assertThat(person.version, is(1));
+		assertThat(person.version).isOne();
 	}
 
 	@Test // DATAMONGO-1444
@@ -818,7 +817,7 @@ public class ReactiveMongoTemplateTests {
 		person.firstName = "Dave";
 
 		StepVerifier.create(template.save(person, "personX")).expectNextCount(1).verifyComplete();
-		assertThat(person.version, is(0L));
+		assertThat(person.version).isZero();
 	}
 
 	@Test // DATAMONGO-1444
@@ -852,7 +851,7 @@ public class ReactiveMongoTemplateTests {
 		person.firstName = "Dave";
 
 		StepVerifier.create(template.save(person)).expectNextCount(1).verifyComplete();
-		assertThat(person.version, is(0));
+		assertThat(person.version).isZero();
 
 		person.version = null;
 		StepVerifier.create(template.save(person)).expectError(DuplicateKeyException.class).verify();
@@ -881,7 +880,7 @@ public class ReactiveMongoTemplateTests {
 
 		StepVerifier.create(template.save(person)).expectNextCount(1).verifyComplete();
 
-		assertThat(person.id, is(notNullValue()));
+		assertThat(person.id).isNotNull();
 
 		person.lastname = null;
 		StepVerifier.create(template.save(person)).expectNextCount(1).verifyComplete();
@@ -889,7 +888,7 @@ public class ReactiveMongoTemplateTests {
 		StepVerifier.create(template.findOne(query(where("id").is(person.id)), VersionedPerson.class)) //
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.lastname, is(nullValue()));
+					assertThat(actual.lastname).isNull();
 				}) //
 				.verifyComplete();
 	}
@@ -906,7 +905,7 @@ public class ReactiveMongoTemplateTests {
 		StepVerifier.create(template.findOne(query(where("id").is(person.getId())), Person.class)) //
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.getFirstName(), is(nullValue()));
+					assertThat(actual.getFirstName()).isNull();
 				}) //
 				.verifyComplete();
 	}
@@ -921,7 +920,7 @@ public class ReactiveMongoTemplateTests {
 		StepVerifier.create(template.findAll(Document.class, "collection")) //
 				.consumeNextWith(actual -> {
 
-					assertThat(actual.containsKey("first"), is(true));
+					assertThat(actual.containsKey("first")).isTrue();
 				}) //
 				.verifyComplete();
 	}
@@ -959,8 +958,8 @@ public class ReactiveMongoTemplateTests {
 
 		Disposable disposable = capped.doOnNext(documents::add).subscribe();
 
-		assertThat(documents.poll(5, TimeUnit.SECONDS), is(notNullValue()));
-		assertThat(documents.isEmpty(), is(true));
+		assertThat(documents.poll(5, TimeUnit.SECONDS)).isNotNull();
+		assertThat(documents).isEmpty();
 
 		disposable.dispose();
 	}
@@ -981,14 +980,14 @@ public class ReactiveMongoTemplateTests {
 
 		Disposable disposable = capped.doOnNext(documents::add).subscribe();
 
-		assertThat(documents.poll(5, TimeUnit.SECONDS), is(notNullValue()));
-		assertThat(documents.isEmpty(), is(true));
+		assertThat(documents.poll(5, TimeUnit.SECONDS)).isNotNull();
+		assertThat(documents).isEmpty();
 
 		StepVerifier.create(template.insert(new Document("random", Math.random()).append("key", "value"), "capped")) //
 				.expectNextCount(1) //
 				.verifyComplete();
 
-		assertThat(documents.poll(5, TimeUnit.SECONDS), is(notNullValue()));
+		assertThat(documents.poll(5, TimeUnit.SECONDS)).isNotNull();
 
 		disposable.dispose();
 
@@ -996,7 +995,7 @@ public class ReactiveMongoTemplateTests {
 				.expectNextCount(1) //
 				.verifyComplete();
 
-		assertThat(documents.poll(1, TimeUnit.SECONDS), is(nullValue()));
+		assertThat(documents.poll(1, TimeUnit.SECONDS)).isNull();
 	}
 
 	@Test // DATAMONGO-1761

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -198,6 +198,18 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
+	public void findAndReplaceWithProjection() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class).findAndReplace() //
+				.as(StepVerifier::create).consumeNextWith(it -> {
+					assertThat(it.getName()).isEqualTo(han.firstname);
+				}).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1827
 	public void findAndReplaceWithCollection() {
 
 		Person luke = new Person();
@@ -220,7 +232,7 @@ public class ReactiveUpdateOperationSupportTests {
 		luke.firstname = "Luke";
 
 		template.update(Person.class).matching(queryHan()).replaceWith(luke)
-				.withOptions(FindAndReplaceOptions.options().returnNew(true)).findAndReplace() //
+				.withOptions(FindAndReplaceOptions.options().returnNew()).findAndReplace() //
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
 					assertThat(actual).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -181,6 +181,52 @@ public class ReactiveUpdateOperationSupportTests {
 				}).verifyComplete();
 	}
 
+	@Test // DATAMONGO-1827
+	public void findAndReplace() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		template.update(Person.class).matching(queryHan()).replaceWith(luke).findAndReplace() //
+				.as(StepVerifier::create).expectNext(han).verifyComplete();
+
+		template.findOne(queryHan(), Person.class) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");
+				}).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplaceWithCollection() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		template.update(Person.class).inCollection(STAR_WARS).matching(queryHan()).replaceWith(luke).findAndReplace() //
+				.as(StepVerifier::create).expectNext(han).verifyComplete();
+
+		template.findOne(queryHan(), Person.class) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");
+				}).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1827
+	public void findAndReplaceWithOptions() {
+
+		Person luke = new Person();
+		luke.firstname = "Luke";
+
+		template.update(Person.class).matching(queryHan()).replaceWith(luke)
+				.withOptions(FindAndReplaceOptions.options().returnNew(true)).findAndReplace() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname", "Luke");
+				}).verifyComplete();
+	}
+
 	private Query queryHan() {
 		return query(where("id").is(han.getId()));
 	}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -14,7 +14,7 @@
 * <<mongo.sessions, MongoDB 3.6 Session>> support for the imperative and reactive Template APIs.
 * <<mongo.transactions, MongoDB 4.0 Transaction>> support and a MongoDB-specific transaction manager implementation.
 * <<mongodb.repositories.queries.sort,Default sort specifications for repository query methods>> using `@Query(sort=…)`.
-* `findAndReplace` support through imperative and reactive Template APIs.
+* <<mongo-template.find-and-replace,findAndReplace>> support through imperative and reactive Template APIs.
 
 [[new-features.2-0-0]]
 == What's New in Spring Data MongoDB 2.0

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -14,6 +14,7 @@
 * <<mongo.sessions, MongoDB 3.6 Session>> support for the imperative and reactive Template APIs.
 * <<mongo.transactions, MongoDB 4.0 Transaction>> support and a MongoDB-specific transaction manager implementation.
 * <<mongodb.repositories.queries.sort,Default sort specifications for repository query methods>> using `@Query(sort=…)`.
+* `findAndReplace` support through imperative and reactive Template APIs.
 
 [[new-features.2-0-0]]
 == What's New in Spring Data MongoDB 2.0

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -437,7 +437,7 @@ NOTE: Once configured, `MongoTemplate` is thread-safe and can be reused across m
 
 The mapping between MongoDB documents and domain classes is done by delegating to an implementation of the `MongoConverter` interface. Spring provides `MappingMongoConverter`, but you can also write your own converter. See "`<<mongo.custom-converters>>`" for more detailed information.
 
-The `MongoTemplate` class implements the interface `MongoOperations`. In as much as possible, the methods on `MongoOperations` are named after methods available on the MongoDB driver `Collection` object, to make the API familiar to existing MongoDB developers who are used to the driver API. For example, you can find methods such as `find`, `findAndModify`, `findOne`, `insert`, `remove`, `save`, `update`, and `updateMulti`. The design goal was to make it as easy as possible to transition between the use of the base MongoDB driver and `MongoOperations`. A major difference between the two APIs is that `MongoOperations` can be passed domain objects instead of `Document`. Also, `MongoOperations` has fluent APIs for `Query`, `Criteria`, and `Update` operations instead of populating a `Document` to specify the parameters for those operations.
+The `MongoTemplate` class implements the interface `MongoOperations`. In as much as possible, the methods on `MongoOperations` are named after methods available on the MongoDB driver `Collection` object, to make the API familiar to existing MongoDB developers who are used to the driver API. For example, you can find methods such as `find`, `findAndModify`, `findAndReplace`, `findOne`, `insert`, `remove`, `save`, `update`, and `updateMulti`. The design goal was to make it as easy as possible to transition between the use of the base MongoDB driver and `MongoOperations`. A major difference between the two APIs is that `MongoOperations` can be passed domain objects instead of `Document`. Also, `MongoOperations` has fluent APIs for `Query`, `Criteria`, and `Update` operations instead of populating a `Document` to specify the parameters for those operations.
 
 NOTE: The preferred way to reference the operations on `MongoTemplate` instance is through its interface, `MongoOperations`.
 
@@ -966,6 +966,35 @@ p = mongoTemplate.findAndModify(query2, update, new FindAndModifyOptions().retur
 assertThat(p.getFirstName(), is("Mary"));
 assertThat(p.getAge(), is(1));
 ----
+
+[[mongo-template.find-and-replace]]
+=== Finding and Replacing Documents
+
+The most straight forward method of replacing an entire `Document` is via its `id` using the `save` method. However this
+might not always be feasible. `findAndReplace` offers an alternative that allows to identify the document to replace via
+a simple query.
+
+.Find and Replace Documents
+====
+[source,java]
+----
+Optional<User> result = template.update(Person.class)      <1>
+    .matching(query(where("firstame").is("Tom")))          <2>
+    .replaceWith(new Person("Dick"))
+    .withOptions(FindAndReplaceOptions.options().upsert()) <3>
+    .as(User.class)                                        <4>
+    .findAndReplace();                                     <5>
+----
+<1> Use the fluent update API with the domain type given for mapping the query and deriving the collection name or just use `MongoOperations#findAndReplace`.
+<2> The actual match query mapped against the given domain type. Provide `sort`, `fields` and `collation` settings via the query.
+<3> Additional optional hook to provide options other than the defaults, like `upsert`.
+<4> An optional projection type used for mapping the operation result. If none given the initial domain type is used.
+<5> Trigger the actual execution. Use `findAndReplaceValue` to obtain the nullable result instead of an `Optional`.
+====
+
+IMPORTANT: Please note that the replacement must not hold an `id` itself as the `id` of the existing `Document` will be
+carried over to the replacement by the store itself. Also keep in mind that `findAndReplace` will only replace the first
+document matching the query criteria depending on a potentially given sort order.
 
 [[mongo-template.delete]]
 === Methods for Removing Documents


### PR DESCRIPTION
We now support `findAndReplace` operations through the imperative and reactive Template API to find an object by a query and entirely replace it (except for the `_id`).

```java
template.findAndReplace(query(where("name").is("Han")), new Person("Luke"));

template.update(Person.class).inCollection(STAR_WARS).matching(query(where("name").is("Han"))).replaceWith(luke).findAndReplace();
```

---

Related ticket: [DATAMONGO-1827](https://jira.spring.io/browse/DATAMONGO-1827).