### PR TITLE
DATAMONGO-2004 - Support lazy DBRef resolution through constructor creation of the enclosing entity.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -59,6 +59,14 @@ class DocumentAccessor {
 	}
 
 	/**
+	 * @return the underlying {@link Bson document}.
+	 * @since 2.1
+	 */
+	public Bson getDocument() {
+		return this.document;
+	}
+
+	/**
 	 * Puts the given value into the backing {@link Document} based on the coordinates defined through the given
 	 * {@link MongoPersistentProperty}. By default this will be the plain field name. But field names might also consist
 	 * of path traversals so we might need to create intermediate {@link BasicDocument}s.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -3069,8 +3069,8 @@ public class MongoTemplateTests {
 		assertThat(contentLoaded.dbrefMessage.id, is(messageLoaded.id));
 	}
 
-	@Test // DATAMONGO-1287
-	public void shouldReuseAlreadyResolvedLazyLoadedDBRefWhenUsedAsPersistenceConstrcutorArgument() {
+	@Test // DATAMONGO-1287, DATAMONGO-2004
+	public void shouldReuseAlreadyResolvedLazyLoadedDBRefWhenUsedAsPersistenceConstructorArgument() {
 
 		Document docInCtor = new Document();
 		docInCtor.id = "doc-in-ctor";
@@ -3083,7 +3083,7 @@ public class MongoTemplateTests {
 
 		DocumentWithLazyDBrefUsedInPresistenceConstructor loaded = template.findOne(query(where("id").is(source.id)),
 				DocumentWithLazyDBrefUsedInPresistenceConstructor.class);
-		assertThat(loaded.refToDocUsedInCtor, not(instanceOf(LazyLoadingProxy.class)));
+		assertThat(loaded.refToDocUsedInCtor, instanceOf(LazyLoadingProxy.class));
 		assertThat(loaded.refToDocNotUsedInCtor, nullValue());
 	}
 
@@ -3106,8 +3106,8 @@ public class MongoTemplateTests {
 		assertThat(loaded.refToDocUsedInCtor, nullValue());
 	}
 
-	@Test // DATAMONGO-1287
-	public void shouldRespectParamterValueWhenAttemptingToReuseLazyLoadedDBRefUsedInPersistenceConstrcutor() {
+	@Test // DATAMONGO-1287, DATAMONGO-2004
+	public void shouldRespectParameterValueWhenAttemptingToReuseLazyLoadedDBRefUsedInPersistenceConstructor() {
 
 		Document docInCtor = new Document();
 		docInCtor.id = "doc-in-ctor";
@@ -3125,7 +3125,7 @@ public class MongoTemplateTests {
 
 		DocumentWithLazyDBrefUsedInPresistenceConstructor loaded = template.findOne(query(where("id").is(source.id)),
 				DocumentWithLazyDBrefUsedInPresistenceConstructor.class);
-		assertThat(loaded.refToDocUsedInCtor, not(instanceOf(LazyLoadingProxy.class)));
+		assertThat(loaded.refToDocUsedInCtor, instanceOf(LazyLoadingProxy.class));
 		assertThat(loaded.refToDocNotUsedInCtor, instanceOf(LazyLoadingProxy.class));
 	}
 
@@ -3384,6 +3384,73 @@ public class MongoTemplateTests {
 		assertThat(target.lazyDbRefAnnotatedMap.values(), contains(two, one));
 	}
 
+	@Test // DATAMONGO-2004
+	public void shouldFetchLazyReferenceWithConstructorCreationCorrectly() {
+
+		Sample one = new Sample("1", "jon snow");
+
+		template.save(one);
+
+		DocumentWithLazyDBRefsAndConstructorCreation source = new DocumentWithLazyDBRefsAndConstructorCreation(null, one,
+				null, null);
+
+		template.save(source);
+
+		DocumentWithLazyDBRefsAndConstructorCreation target = template.findOne(query(where("id").is(source.id)),
+				DocumentWithLazyDBRefsAndConstructorCreation.class);
+
+		assertThat(target.lazyDbRefProperty, instanceOf(LazyLoadingProxy.class));
+		assertThat(target.lazyDbRefProperty, is(one));
+	}
+
+	@Test // DATAMONGO-2004
+	public void shouldFetchMapOfLazyReferencesWithConstructorCreationCorrectly() {
+
+		Sample one = new Sample("1", "jon snow");
+		Sample two = new Sample("2", "tyrion lannister");
+
+		template.save(one);
+		template.save(two);
+
+		Map<String, Sample> map = new LinkedHashMap<>();
+		map.put("tyrion", two);
+		map.put("jon", one);
+
+		DocumentWithLazyDBRefsAndConstructorCreation source = new DocumentWithLazyDBRefsAndConstructorCreation(null, null,
+				null, map);
+
+		template.save(source);
+
+		DocumentWithLazyDBRefsAndConstructorCreation target = template.findOne(query(where("id").is(source.id)),
+				DocumentWithLazyDBRefsAndConstructorCreation.class);
+
+		assertThat(target.lazyDbRefAnnotatedMap, instanceOf(LazyLoadingProxy.class));
+		assertThat(target.lazyDbRefAnnotatedMap.values(), contains(two, one));
+	}
+
+	@Test // DATAMONGO-2004
+	public void shouldFetchListOfLazyReferencesWithConstructorCreationCorrectly() {
+
+		Sample one = new Sample("1", "jon snow");
+		Sample two = new Sample("2", "tyrion lannister");
+
+		template.save(one);
+		template.save(two);
+
+		List<Sample> list = Arrays.asList(two, one);
+
+		DocumentWithLazyDBRefsAndConstructorCreation source = new DocumentWithLazyDBRefsAndConstructorCreation(null, null,
+				list, null);
+
+		template.save(source);
+
+		DocumentWithLazyDBRefsAndConstructorCreation target = template.findOne(query(where("id").is(source.id)),
+				DocumentWithLazyDBRefsAndConstructorCreation.class);
+
+		assertThat(target.lazyDbRefAnnotatedList, instanceOf(LazyLoadingProxy.class));
+		assertThat(target.lazyDbRefAnnotatedList, contains(two, one));
+	}
+
 	@Test // DATAMONGO-1513
 	@DirtiesContext
 	public void populatesIdsAddedByEventListener() {
@@ -3588,6 +3655,29 @@ public class MongoTemplateTests {
 
 		@Field("lazy_db_ref_map") // DATAMONGO-1194
 		@org.springframework.data.mongodb.core.mapping.DBRef(lazy = true) public Map<String, Sample> lazyDbRefAnnotatedMap;
+	}
+
+	@Data
+	static class DocumentWithLazyDBRefsAndConstructorCreation {
+
+		@Id public final String id;
+
+		public DocumentWithLazyDBRefsAndConstructorCreation(String id, Sample lazyDbRefProperty,
+				List<Sample> lazyDbRefAnnotatedList, Map<String, Sample> lazyDbRefAnnotatedMap) {
+			this.id = id;
+			this.lazyDbRefProperty = lazyDbRefProperty;
+			this.lazyDbRefAnnotatedList = lazyDbRefAnnotatedList;
+			this.lazyDbRefAnnotatedMap = lazyDbRefAnnotatedMap;
+		}
+
+		@org.springframework.data.mongodb.core.mapping.DBRef(lazy = true) //
+		public final Sample lazyDbRefProperty;
+
+		@Field("lazy_db_ref_list") @org.springframework.data.mongodb.core.mapping.DBRef(lazy = true) //
+		public final List<Sample> lazyDbRefAnnotatedList;
+
+		@Field("lazy_db_ref_map") @org.springframework.data.mongodb.core.mapping.DBRef(
+				lazy = true) public final Map<String, Sample> lazyDbRefAnnotatedMap;
 	}
 
 	@EqualsAndHashCode

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -3448,7 +3448,7 @@ public class MongoTemplateTests {
 				DocumentWithLazyDBRefsAndConstructorCreation.class);
 
 		assertThat(target.lazyDbRefAnnotatedList, instanceOf(LazyLoadingProxy.class));
-		assertThat(target.lazyDbRefAnnotatedList, contains(two, one));
+		assertThat(target.getLazyDbRefAnnotatedList(), contains(two, one));
 	}
 
 	@Test // DATAMONGO-1513

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import com.mongodb.MongoClient;
+
+/**
+ * Integration tests for {@link MappingMongoConverter}.
+ *
+ * @author Christoph Strobl
+ */
+public class MappingMongoConverterTests {
+
+	MongoClient client;
+
+	MappingMongoConverter converter;
+	MongoMappingContext mappingContext;
+	DbRefResolver dbRefResolver;
+
+	@Before
+	public void setUp() {
+
+		client = new MongoClient();
+		client.dropDatabase("mapping-converter-tests");
+
+		MongoDbFactory factory = new SimpleMongoDbFactory(client, "mapping-converter-tests");
+
+		dbRefResolver = spy(new DefaultDbRefResolver(factory));
+		mappingContext = new MongoMappingContext();
+		mappingContext.afterPropertiesSet();
+
+		converter = new MappingMongoConverter(dbRefResolver, mappingContext);
+	}
+
+	@Test // DATAMONGO-2004
+	public void resolvesLazyDBRefOnAccess() {
+
+		client.getDatabase("mapping-converter-tests").getCollection("samples")
+				.insertMany(Arrays.asList(new Document("_id", "sample-1").append("value", "one"),
+						new Document("_id", "sample-2").append("value", "two")));
+
+		Document source = new Document("_id", "id-1").append("lazyList",
+				Arrays.asList(new com.mongodb.DBRef("samples", "sample-1"), new com.mongodb.DBRef("samples", "sample-2")));
+
+		WithLazyDBRef target = converter.read(WithLazyDBRef.class, source);
+
+		verify(dbRefResolver).resolveDbRef(any(), isNull(), any(), any());
+		verifyNoMoreInteractions(dbRefResolver);
+
+		assertThat(target.lazyList).isInstanceOf(LazyLoadingProxy.class);
+		assertThat(target.getLazyList()).contains(new Sample("sample-1", "one"), new Sample("sample-2", "two"));
+
+		verify(dbRefResolver).bulkFetch(any());
+	}
+
+	@Test // DATAMONGO-2004
+	public void resolvesLazyDBRefConstructorArgOnAccess() {
+
+		client.getDatabase("mapping-converter-tests").getCollection("samples")
+				.insertMany(Arrays.asList(new Document("_id", "sample-1").append("value", "one"),
+						new Document("_id", "sample-2").append("value", "two")));
+
+		Document source = new Document("_id", "id-1").append("lazyList",
+				Arrays.asList(new com.mongodb.DBRef("samples", "sample-1"), new com.mongodb.DBRef("samples", "sample-2")));
+
+		WithLazyDBRefAsConstructorArg target = converter.read(WithLazyDBRefAsConstructorArg.class, source);
+
+		verify(dbRefResolver).resolveDbRef(any(), isNull(), any(), any());
+		verifyNoMoreInteractions(dbRefResolver);
+
+		assertThat(target.lazyList).isInstanceOf(LazyLoadingProxy.class);
+		assertThat(target.getLazyList()).contains(new Sample("sample-1", "one"), new Sample("sample-2", "two"));
+
+		verify(dbRefResolver).bulkFetch(any());
+	}
+
+	public static class WithLazyDBRef {
+
+		@Id String id;
+		@DBRef(lazy = true) List<Sample> lazyList;
+
+		public List<Sample> getLazyList() {
+			return lazyList;
+		}
+	}
+
+	public static class WithLazyDBRefAsConstructorArg {
+
+		@Id String id;
+		@DBRef(lazy = true) List<Sample> lazyList;
+
+		public WithLazyDBRefAsConstructorArg(String id, List<Sample> lazyList) {
+
+			this.id = id;
+			this.lazyList = lazyList;
+		}
+
+		public List<Sample> getLazyList() {
+			return lazyList;
+		}
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class Sample {
+
+		@Id String id;
+		String value;
+	}
+}

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -584,8 +584,12 @@ public class Person {
 ====
 
 You need not use `@OneToMany` or similar mechanisms because the List of objects tells the mapping framework that you want a one-to-many relationship. When the object is stored in MongoDB, there is a list of DBRefs rather than the `Account` objects themselves.
+When it comes to loading collections of ``DBRef``s it is advisable to restrict references held in collection types to a specific MongoDB collection. This allows bulk loading of all references, whereas references pointing to different MongoDB collections need to be resolved one by one.
 
 IMPORTANT: The mapping framework does not handle cascading saves. If you change an `Account` object that is referenced by a `Person` object, you must save the `Account` object separately. Calling `save` on the `Person` object does not automatically save the `Account` objects in the `accounts` property.
+
+``DBRef``s can also be resolved lazily. In this case the actual `Object` or `Collection` of references is resolved on first access of the property. Use the `lazy` attribute of `@DBRef` to specify this.
+Required properties that are also defined as lazy loading ``DBRef`` and used as constructor arguments are also decorated with the lazy loading proxy making sure to put as little pressure on the database and network as possible.
 
 [[mapping-usage-events]]
 === Mapping Framework Events


### PR DESCRIPTION
We now respect eager/lazy loading preferences of the annotated association property when the enclosing entity is created through its constructor and the reference is passed as constructor argument.

Previously, we eagerly resolved DBRefs and passed the resolved value to the constructor.

---

Related ticket: [DATAMONGO-2004](https://jira.spring.io/browse/DATAMONGO-2004).