### PR TITLE
DATAMONGO-2015 - Attach Kotlin source dir to source code artifact.

### DIFF
--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -356,6 +356,25 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-kotlin-source</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/main/kotlin</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 
 	</build>


### PR DESCRIPTION
Sources of Kotlin-specific Spring Data MongoDB extensions are missing from `spring-data-mongodb-`_version_`-sources.jar` Maven artifact.

That happens 'cause Kotlin sources are stored under their own sources directory and are not picked up by `maven-source-plugin`.

PR adds a `build-helper-maven-plugin` execution to attach Kotlin source directory to set of source directories. That way its picked up by `maven-source-plugin` and packed into source code artifact.