### PR TITLE
DATAMONGO-2016 fixing issue where question mark in password broke option extraction

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditor.java
@@ -35,6 +35,7 @@ import com.mongodb.MongoCredential;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Stephen Tyler Conrad
  * @since 1.7
  */
 public class MongoCredentialPropertyEditor extends PropertyEditorSupport {
@@ -164,7 +165,7 @@ public class MongoCredentialPropertyEditor extends PropertyEditorSupport {
 	private static Properties extractOptions(String text) {
 
 		int optionsSeparationIndex = text.lastIndexOf(OPTIONS_DELIMITER);
-		int dbSeparationIndex = text.lastIndexOf(OPTIONS_DELIMITER);
+		int dbSeparationIndex = text.lastIndexOf(DATABASE_DELIMITER);
 
 		if (optionsSeparationIndex == -1 || dbSeparationIndex > optionsSeparationIndex) {
 			return new Properties();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
@@ -253,7 +253,7 @@ public class MongoCredentialPropertyEditorUnitTests {
 		assertThat((List<MongoCredential>) editor.getValue(), contains(USER_4_CREDENTIALS));
 	}
 
-	@Test
+	@Test //DATAMONGO-2016
 	@SuppressWarnings("unchecked")
 	public void passwordWithQuestionMarkShouldNotBeInterpretedAsOptionString() {
 
@@ -262,7 +262,7 @@ public class MongoCredentialPropertyEditorUnitTests {
 		assertThat((List<MongoCredential>) editor.getValue(), contains(USER_5_CREDENTIALS));
 	}
 
-	@Test
+	@Test //DATAMONGO-2016
 	@SuppressWarnings("unchecked")
 	public void passwordWithQuestionMarkShouldNotBreakParsingOfOptionString() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
@@ -34,6 +34,7 @@ import com.mongodb.MongoCredential;
  * Unit tests for {@link MongoCredentialPropertyEditor}.
  *
  * @author Christoph Strobl
+ * @author Stephen Tyler Conrad
  */
 public class MongoCredentialPropertyEditorUnitTests {
 
@@ -54,6 +55,10 @@ public class MongoCredentialPropertyEditorUnitTests {
 	static final String USER_4_ENCODED_PWD;
 	static final String USER_4_DB = "targaryen";
 
+	static final String USER_5_NAME = "lyanna";
+	static final String USER_5_PWD = "random?password";
+	static final String USER_5_DB = "mormont";
+
 	static final String USER_1_AUTH_STRING = USER_1_NAME + ":" + USER_1_PWD + "@" + USER_1_DB;
 	static final String USER_1_AUTH_STRING_WITH_PLAIN_AUTH_MECHANISM = USER_1_AUTH_STRING + "?uri.authMechanism=PLAIN";
 
@@ -65,6 +70,9 @@ public class MongoCredentialPropertyEditorUnitTests {
 			+ "?uri.authMechanism=MONGODB-X509'";
 
 	static final String USER_4_AUTH_STRING;
+
+	static final String USER_5_AUTH_STRING = USER_5_NAME + ":" + USER_5_PWD + "@" + USER_5_DB;
+	static final String USER_5_AUTH_STRING_WITH_PLAIN_AUTH_MECHANISM = USER_5_AUTH_STRING + "?uri.authMechanism=PLAIN";
 
 	static final MongoCredential USER_1_CREDENTIALS = MongoCredential.createCredential(USER_1_NAME, USER_1_DB,
 			USER_1_PWD.toCharArray());
@@ -80,6 +88,11 @@ public class MongoCredentialPropertyEditorUnitTests {
 
 	static final MongoCredential USER_4_CREDENTIALS = MongoCredential.createCredential(USER_4_PLAIN_NAME, USER_4_DB,
 			USER_4_PLAIN_PWD.toCharArray());
+
+	static final MongoCredential USER_5_CREDENTIALS = MongoCredential.createCredential(USER_5_NAME, USER_5_DB,
+			USER_5_PWD.toCharArray());
+	static final MongoCredential USER_5_CREDENTIALS_PLAIN_AUTH = MongoCredential.createPlainCredential(USER_5_NAME, USER_5_DB,
+			USER_5_PWD.toCharArray());
 
 	MongoCredentialPropertyEditor editor;
 
@@ -238,5 +251,23 @@ public class MongoCredentialPropertyEditorUnitTests {
 		editor.setAsText(USER_4_AUTH_STRING);
 
 		assertThat((List<MongoCredential>) editor.getValue(), contains(USER_4_CREDENTIALS));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void passwordWithQuestionMarkShouldNotBeInterpretedAsOptionString() {
+
+		editor.setAsText(USER_5_AUTH_STRING);
+
+		assertThat((List<MongoCredential>) editor.getValue(), contains(USER_5_CREDENTIALS));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void passwordWithQuestionMarkShouldNotBreakParsingOfOptionString() {
+
+		editor.setAsText(USER_5_AUTH_STRING_WITH_PLAIN_AUTH_MECHANISM);
+
+		assertThat((List<MongoCredential>) editor.getValue(), contains(USER_5_CREDENTIALS_PLAIN_AUTH));
 	}
 }


### PR DESCRIPTION
I tried to follow the guidelines, but I can't seem to figure out how to create a bug for this issue in the JIRA. This is actually my first attempt at a contribution so I'm sure I'm missing something. I did search the JIRA for an issue with credentials and "?" characters but couldn't find one.

The issue I've run into is that if a mongo password contains a "?" character, but no auth-mechanism option, then the MongoCredentialPropertyEditor will throw an ArrayIndexOutOfBoundsException. I've done some research on mongo password rules and there doesn't seem to be any limit on using a "?" in the password.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO). **was not sure how to actually create an issue**
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
