### PR TITLE
DATAMONGO-2021 - Use getObjectId() instead of getFilename()

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
@@ -240,7 +240,7 @@ public class GridFsTemplate implements GridFsOperations, ResourcePatternResolver
 
 		Assert.notNull(file, "GridFSFile must not be null!");
 
-		return new GridFsResource(file, getGridFs().openDownloadStream(file.getFilename()));
+		return new GridFsResource(file, getGridFs().openDownloadStream(file.getObjectId()));
 	}
 
 	/*


### PR DESCRIPTION
Using the file name leads to duplicate resource streams as file names
are not unique.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
