### PR TITLE
DATAMONGO-2023 - Allow usage of $sample in aggregation pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>1.10.14.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.14.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.14.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>1.10.14.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.14.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-log4j/pom.xml
+++ b/spring-data-mongodb-log4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.14.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>1.10.14.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2023-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 the original author or authors.
+ * Copyright 2011-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -592,7 +592,7 @@ public class QueryMapper {
 		 * @since 1.8
 		 */
 		public boolean isSample() {
-			return "$sample".equalsIgnoreCase(key);
+			return "$example".equalsIgnoreCase(key);
 		}
 
 		public boolean hasIterableValue() {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -52,7 +52,7 @@ import com.mongodb.DBRef;
 
 /**
  * A helper class to encapsulate any modifications of a Query object before it gets submitted to the database.
- * 
+ *
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Patryk Wasik
@@ -77,7 +77,7 @@ public class QueryMapper {
 
 	/**
 	 * Creates a new {@link QueryMapper} with the given {@link MongoConverter}.
-	 * 
+	 *
 	 * @param converter must not be {@literal null}.
 	 */
 	public QueryMapper(MongoConverter converter) {
@@ -93,7 +93,7 @@ public class QueryMapper {
 	/**
 	 * Replaces the property keys used in the given {@link DBObject} with the appropriate keys by using the
 	 * {@link PersistentEntity} metadata.
-	 * 
+	 *
 	 * @param query must not be {@literal null}.
 	 * @param entity can be {@literal null}.
 	 * @return
@@ -146,7 +146,7 @@ public class QueryMapper {
 	/**
 	 * Maps fields used for sorting to the {@link MongoPersistentEntity}s properties. <br />
 	 * Also converts properties to their {@code $meta} representation if present.
-	 * 
+	 *
 	 * @param sortObject
 	 * @param entity
 	 * @return
@@ -166,7 +166,7 @@ public class QueryMapper {
 	/**
 	 * Maps fields to retrieve to the {@link MongoPersistentEntity}s properties. <br />
 	 * Also onverts and potentially adds missing property {@code $meta} representation.
-	 * 
+	 *
 	 * @param fieldsObject
 	 * @param entity
 	 * @return
@@ -200,7 +200,7 @@ public class QueryMapper {
 
 	/**
 	 * Extracts the mapped object value for given field out of rawValue taking nested {@link Keyword}s into account
-	 * 
+	 *
 	 * @param field
 	 * @param rawValue
 	 * @return
@@ -233,7 +233,7 @@ public class QueryMapper {
 
 	/**
 	 * Returns the given {@link DBObject} representing a keyword by mapping the keyword's value.
-	 * 
+	 *
 	 * @param keyword the {@link DBObject} representing a keyword (e.g. {@code $ne : … } )
 	 * @param entity
 	 * @return
@@ -263,7 +263,7 @@ public class QueryMapper {
 
 	/**
 	 * Returns the mapped keyword considered defining a criteria for the given property.
-	 * 
+	 *
 	 * @param property
 	 * @param keyword
 	 * @return
@@ -282,7 +282,7 @@ public class QueryMapper {
 	/**
 	 * Returns the mapped value for the given source object assuming it's a value for the given
 	 * {@link MongoPersistentProperty}.
-	 * 
+	 *
 	 * @param value the source object to be mapped
 	 * @param property the property the value is a value for
 	 * @param newKey the key the value will be bound to eventually
@@ -332,7 +332,7 @@ public class QueryMapper {
 	 * requires conversion to a {@link org.springframework.data.mongodb.core.mapping.DBRef} object. We check whether the
 	 * type of the given value is compatible with the type of the given document field in order to deal with potential
 	 * query field exclusions, since MongoDB uses the {@code int} {@literal 0} as an indicator for an excluded field.
-	 * 
+	 *
 	 * @param documentField must not be {@literal null}.
 	 * @param value
 	 * @return
@@ -363,7 +363,7 @@ public class QueryMapper {
 
 	/**
 	 * Retriggers mapping if the given source is a {@link DBObject} or simply invokes the
-	 * 
+	 *
 	 * @param source
 	 * @param entity
 	 * @return
@@ -384,7 +384,7 @@ public class QueryMapper {
 	/**
 	 * Converts the given source Object to a mongo type with the type information of the original source type omitted.
 	 * Subclasses may overwrite this method to retain the type information of the source type on the resulting mongo type.
-	 * 
+	 *
 	 * @param source
 	 * @param entity
 	 * @return the converted mongo type or null if source is null
@@ -399,7 +399,7 @@ public class QueryMapper {
 
 	/**
 	 * Converts the given source assuming it's actually an association to another object.
-	 * 
+	 *
 	 * @param source
 	 * @param property
 	 * @return
@@ -438,7 +438,7 @@ public class QueryMapper {
 
 	/**
 	 * Checks whether the given value is a {@link DBObject}.
-	 * 
+	 *
 	 * @param value can be {@literal null}.
 	 * @return
 	 */
@@ -448,7 +448,7 @@ public class QueryMapper {
 
 	/**
 	 * Creates a new {@link Entry} for the given {@link Field} with the given value.
-	 * 
+	 *
 	 * @param field must not be {@literal null}.
 	 * @param value can be {@literal null}.
 	 * @return
@@ -459,7 +459,7 @@ public class QueryMapper {
 
 	/**
 	 * Creates a new {@link Entry} with the given key and value.
-	 * 
+	 *
 	 * @param key must not be {@literal null} or empty.
 	 * @param value can be {@literal null}
 	 * @return
@@ -481,7 +481,7 @@ public class QueryMapper {
 
 	/**
 	 * Converts the given raw id value into either {@link ObjectId} or {@link String}.
-	 * 
+	 *
 	 * @param id
 	 * @return
 	 */
@@ -505,7 +505,7 @@ public class QueryMapper {
 
 	/**
 	 * Returns whether the given {@link Object} is a keyword, i.e. if it's a {@link DBObject} with a keyword key.
-	 * 
+	 *
 	 * @param candidate
 	 * @return
 	 */
@@ -528,7 +528,7 @@ public class QueryMapper {
 	/**
 	 * Returns whether the given {@link String} is a MongoDB keyword. The default implementation will check against the
 	 * set of registered keywords returned by {@link #getKeywords()}.
-	 * 
+	 *
 	 * @param candidate
 	 * @return
 	 */
@@ -538,7 +538,7 @@ public class QueryMapper {
 
 	/**
 	 * Value object to capture a query keyword representation.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	static class Keyword {
@@ -564,7 +564,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns whether the current keyword is the {@code $exists} keyword.
-		 * 
+		 *
 		 * @return
 		 */
 		public boolean isExists() {
@@ -577,7 +577,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns whether the current keyword is the {@code $geometry} keyword.
-		 * 
+		 *
 		 * @return
 		 * @since 1.8
 		 */
@@ -587,7 +587,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns wheter the current keyword indicates a sample object.
-		 * 
+		 *
 		 * @return
 		 * @since 1.8
 		 */
@@ -611,7 +611,7 @@ public class QueryMapper {
 
 	/**
 	 * Value object to represent a field and its meta-information.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	protected static class Field {
@@ -622,7 +622,7 @@ public class QueryMapper {
 
 		/**
 		 * Creates a new {@link DocumentField} without meta-information but the given name.
-		 * 
+		 *
 		 * @param name must not be {@literal null} or empty.
 		 */
 		public Field(String name) {
@@ -633,7 +633,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns a new {@link DocumentField} with the given name.
-		 * 
+		 *
 		 * @param name must not be {@literal null} or empty.
 		 * @return
 		 */
@@ -643,7 +643,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns whether the current field is the id field.
-		 * 
+		 *
 		 * @return
 		 */
 		public boolean isIdField() {
@@ -654,7 +654,7 @@ public class QueryMapper {
 		 * Returns the underlying {@link MongoPersistentProperty} backing the field. For path traversals this will be the
 		 * property that represents the value to handle. This means it'll be the leaf property for plain paths or the
 		 * association property in case we refer to an association somewhere in the path.
-		 * 
+		 *
 		 * @return
 		 */
 		public MongoPersistentProperty getProperty() {
@@ -663,7 +663,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns the {@link MongoPersistentEntity} that field is conatined in.
-		 * 
+		 *
 		 * @return
 		 */
 		public MongoPersistentEntity<?> getPropertyEntity() {
@@ -672,7 +672,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns whether the field represents an association.
-		 * 
+		 *
 		 * @return
 		 */
 		public boolean isAssociation() {
@@ -681,7 +681,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns the key to be used in the mapped document eventually.
-		 * 
+		 *
 		 * @return
 		 */
 		public String getMappedKey() {
@@ -690,7 +690,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns whether the field references an association in case it refers to a nested field.
-		 * 
+		 *
 		 * @return
 		 */
 		public boolean containsAssociation() {
@@ -708,7 +708,7 @@ public class QueryMapper {
 
 	/**
 	 * Extension of {@link DocumentField} to be backed with mapping metadata.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 * @author Thomas Darimont
 	 */
@@ -725,7 +725,7 @@ public class QueryMapper {
 		/**
 		 * Creates a new {@link MetadataBackedField} with the given name, {@link MongoPersistentEntity} and
 		 * {@link MappingContext}.
-		 * 
+		 *
 		 * @param name must not be {@literal null} or empty.
 		 * @param entity must not be {@literal null}.
 		 * @param context must not be {@literal null}.
@@ -738,7 +738,7 @@ public class QueryMapper {
 		/**
 		 * Creates a new {@link MetadataBackedField} with the given name, {@link MongoPersistentEntity} and
 		 * {@link MappingContext} with the given {@link MongoPersistentProperty}.
-		 * 
+		 *
 		 * @param name must not be {@literal null} or empty.
 		 * @param entity must not be {@literal null}.
 		 * @param context must not be {@literal null}.
@@ -788,7 +788,7 @@ public class QueryMapper {
 			return DEFAULT_ID_NAMES.contains(name);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#getProperty()
 		 */
@@ -797,7 +797,7 @@ public class QueryMapper {
 			return association == null ? property : association.getInverse();
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#getEntity()
 		 */
@@ -807,7 +807,7 @@ public class QueryMapper {
 			return property == null ? null : mappingContext.getPersistentEntity(property);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#isAssociation()
 		 */
@@ -816,7 +816,7 @@ public class QueryMapper {
 			return association != null;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#getAssociation()
 		 */
@@ -827,7 +827,7 @@ public class QueryMapper {
 
 		/**
 		 * Finds the association property in the {@link PersistentPropertyPath}.
-		 * 
+		 *
 		 * @return
 		 */
 		private final Association<MongoPersistentProperty> findAssociation() {
@@ -858,7 +858,7 @@ public class QueryMapper {
 
 		/**
 		 * Returns the {@link PersistentPropertyPath} for the given <code>pathExpression</code>.
-		 * 
+		 *
 		 * @param pathExpression
 		 * @return
 		 */
@@ -895,7 +895,7 @@ public class QueryMapper {
 		/**
 		 * Return the {@link Converter} to be used to created the mapped key. Default implementation will use
 		 * {@link PropertyToFieldNameConverter}.
-		 * 
+		 *
 		 * @return
 		 */
 		protected Converter<MongoPersistentProperty, String> getPropertyConverter() {
@@ -905,7 +905,7 @@ public class QueryMapper {
 		/**
 		 * Return the {@link Converter} to use for creating the mapped key of an association. Default implementation is
 		 * {@link AssociationConverter}.
-		 * 
+		 *
 		 * @return
 		 * @since 1.7
 		 */
@@ -935,7 +935,7 @@ public class QueryMapper {
 			}
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#getTypeHint()
 		 */
@@ -972,7 +972,7 @@ public class QueryMapper {
 
 			/**
 			 * Maps the property name while retaining potential positional operator {@literal $}.
-			 * 
+			 *
 			 * @param property
 			 * @return
 			 */
@@ -1014,7 +1014,7 @@ public class QueryMapper {
 
 	/**
 	 * Converter to skip all properties after an association property was rendered.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	protected static class AssociationConverter implements Converter<MongoPersistentProperty, String> {
@@ -1024,7 +1024,7 @@ public class QueryMapper {
 
 		/**
 		 * Creates a new {@link AssociationConverter} for the given {@link Association}.
-		 * 
+		 *
 		 * @param association must not be {@literal null}.
 		 */
 		public AssociationConverter(Association<MongoPersistentProperty> association) {
@@ -1033,7 +1033,7 @@ public class QueryMapper {
 			this.property = association.getInverse();
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
 		 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -45,7 +45,7 @@ import com.mongodb.DBObject;
 /**
  * Central class for creating queries. It follows a fluent API style so that you can easily chain together multiple
  * criteria. Static import of the 'Criteria.where' method will improve readability.
- * 
+ *
  * @author Thomas Risberg
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -82,7 +82,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Static factory method to create a Criteria using the provided key
-	 * 
+	 *
 	 * @param key
 	 * @return
 	 */
@@ -92,7 +92,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Static factory method to create a {@link Criteria} matching an example object.
-	 * 
+	 *
 	 * @param example must not be {@literal null}.
 	 * @return
 	 * @see Criteria#alike(Example)
@@ -104,7 +104,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Static factory method to create a {@link Criteria} matching an example object.
-	 * 
+	 *
 	 * @param example must not be {@literal null}.
 	 * @return
 	 * @see Criteria#alike(Example)
@@ -116,7 +116,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Static factory method to create a Criteria using the provided key
-	 * 
+	 *
 	 * @return
 	 */
 	public Criteria and(String key) {
@@ -125,7 +125,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using equality
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 */
@@ -150,7 +150,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $ne} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/ne/">MongoDB Query operator: $ne</a>
@@ -162,7 +162,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $lt} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/lt/">MongoDB Query operator: $lt</a>
@@ -174,7 +174,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $lte} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/lte/">MongoDB Query operator: $lte</a>
@@ -186,7 +186,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $gt} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/gt/">MongoDB Query operator: $gt</a>
@@ -198,7 +198,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $gte} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/gte/">MongoDB Query operator: $gte</a>
@@ -210,7 +210,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $in} operator.
-	 * 
+	 *
 	 * @param o the values to match against
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/in/">MongoDB Query operator: $in</a>
@@ -226,7 +226,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $in} operator.
-	 * 
+	 *
 	 * @param c the collection containing the values to match against
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/in/">MongoDB Query operator: $in</a>
@@ -238,7 +238,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $nin} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/nin/">MongoDB Query operator: $nin</a>
@@ -249,7 +249,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $nin} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/nin/">MongoDB Query operator: $nin</a>
@@ -261,7 +261,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $mod} operator.
-	 * 
+	 *
 	 * @param value
 	 * @param remainder
 	 * @return
@@ -277,7 +277,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $all} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/all/">MongoDB Query operator: $all</a>
@@ -288,7 +288,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $all} operator.
-	 * 
+	 *
 	 * @param o
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/all/">MongoDB Query operator: $all</a>
@@ -300,7 +300,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $size} operator.
-	 * 
+	 *
 	 * @param s
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/size/">MongoDB Query operator: $size</a>
@@ -312,7 +312,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $exists} operator.
-	 * 
+	 *
 	 * @param b
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/exists/">MongoDB Query operator: $exists</a>
@@ -324,7 +324,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $type} operator.
-	 * 
+	 *
 	 * @param t
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/type/">MongoDB Query operator: $type</a>
@@ -336,7 +336,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $not} meta operator which affects the clause directly following
-	 * 
+	 *
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/not/">MongoDB Query operator: $not</a>
 	 */
@@ -346,7 +346,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $not} operator.
-	 * 
+	 *
 	 * @param value
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/not/">MongoDB Query operator: $not</a>
@@ -358,7 +358,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using a {@literal $regex} operator.
-	 * 
+	 *
 	 * @param re
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/regex/">MongoDB Query operator: $regex</a>
@@ -369,7 +369,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using a {@literal $regex} and {@literal $options} operator.
-	 * 
+	 *
 	 * @param re
 	 * @param options
 	 * @return
@@ -381,7 +381,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Syntactical sugar for {@link #is(Object)} making obvious that we create a regex predicate.
-	 * 
+	 *
 	 * @param pattern
 	 * @return
 	 */
@@ -407,7 +407,7 @@ public class Criteria implements CriteriaDefinition {
 	/**
 	 * Creates a geospatial criterion using a {@literal $geoWithin $centerSphere} operation. This is only available for
 	 * Mongo 2.4 and higher.
-	 * 
+	 *
 	 * @param circle must not be {@literal null}
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/geoWithin/">MongoDB Query operator: $geoWithin</a>
@@ -423,7 +423,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a geospatial criterion using a {@literal $geoWithin} operation.
-	 * 
+	 *
 	 * @param shape
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/geoWithin/">MongoDB Query operator: $geoWithin</a>
@@ -438,7 +438,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a geospatial criterion using a {@literal $near} operation.
-	 * 
+	 *
 	 * @param point must not be {@literal null}
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/near/">MongoDB Query operator: $near</a>
@@ -454,7 +454,7 @@ public class Criteria implements CriteriaDefinition {
 	/**
 	 * Creates a geospatial criterion using a {@literal $nearSphere} operation. This is only available for Mongo 1.7 and
 	 * higher.
-	 * 
+	 *
 	 * @param point must not be {@literal null}
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/nearSphere/">MongoDB Query operator: $nearSphere</a>
@@ -470,7 +470,7 @@ public class Criteria implements CriteriaDefinition {
 	/**
 	 * Creates criterion using {@code $geoIntersects} operator which matches intersections of the given {@code geoJson}
 	 * structure and the documents one. Requires MongoDB 2.4 or better.
-	 * 
+	 *
 	 * @param geoJson must not be {@literal null}.
 	 * @return
 	 * @since 1.8
@@ -485,7 +485,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a geo-spatial criterion using a {@literal $maxDistance} operation, for use with $near
-	 * 
+	 *
 	 * @param maxDistance
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/maxDistance/">MongoDB Query operator: $maxDistance</a>
@@ -504,7 +504,7 @@ public class Criteria implements CriteriaDefinition {
 	/**
 	 * Creates a geospatial criterion using a {@literal $minDistance} operation, for use with {@literal $near} or
 	 * {@literal $nearSphere}.
-	 * 
+	 *
 	 * @param minDistance
 	 * @return
 	 * @since 1.7
@@ -522,7 +522,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the {@literal $elemMatch} operator
-	 * 
+	 *
 	 * @param c
 	 * @return
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/elemMatch/">MongoDB Query operator: $elemMatch</a>
@@ -534,7 +534,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Creates a criterion using the given object as a pattern.
-	 * 
+	 *
 	 * @param sample
 	 * @return
 	 * @since 1.8
@@ -551,7 +551,7 @@ public class Criteria implements CriteriaDefinition {
 	 * <p>
 	 * Note that mongodb doesn't support an $or operator to be wrapped in a $not operator.
 	 * <p>
-	 * 
+	 *
 	 * @throws IllegalArgumentException if {@link #orOperator(Criteria...)} follows a not() call directly.
 	 * @param criteria
 	 */
@@ -565,7 +565,7 @@ public class Criteria implements CriteriaDefinition {
 	 * <p>
 	 * Note that mongodb doesn't support an $nor operator to be wrapped in a $not operator.
 	 * <p>
-	 * 
+	 *
 	 * @throws IllegalArgumentException if {@link #norOperator(Criteria...)} follows a not() call directly.
 	 * @param criteria
 	 */
@@ -579,7 +579,7 @@ public class Criteria implements CriteriaDefinition {
 	 * <p>
 	 * Note that mongodb doesn't support an $and operator to be wrapped in a $not operator.
 	 * <p>
-	 * 
+	 *
 	 * @throws IllegalArgumentException if {@link #andOperator(Criteria...)} follows a not() call directly.
 	 * @param criteria
 	 */
@@ -761,7 +761,7 @@ public class Criteria implements CriteriaDefinition {
 
 	/**
 	 * Checks the given objects for equality. Handles {@link Pattern} and arrays correctly.
-	 * 
+	 *
 	 * @param left
 	 * @param right
 	 * @return

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 the original author or authors.
+ * Copyright 2010-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -541,7 +541,7 @@ public class Criteria implements CriteriaDefinition {
 	 */
 	public Criteria alike(Example<?> sample) {
 
-		criteria.put("$sample", sample);
+		criteria.put("$example", sample);
 		this.criteriaChain.add(this);
 		return this;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 the original author or authors.
+ * Copyright 2011-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -138,6 +137,14 @@ public class QueryMapperUnitTests {
 		assertThat(object, is(instanceOf(DBObject.class)));
 		DBObject dbObject = (DBObject) object;
 		assertThat(dbObject.get("$ne"), is(instanceOf(ObjectId.class)));
+	}
+
+	@Test // DATAMONGO-2023
+	public void translates$SampleCorrectly() {
+
+		DBObject dbObject = new BasicDBObject("$sample", new BasicDBObject("size", 1));
+		DBObject result = mapper.getMappedObject(dbObject, context.getPersistentEntity(Sample.class));
+		assertThat((BasicDBObject) result.get("$sample"), is(new BasicDBObject("size", 1)));
 	}
 
 	@Test // DATAMONGO-326


### PR DESCRIPTION
We now allow usage of `$sample` as aggregation framework stage and are no longer in the way with Query by Example. Previously, we identified Example objects using the `$sample` keyword which prevented query mapping of aggregation pipelines that contained a sample stage.

---

Related ticket: [DATAMONGO-2023](https://jira.spring.io/browse/DATAMONGO-2023).