### PR TITLE
DATAMONGO-2026 - Fix id property resolution for immutable objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2026-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -282,10 +282,15 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		// make sure id property is set before all other properties
 		Object idValue = null;
 
-		if (idProperty != null && documentAccessor.hasValue(idProperty)) {
+		if (idProperty != null) {
 
-			idValue = readIdValue(path, evaluator, idProperty, documentAccessor);
-			accessor.setProperty(idProperty, idValue);
+			if (idProperty.isImmutable() && entity.isConstructorArgument(idProperty)) {
+				idValue = accessor.getProperty(idProperty);
+			} else if (documentAccessor.hasValue(idProperty)) {
+
+				idValue = readIdValue(path, evaluator, idProperty, documentAccessor);
+				accessor.setProperty(idProperty, idValue);
+			}
 		}
 
 		ObjectPath currentPath = path.push(instance, entity, idValue != null ? bson.get(idProperty.getFieldName()) : null);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -1882,6 +1882,15 @@ public class MappingMongoConverterUnitTests {
 		assertThat(result.id).isEqualTo("foo");
 		assertThat(result.witherUsed).isTrue();
 	}
+	@Test // DATAMONGO-2026
+	public void readsImmutableObjectWithConstructorIdPropertyCorrectly() {
+
+		org.bson.Document source = new org.bson.Document("_id", "spring").append("value", "data");
+
+		ImmutableObjectWithIdConstructorPropertyAndNoIdWitherMethod target = converter.read(ImmutableObjectWithIdConstructorPropertyAndNoIdWitherMethod.class, source);
+		assertThat(target.id).isEqualTo("spring");
+		assertThat(target.value).isEqualTo("data");
+	}
 
 	static class GenericType<T> {
 		T content;
@@ -2265,6 +2274,7 @@ public class MappingMongoConverterUnitTests {
 	}
 
 	static class ImmutableObject {
+
 		final String id;
 		final String name;
 		final boolean witherUsed;
@@ -2302,5 +2312,12 @@ public class MappingMongoConverterUnitTests {
 		public boolean isWitherUsed() {
 			return witherUsed;
 		}
+	}
+
+	@RequiredArgsConstructor
+	static class ImmutableObjectWithIdConstructorPropertyAndNoIdWitherMethod {
+
+		final @Id String id;
+		String value;
 	}
 }


### PR DESCRIPTION
We now make sure `id` properties used as persistence constructor arguments are no longer set via the property accessor, but during object instantiation. Previous to this change this caused an `UnsupportedOperationException`.

Related to: #573 