### PR TITLE
DATAMONGO-2027 - Consider MapReduce output type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2027-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1809,6 +1809,12 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			if (mapReduceOptions.getOutputSharded().isPresent()) {
 				mapReduce = mapReduce.sharded(mapReduceOptions.getOutputSharded().get());
 			}
+
+			MapReduceAction action = mapReduceOptions.getMapReduceAction();
+
+			if(action != null && mapReduceOptions.getOutputCollection() != null){
+				mapReduce = mapReduce.action(action).collectionName(mapReduceOptions.getOutputCollection());
+			}
 		}
 
 		mapReduce = collation.map(Collation::toMongoCollation).map(mapReduce::collation).orElse(mapReduce);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2031,6 +2031,12 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 				publisher = publisher.sharded(options.getOutputSharded().get());
 			}
 
+			MapReduceAction action = options.getMapReduceAction();
+
+			if (action != null && options.getOutputCollection() != null) {
+				publisher = publisher.action(action).collectionName(options.getOutputCollection());
+			}
+
 			publisher = collation.map(Collation::toMongoCollation).map(publisher::collation).orElse(publisher);
 
 			return Flux.from(publisher)

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/MapReduceOptions.java
@@ -24,6 +24,7 @@ import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.lang.Nullable;
 
 import com.mongodb.MapReduceCommand;
+import com.mongodb.client.model.MapReduceAction;
 
 /**
  * @author Mark Pollack
@@ -295,6 +296,27 @@ public class MapReduceOptions {
 		return collation;
 	}
 
+	/**
+	 * Return the {@link MapReduceAction} derived from {@link com.mongodb.MapReduceCommand.OutputType}.
+	 *
+	 * @return the mapped action or {@literal null} if the action maps to inline output.
+	 * @since 2.0.9
+	 */
+	@Nullable
+	public MapReduceAction getMapReduceAction() {
+
+		switch (outputType) {
+			case MERGE:
+				return MapReduceAction.MERGE;
+			case REDUCE:
+				return MapReduceAction.REDUCE;
+			case REPLACE:
+				return MapReduceAction.REPLACE;
+		}
+
+		return null;
+	}
+
 	public Document getOptionsObject() {
 
 		Document cmd = new Document();
@@ -328,7 +350,7 @@ public class MapReduceOptions {
 
 		Document out = new Document();
 
-		switch (outputType) {
+		switch (getOutputType()) {
 			case INLINE:
 				out.put("inline", 1);
 				break;


### PR DESCRIPTION
We now consider the output type (collection output) when rendering the `MapReduce` command. Previously, all output was returned inline without storing the results in the configured collection.

---

Related ticket: [DATAMONGO-2027](https://jira.spring.io/browse/DATAMONGO-2027).