### PR TITLE
DATAMONGO-2043 - Omit type hint when mapping simple types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2043-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -412,10 +412,21 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			removeFromMap(bson, "_id");
 		}
 
-		boolean handledByCustomConverter = conversions.hasCustomWriteTarget(entityType, Document.class);
-		if (!handledByCustomConverter && !(bson instanceof Collection)) {
+		if (requiresTypeHint(entityType)) {
 			typeMapper.writeType(type, bson);
 		}
+	}
+
+	/**
+	 * Check if a given type requires a type hint {@literal aka _class attribute} when writing to the document.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return true if not a simple type, collection or type with custom write target.
+	 */
+	private boolean requiresTypeHint(Class<?> type) {
+
+		return !conversions.isSimpleType(type) && !ClassUtils.isAssignable(Collection.class, type)
+				&& !conversions.hasCustomWriteTarget(type, Document.class);
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -1904,6 +1904,15 @@ public class MappingMongoConverterUnitTests {
 		assertThat(converter.read(Attribute.class, source).value).isInstanceOf(List.class);
 	}
 
+	@Test // DATAMONGO-2043
+	public void omitsTypeHintWhenWritingSimpleTypes() {
+
+		org.bson.Document target = new org.bson.Document();
+		converter.write(new org.bson.Document("value", "FitzChivalry"), target);
+
+		assertThat(target).doesNotContainKeys("_class");
+	}
+
 	static class GenericType<T> {
 		T content;
 	}


### PR DESCRIPTION
Make sure to omit the type hint (aka `_class` attribute) when writing objects that are actually considered simple types, eg. `org.bson.Document`.