### PR TITLE
DATAMONGO-2044 make ensureNotIterable actually check if object is iterable

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -151,23 +151,13 @@ import com.mongodb.client.result.UpdateResult;
  * @author Borislav Rangelov
  * @author duozhilin
  * @author Andreas Zink
+ * @author Bartłomiej Mazur
  */
 @SuppressWarnings("deprecation")
 public class MongoTemplate implements MongoOperations, ApplicationContextAware, IndexOperationsProvider {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MongoTemplate.class);
 	private static final WriteResultChecking DEFAULT_WRITE_RESULT_CHECKING = WriteResultChecking.NONE;
-	private static final Collection<String> ITERABLE_CLASSES;
-
-	static {
-
-		Set<String> iterableClasses = new HashSet<>();
-		iterableClasses.add(List.class.getName());
-		iterableClasses.add(Collection.class.getName());
-		iterableClasses.add(Iterator.class.getName());
-
-		ITERABLE_CLASSES = Collections.unmodifiableCollection(iterableClasses);
-	}
 
 	private final MongoConverter mongoConverter;
 	private final MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext;
@@ -1129,7 +1119,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Assert.notNull(objectToSave, "ObjectToSave must not be null!");
 
-		ensureNotIterable(objectToSave);
+		ensureNotAnArrayOrCollection(objectToSave);
 		return insert(objectToSave, operations.determineEntityCollectionName(objectToSave));
 	}
 
@@ -1144,13 +1134,13 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Assert.notNull(objectToSave, "ObjectToSave must not be null!");
 		Assert.notNull(collectionName, "CollectionName must not be null!");
 
-		ensureNotIterable(objectToSave);
+		ensureNotAnArrayOrCollection(objectToSave);
 		return (T) doInsert(collectionName, objectToSave, this.mongoConverter);
 	}
 
-	protected void ensureNotIterable(@Nullable Object o) {
+	protected void ensureNotAnArrayOrCollection(@Nullable Object o) {
 		if (null != o) {
-			if (o.getClass().isArray() || ITERABLE_CLASSES.contains(o.getClass().getName())) {
+			if (o.getClass().isArray() || (o instanceof Collection) || (o instanceof Iterator)) {
 				throw new IllegalArgumentException("Cannot use a collection here.");
 			}
 		}


### PR DESCRIPTION
Other option would be just to remove that check, as it might be possible that someone is saving objects that implement iterable but are valid data classes?

As current code just does nothing, as object can be of type that is implementing one of that interfaces, but it can not be of interface type itself.