### PR TITLE
DATAMONGO-2048 - Add support for MongoDB 4.0 convert aggregation operators.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2048-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -141,8 +141,23 @@ public class ConvertOperators {
 			return createConvert().toTypeOf(expression);
 		}
 
+		/**
+		 * Creates new {@link ToBool aggregation expression} for {@code $toBool} that converts a value to boolean. Shorthand
+		 * for {@link #convertTo(String) #convertTo("bool")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToBool}.
+		 */
+		public ToBool convertToBoolean() {
+			return ToBool.toBoolean(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
+		}
+
+		private Object valueObject() {
+			return usesFieldRef() ? Fields.field(fieldReference) : expression;
 		}
 
 		private boolean usesFieldRef() {
@@ -340,6 +355,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$convert";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toBool} that converts a value to boolean. Shorthand for
+	 * {@link Convert#to(String) Convert#to("bool")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 * "https://docs.mongodb.com/manual/reference/operator/aggregation/toBool/">https://docs.mongodb.com/manual/reference/operator/aggregation/toBool/</a>
+	 * @since 2.1
+	 */
+	public static class ToBool extends AbstractAggregationExpression {
+
+		private ToBool(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToBool} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToBool}.
+		 */
+		public static ToBool toBoolean(Object value) {
+			return new ToBool(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toBool";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -163,6 +163,17 @@ public class ConvertOperators {
 			return ToDate.toDate(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToDecimal aggregation expression} for {@code $toDecimal} that converts a value to a decimal.
+		 * Shorthand for {@link #convertTo(String) #convertTo("decimal")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToDecimal}.
+		 */
+		public ToDecimal convertToDecimal() {
+			return ToDecimal.toDecimal(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -430,6 +441,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toDate";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toDecimal} that converts a value to decimal. Shorthand for
+	 * {@link Convert#to(String) Convert#to("decimal")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toDecimal/">https://docs.mongodb.com/manual/reference/operator/aggregation/toDecimal/</a>
+	 * @since 2.1
+	 */
+	public static class ToDecimal extends AbstractAggregationExpression {
+
+		private ToDecimal(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToDecimal} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToDecimal}.
+		 */
+		public static ToDecimal toDecimal(Object value) {
+			return new ToDecimal(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toDecimal";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -207,6 +207,17 @@ public class ConvertOperators {
 			return ToLong.toLong(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToInt aggregation expression} for {@code $toObjectId} that converts a value to a objectId. Shorthand
+		 * for {@link #convertTo(String) #convertTo("objectId")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToInt}.
+		 */
+		public ToObjectId convertToObjectId() {
+			return ToObjectId.toObjectId(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -602,6 +613,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toLong";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toObjectId} that converts a value to objectId. Shorthand for
+	 * {@link Convert#to(String) Convert#to("objectId")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toObjectId/">https://docs.mongodb.com/manual/reference/operator/aggregation/toObjectId/</a>
+	 * @since 2.1
+	 */
+	public static class ToObjectId extends AbstractAggregationExpression {
+
+		private ToObjectId(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToObjectId} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToObjectId}.
+		 */
+		public static ToObjectId toObjectId(Object value) {
+			return new ToObjectId(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toObjectId";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -174,6 +174,17 @@ public class ConvertOperators {
 			return ToDecimal.toDecimal(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToDouble aggregation expression} for {@code $toDouble} that converts a value to a decimal.
+		 * Shorthand for {@link #convertTo(String) #convertTo("double")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToDouble}.
+		 */
+		public ToDouble convertToDouble() {
+			return ToDouble.toDouble(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -473,6 +484,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toDecimal";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toDouble} that converts a value to double. Shorthand for
+	 * {@link Convert#to(String) Convert#to("double")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toDouble/">https://docs.mongodb.com/manual/reference/operator/aggregation/toDouble/</a>
+	 * @since 2.1
+	 */
+	public static class ToDouble extends AbstractAggregationExpression {
+
+		private ToDouble(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToDouble} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToDouble}.
+		 */
+		public static ToDouble toDouble(Object value) {
+			return new ToDouble(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toDouble";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import java.util.Collections;
+
+import org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Gateway to {@literal convert} aggregation operations.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+public class ConvertOperators {
+
+	/**
+	 * Take the value referenced by given {@literal fieldReference}.
+	 *
+	 * @param fieldReference must not be {@literal null}.
+	 * @return
+	 */
+	public static ConvertOperatorFactory valueOf(String fieldReference) {
+		return new ConvertOperatorFactory(fieldReference);
+	}
+
+	/**
+	 * Take the value provided by the given {@link AggregationExpression}.
+	 *
+	 * @param expression must not be {@literal null}.
+	 * @return
+	 */
+	public static ConvertOperatorFactory valueOf(AggregationExpression expression) {
+		return new ConvertOperatorFactory(expression);
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	public static class ConvertOperatorFactory {
+
+		private final @Nullable String fieldReference;
+		private final @Nullable AggregationExpression expression;
+
+		/**
+		 * Creates new {@link ConvertOperatorFactory} for given {@literal fieldReference}.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 */
+		public ConvertOperatorFactory(String fieldReference) {
+
+			Assert.notNull(fieldReference, "FieldReference must not be null!");
+			this.fieldReference = fieldReference;
+			this.expression = null;
+		}
+
+		/**
+		 * Creates new {@link ConvertOperatorFactory} for given {@link AggregationExpression}.
+		 *
+		 * @param expression must not be {@literal null}.
+		 */
+		public ConvertOperatorFactory(AggregationExpression expression) {
+
+			Assert.notNull(expression, "Expression must not be null!");
+			this.fieldReference = null;
+			this.expression = expression;
+		}
+
+		/**
+		 * Creates new {@link Convert aggregation expression} that takes the associated value and converts it into the type
+		 * specified by the given identifier. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @param stringTypeIdentifier must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert convertTo(String stringTypeIdentifier) {
+			return createConvert().to(stringTypeIdentifier);
+		}
+
+		/**
+		 * Creates new {@link Convert aggregation expression} that takes the associated value and converts it into the type
+		 * specified by the given identifier. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @param numericTypeIdentifier must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert convertTo(int numericTypeIdentifier) {
+			return createConvert().to(numericTypeIdentifier);
+		}
+
+		/**
+		 * Creates new {@link Convert aggregation expression} that takes the associated value and converts it into the type
+		 * specified by the given type. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @param type must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert convertTo(Type type) {
+			return createConvert().to(type);
+		}
+
+		/**
+		 * Creates new {@link Convert aggregation expression} that takes the associated value and converts it into the type
+		 * specified by the value of the given {@link Field field reference}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert convertToTypeOf(String fieldReference) {
+			return createConvert().toTypeOf(fieldReference);
+		}
+
+		/**
+		 * Creates new {@link Convert aggregation expression} that takes the associated value and converts it into the type
+		 * specified by the given {@link AggregationExpression expression}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert convertToTypeOf(AggregationExpression expression) {
+			return createConvert().toTypeOf(expression);
+		}
+
+		private Convert createConvert() {
+			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
+		}
+
+		private boolean usesFieldRef() {
+			return fieldReference != null;
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $convert} that converts a value to a specified type. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 * "https://docs.mongodb.com/manual/reference/operator/aggregation/convert/">https://docs.mongodb.com/manual/reference/operator/aggregation/convert/</a>
+	 * @since 2.1
+	 */
+	public static class Convert extends AbstractAggregationExpression {
+
+		private Convert(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link Convert} using the given value for the {@literal input} attribute.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public static Convert convertValue(Object value) {
+			return new Convert(Collections.singletonMap("input", value));
+		}
+
+		/**
+		 * Creates new {@link Convert} using the value of the provided {@link Field fieldReference} as {@literal input}
+		 * value.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public static Convert convertValueOf(String fieldReference) {
+			return convertValue(Fields.field(fieldReference));
+		}
+
+		/**
+		 * Creates new {@link Convert} using the result of the provided {@link AggregationExpression expression} as
+		 * {@literal input} value.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public static Convert convertValueOf(AggregationExpression expression) {
+			return convertValue(expression);
+		}
+
+		/**
+		 * Specify the conversion target type via its {@link String} representation.
+		 * <ul>
+		 * <li>double</li>
+		 * <li>string</li>
+		 * <li>objectId</li>
+		 * <li>bool</li>
+		 * <li>date</li>
+		 * <li>int</li>
+		 * <li>long</li>
+		 * <li>decimal</li>
+		 * </ul>
+		 *
+		 * @param stringTypeIdentifier must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert to(String stringTypeIdentifier) {
+			return new Convert(append("to", stringTypeIdentifier));
+		}
+
+		/**
+		 * Specify the conversion target type via its numeric representation.
+		 * <dl>
+		 * <dt>1</dt>
+		 * <dd>double</dd>
+		 * <dt>2</dt>
+		 * <dd>string</li>
+		 * <dt>7</dt>
+		 * <dd>objectId</li>
+		 * <dt>8</dt>
+		 * <dd>bool</dd>
+		 * <dt>9</dt>
+		 * <dd>date</dd>
+		 * <dt>16</dt>
+		 * <dd>int</dd>
+		 * <dt>18</dt>
+		 * <dd>long</dd>
+		 * <dt>19</dt>
+		 * <dd>decimal</dd>
+		 * </dl>
+		 *
+		 * @param numericTypeIdentifier must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert to(int numericTypeIdentifier) {
+			return new Convert(append("to", numericTypeIdentifier));
+		}
+
+		/**
+		 * Specify the conversion target type.
+		 *
+		 * @param type must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert to(Type type) {
+
+			String typeString = Type.BOOLEAN.equals(type) ? "bool" : type.value().toString();
+			return to(typeString);
+		}
+
+		/**
+		 * Specify the conversion target type via the value of the given field.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert toTypeOf(String fieldReference) {
+			return new Convert(append("to", Fields.field(fieldReference)));
+		}
+
+		/**
+		 * Specify the conversion target type via the value of the given {@link AggregationExpression expression}.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert toTypeOf(AggregationExpression expression) {
+			return new Convert(append("to", expression));
+		}
+
+		/**
+		 * Optionally specify the value to return on encountering an error during conversion.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onErrorReturn(Object value) {
+			return new Convert(append("onError", value));
+		}
+
+		/**
+		 * Optionally specify the field holding the value to return on encountering an error during conversion.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onErrorReturnValueOf(String fieldReference) {
+			return onErrorReturn(Fields.field(fieldReference));
+		}
+
+		/**
+		 * Optionally specify the expression to evaluate and return on encountering an error during conversion.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onErrorReturnValueOf(AggregationExpression expression) {
+			return onErrorReturn(expression);
+		}
+
+		/**
+		 * Optionally specify the value to return when the input is {@literal null} or missing.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onNullReturn(Object value) {
+			return new Convert(append("onNull", value));
+		}
+
+		/**
+		 * Optionally specify the field holding the value to return when the input is {@literal null} or missing.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onNullReturnValueOf(String fieldReference) {
+			return onNullReturn(Fields.field(fieldReference));
+		}
+
+		/**
+		 * Optionally specify the expression to evaluate and return when the input is {@literal null} or missing.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance of {@link Convert}.
+		 */
+		public Convert onNullReturnValueOf(AggregationExpression expression) {
+			return onNullReturn(expression);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$convert";
+		}
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -152,6 +152,17 @@ public class ConvertOperators {
 			return ToBool.toBoolean(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToDate aggregation expression} for {@code $toDate} that converts a value to a date. Shorthand
+		 * for {@link #convertTo(String) #convertTo("date")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToDate}.
+		 */
+		public ToDate convertToDate() {
+			return ToDate.toDate(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -387,6 +398,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toBool";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toDate} that converts a value to boolean. Shorthand for
+	 * {@link Convert#to(String) Convert#to("date")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toDate/">https://docs.mongodb.com/manual/reference/operator/aggregation/toDate/</a>
+	 * @since 2.1
+	 */
+	public static class ToDate extends AbstractAggregationExpression {
+
+		private ToDate(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToDate} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToDate}.
+		 */
+		public static ToDate toDate(Object value) {
+			return new ToDate(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toDate";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -218,6 +218,17 @@ public class ConvertOperators {
 			return ToObjectId.toObjectId(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToInt aggregation expression} for {@code $toString} that converts a value to a string. Shorthand
+		 * for {@link #convertTo(String) #convertTo("string")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToInt}.
+		 */
+		public ToString convertToString() {
+			return ToString.toString(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -645,6 +656,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toObjectId";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toString} that converts a value to string. Shorthand for
+	 * {@link Convert#to(String) Convert#to("string")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toString/">https://docs.mongodb.com/manual/reference/operator/aggregation/toString/</a>
+	 * @since 2.1
+	 */
+	public static class ToString extends AbstractAggregationExpression {
+
+		private ToString(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToString} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToString}.
+		 */
+		public static ToString toString(Object value) {
+			return new ToString(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toString";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -185,6 +185,17 @@ public class ConvertOperators {
 			return ToDouble.toDouble(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToInt aggregation expression} for {@code $toInt} that converts a value to an int. Shorthand
+		 * for {@link #convertTo(String) #convertTo("int")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToInt}.
+		 */
+		public ToInt convertToInt() {
+			return ToInt.toInt(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -516,6 +527,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toDouble";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toInt} that converts a value to integer. Shorthand for
+	 * {@link Convert#to(String) Convert#to("int")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toInt/">https://docs.mongodb.com/manual/reference/operator/aggregation/toInt/</a>
+	 * @since 2.1
+	 */
+	public static class ToInt extends AbstractAggregationExpression {
+
+		private ToInt(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToInt} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToInt}.
+		 */
+		public static ToInt toInt(Object value) {
+			return new ToInt(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toInt";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ConvertOperators.java
@@ -196,6 +196,17 @@ public class ConvertOperators {
 			return ToInt.toInt(valueObject());
 		}
 
+		/**
+		 * Creates new {@link ToInt aggregation expression} for {@code $toLong} that converts a value to a long. Shorthand
+		 * for {@link #convertTo(String) #convertTo("long")}. <br />
+		 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+		 *
+		 * @return new instance of {@link ToInt}.
+		 */
+		public ToLong convertToLong() {
+			return ToLong.toLong(valueObject());
+		}
+
 		private Convert createConvert() {
 			return usesFieldRef() ? Convert.convertValueOf(fieldReference) : Convert.convertValueOf(expression);
 		}
@@ -559,6 +570,38 @@ public class ConvertOperators {
 		@Override
 		protected String getMongoMethod() {
 			return "$toInt";
+		}
+	}
+
+	/**
+	 * {@link AggregationExpression} for {@code $toLong} that converts a value to long. Shorthand for
+	 * {@link Convert#to(String) Convert#to("long")}. <br />
+	 * <strong>NOTE:</strong> Requires MongoDB 4.0 or later.
+	 *
+	 * @author Christoph Strobl
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/reference/operator/aggregation/toLong/">https://docs.mongodb.com/manual/reference/operator/aggregation/toLong/</a>
+	 * @since 2.1
+	 */
+	public static class ToLong extends AbstractAggregationExpression {
+
+		private ToLong(Object value) {
+			super(value);
+		}
+
+		/**
+		 * Creates new {@link ToLong} using the given value as input.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return new instance of {@link ToLong}.
+		 */
+		public static ToLong toLong(Object value) {
+			return new ToLong(value);
+		}
+
+		@Override
+		protected String getMongoMethod() {
+			return "$toLong";
 		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -110,4 +110,18 @@ public class ConvertOperatorsUnitTests {
 				.toDocument(Aggregation.DEFAULT_CONTEXT)).isEqualTo(Document.parse(
 						"{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onNull\" : " + EXPRESSION_STRING + " } } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toBoolUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToBoolean().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toBool: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toBoolUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToBoolean().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toBool: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -166,4 +166,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDouble().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toDouble: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toIntUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToInt().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toInt: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toIntUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToInt().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toInt: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.bson.Document;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ConvertOperators}.
+ *
+ * @author Christoph Strobl
+ * @currentRead Royal Assassin - Robin Hobb
+ */
+public class ConvertOperatorsUnitTests {
+
+	static final String EXPRESSION_STRING = "{ \"$molly\" : \"chandler\" }";
+	static final Document EXPRESSION_DOC = Document.parse(EXPRESSION_STRING);
+	static final AggregationExpression EXPRESSION = context -> EXPRESSION_DOC;
+
+	@Test // DATAMONGO-2048
+	public void convertToUsingStringIdentifier() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToUsingIntIdentifier() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo(1).toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : 1 } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToTypeOf("fitz").toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"$fitz\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToTypeOf(EXPRESSION).toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : " + EXPRESSION_STRING + " } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnErrorValue() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onErrorReturn("foo")
+				.toDocument(Aggregation.DEFAULT_CONTEXT)).isEqualTo(
+						Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onError\" : \"foo\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnErrorValueOfField() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onErrorReturnValueOf("verity")
+				.toDocument(Aggregation.DEFAULT_CONTEXT))
+						.isEqualTo(Document
+								.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onError\" : \"$verity\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnErrorValueOfExpression() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onErrorReturnValueOf(EXPRESSION)
+				.toDocument(Aggregation.DEFAULT_CONTEXT))
+						.isEqualTo(Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onError\" : "
+								+ EXPRESSION_STRING + " } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnNullValue() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onNullReturn("foo")
+				.toDocument(Aggregation.DEFAULT_CONTEXT)).isEqualTo(
+						Document.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onNull\" : \"foo\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnNullValueOfField() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onNullReturnValueOf("verity")
+				.toDocument(Aggregation.DEFAULT_CONTEXT))
+						.isEqualTo(Document
+								.parse("{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onNull\" : \"$verity\" } } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void convertToWithOnNullValueOfExpression() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertTo("double").onNullReturnValueOf(EXPRESSION)
+				.toDocument(Aggregation.DEFAULT_CONTEXT)).isEqualTo(Document.parse(
+						"{ $convert: { \"input\" : \"$shrewd\", \"to\" : \"double\", \"onNull\" : " + EXPRESSION_STRING + " } } "));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -152,4 +152,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDecimal().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toDecimal: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toDoubleUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToDouble().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDouble: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toDoubleUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDouble().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDouble: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -124,4 +124,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToBoolean().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toBool: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toDateUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToDate().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDate: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toDateUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDate().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDate: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -208,4 +208,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToObjectId().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toObjectId: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toStringUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToString().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toString: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toStringUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToString().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toString: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -180,4 +180,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToInt().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toInt: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toLongUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToLong().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toLong: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toLongUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToLong().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toLong: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -194,4 +194,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToLong().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toLong: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toObjectIdUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToObjectId().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toObjectId: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toObjectIdUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToObjectId().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toObjectId: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ConvertOperatorsUnitTests.java
@@ -138,4 +138,18 @@ public class ConvertOperatorsUnitTests {
 		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDate().toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo(Document.parse("{ $toDate: " + EXPRESSION_STRING + " } "));
 	}
+
+	@Test // DATAMONGO-2048
+	public void toDecimalUsingFieldReference() {
+
+		assertThat(ConvertOperators.valueOf("shrewd").convertToDecimal().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDecimal: \"$shrewd\" } "));
+	}
+
+	@Test // DATAMONGO-2048
+	public void toDecimalUsingExpression() {
+
+		assertThat(ConvertOperators.valueOf(EXPRESSION).convertToDecimal().toDocument(Aggregation.DEFAULT_CONTEXT))
+				.isEqualTo(Document.parse("{ $toDecimal: " + EXPRESSION_STRING + " } "));
+	}
 }

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2095,6 +2095,7 @@ The MongoDB Aggregation Framework provides the following types of aggregation op
 * Array Aggregation Operators
 * Conditional Aggregation Operators
 * Lookup Aggregation Operators
+* Convert Aggregation Operators
 
 At the time of this writing, we provide support for the following Aggregation Operations in Spring Data MongoDB:
 
@@ -2137,6 +2138,8 @@ At the time of this writing, we provide support for the following Aggregation Op
 | Type Aggregation Operators
 | `type`
 
+| Convert Aggregation Operators
+| `convert`, `toBool`, `toDate`, `toDecimal`, `toDouble`, `toInt`, `toLong`, `toObjectId`, `toString`
 |===
 
 * The operation is mapped or added by Spring Data MongoDB.


### PR DESCRIPTION
Add support for `$convert`, `$toBool`, `$toDate`, `$toDecimal`, `$toDouble`, `$toInt`, `$toLong`, `$toObjectId` and `$toString` aggregation operators.

---

Potential candidate to back port to 1.10.x