### PR TITLE
DATAMONGO-2051 - Add support for SCRAM-SHA-256 authentication mechanism to MongoCredentialPropertyEditor. (2.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.10.BUILD-SNAPSHOT</version>
+	<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.10.BUILD-SNAPSHOT</version>
+		<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.10.BUILD-SNAPSHOT</version>
+		<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.10.BUILD-SNAPSHOT</version>
+			<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.10.BUILD-SNAPSHOT</version>
+		<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.10.BUILD-SNAPSHOT</version>
+		<version>2.0.10.DATAMONGO-2051-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoClientVersion.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoClientVersion.java
@@ -32,6 +32,9 @@ public class MongoClientVersion {
 	private static final boolean IS_MONGO_34 = ClassUtils.isPresent("org.bson.types.Decimal128",
 			MongoClientVersion.class.getClassLoader());
 
+	private static final boolean IS_MONGO_38 = ClassUtils.isPresent("com.mongodb.TransactionOptions",
+			MongoClientVersion.class.getClassLoader());
+
 	private static final boolean IS_ASYNC_CLIENT = ClassUtils.isPresent("com.mongodb.async.client.MongoClient",
 			MongoClientVersion.class.getClassLoader());
 
@@ -51,9 +54,17 @@ public class MongoClientVersion {
 	}
 
 	/**
-	 * @return {lliteral true} if MongoDB Java driver is on classpath.
+	 * @return {@literal true} if MongoDB Java driver is on classpath.
 	 */
 	public static boolean isAsyncClient() {
 		return IS_ASYNC_CLIENT;
+	}
+
+	/**
+	 * @return {@literal true} if MongoDB Java driver version 3.8 or later is on classpath.
+	 * @since 2.10
+	 */
+	public static boolean isMongo38Driver() {
+		return IS_MONGO_38;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/MongoCredentialPropertyEditorUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.config;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -24,6 +25,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.data.mongodb.util.MongoClientVersion;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.MongoCredential;
@@ -72,6 +74,9 @@ public class MongoCredentialPropertyEditorUnitTests {
 	static final String USER_5_AUTH_STRING = USER_5_NAME + ":" + USER_5_PWD + "@" + USER_5_DB;
 	static final String USER_5_AUTH_STRING_WITH_PLAIN_AUTH_MECHANISM = USER_5_AUTH_STRING + "?uri.authMechanism=PLAIN";
 	static final String USER_5_AUTH_STRING_WITH_QUERY_ARGS = USER_5_AUTH_STRING + "?uri.authMechanism=PLAIN&foo=&bar";
+
+	static final String SCRAM_SHA_256_AUTH_STRING = USER_1_NAME + ":" + USER_1_PWD + "@" + USER_1_DB
+			+ "?uri.authMechanism=SCRAM-SHA-256";
 
 	static final MongoCredential USER_1_CREDENTIALS = MongoCredential.createCredential(USER_1_NAME, USER_1_DB,
 			USER_1_PWD.toCharArray());
@@ -223,7 +228,7 @@ public class MongoCredentialPropertyEditorUnitTests {
 
 		editor.setAsText("tyrion?uri.authMechanism=MONGODB-X509");
 
-		assertThat(getValue()). contains(MongoCredential.createMongoX509Credential("tyrion"));
+		assertThat(getValue()).contains(MongoCredential.createMongoX509Credential("tyrion"));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1257
@@ -267,6 +272,16 @@ public class MongoCredentialPropertyEditorUnitTests {
 		editor.setAsText(USER_5_AUTH_STRING_WITH_PLAIN_AUTH_MECHANISM);
 
 		assertThat(getValue()).contains(USER_5_CREDENTIALS_PLAIN_AUTH);
+	}
+
+	@Test // DATAMONGO-2051
+	public void shouldReturnScramSha256Credentials() {
+
+		assumeThat(MongoClientVersion.isMongo38Driver()).isTrue();
+
+		editor.setAsText(SCRAM_SHA_256_AUTH_STRING);
+
+		assertThat(getValue()).isNotEmpty();
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-2016


### PR DESCRIPTION
Using reflective lookup/invocation of `MongoCredential.createScramSha256Credential` available as of MongoDB Java Driver 3.8.