### PR TITLE
DATAMONGO-2046 - Performance optimizations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -27,7 +27,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.1.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.1.0.DATACMNS-1366-SNAPSHOT</springdata.commons>
 		<mongo>3.8.0</mongo>
 		<mongo.reactivestreams>1.9.0</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2046-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -137,7 +137,7 @@ class DocumentAccessor {
 	/**
 	 * Returns the raw identifier for the given {@link MongoPersistentEntity} or the value of the default identifier
 	 * field.
-	 * 
+	 *
 	 * @param entity must not be {@literal null}.
 	 * @return
 	 */
@@ -159,15 +159,20 @@ class DocumentAccessor {
 
 		String fieldName = property.getFieldName();
 
+
+		if (this.document instanceof Document) {
+
+			if (((Document) this.document).containsKey(fieldName)) {
+				return true;
+			}
+		} else if (this.document instanceof DBObject) {
+			if (((DBObject) this.document).containsField(fieldName)) {
+				return true;
+			}
+		}
+
 		if (!fieldName.contains(".")) {
-
-			if (this.document instanceof Document) {
-				return ((Document) this.document).containsKey(fieldName);
-			}
-
-			if (this.document instanceof DBObject) {
-				return ((DBObject) this.document).containsField(fieldName);
-			}
+			return false;
 		}
 
 		String[] parts = fieldName.split("\\.");

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -242,7 +242,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			throw new MappingException(String.format(INVALID_TYPE_TO_READ, target, typeToUse.getType()));
 		}
 
-		return read((MongoPersistentEntity<S>) mappingContext.getRequiredPersistentEntity(typeToUse), target, path);
+		return read((MongoPersistentEntity<S>) entity, target, path);
 	}
 
 	private ParameterValueProvider<MongoPersistentProperty> getParameterProvider(MongoPersistentEntity<?> entity,

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -272,6 +272,16 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		EntityInstantiator instantiator = instantiators.getInstantiatorFor(entity);
 		S instance = instantiator.createInstance(entity, provider);
 
+		if (entity.requiresPropertyPopulation()) {
+			return populateProperties(entity, bson, path, evaluator, instance);
+		}
+
+		return instance;
+	}
+
+	private <S> S populateProperties(MongoPersistentEntity<S> entity, Document bson, ObjectPath path,
+			SpELExpressionEvaluator evaluator, S instance) {
+
 		PersistentPropertyAccessor<S> accessor = new ConvertingPropertyAccessor<>(entity.getPropertyAccessor(instance),
 				conversionService);
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -17,7 +17,6 @@ package org.springframework.data.mongodb.core.convert;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.BiFunction;
 
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -289,7 +288,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		// Make sure id property is set before all other properties
 
 		Object rawId = readAndPopulateIdentifier(accessor, documentAccessor, entity,
-				(property, id) -> readIdValue(path, evaluator, property, id));
+				path, evaluator);
 		ObjectPath currentPath = path.push(accessor.getBean(), entity, rawId);
 
 		MongoDbPropertyValueProvider valueProvider = new MongoDbPropertyValueProvider(documentAccessor, evaluator,
@@ -310,12 +309,12 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	 * @param accessor must not be {@literal null}.
 	 * @param document must not be {@literal null}.
 	 * @param entity must not be {@literal null}.
-	 * @param callback the callback to actually resolve the value for the identifier property, must not be
-	 *          {@literal null}.
+	 * @param path
+	 * @param evaluator
 	 * @return
 	 */
 	private Object readAndPopulateIdentifier(PersistentPropertyAccessor<?> accessor, DocumentAccessor document,
-			MongoPersistentEntity<?> entity, BiFunction<MongoPersistentProperty, Object, Object> callback) {
+			MongoPersistentEntity<?> entity, ObjectPath path, SpELExpressionEvaluator evaluator) {
 
 		Object rawId = document.getRawId(entity);
 
@@ -329,7 +328,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			return rawId;
 		}
 
-		accessor.setProperty(idProperty, callback.apply(idProperty, rawId));
+		accessor.setProperty(idProperty, readIdValue(path, evaluator, idProperty, rawId));
 
 		return rawId;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/CachingMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/CachingMongoPersistentProperty.java
@@ -24,11 +24,14 @@ import org.springframework.lang.Nullable;
  * {@link MongoPersistentProperty} caching access to {@link #isIdProperty()} and {@link #getFieldName()}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class CachingMongoPersistentProperty extends BasicMongoPersistentProperty {
 
 	private @Nullable Boolean isIdProperty;
 	private @Nullable Boolean isAssociation;
+	private @Nullable boolean dbRefResolved;
+	private @Nullable DBRef dbref;
 	private @Nullable String fieldName;
 	private @Nullable Boolean usePropertyAccess;
 	private @Nullable Boolean isTransient;
@@ -36,8 +39,7 @@ public class CachingMongoPersistentProperty extends BasicMongoPersistentProperty
 	/**
 	 * Creates a new {@link CachingMongoPersistentProperty}.
 	 *
-	 * @param field
-	 * @param propertyDescriptor
+	 * @param property
 	 * @param owner
 	 * @param simpleTypeHolder
 	 * @param fieldNamingStrategy
@@ -113,5 +115,29 @@ public class CachingMongoPersistentProperty extends BasicMongoPersistentProperty
 		}
 
 		return this.isTransient;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.mapping.BasicMongoPersistentProperty#isDbReference()
+	 */
+	@Override
+	public boolean isDbReference() {
+		return getDBRef() != null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.mapping.BasicMongoPersistentProperty#getDBRef()
+	 */
+	@Override
+	public DBRef getDBRef() {
+
+		if (!dbRefResolved) {
+			this.dbref = super.getDBRef();
+			this.dbRefResolved = true;
+		}
+
+		return this.dbref;
 	}
 }


### PR DESCRIPTION
Various optimizations to improve CPU and memory consumption.

**Baseline**

```
Benchmark                                                                     Mode  Cnt        Score        Error  Units
MappingMongoConverterBenchmark.readObjectWith2Properties                     thrpt   10  1595760,841 ± 190172,611  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesAnd1NestedObject     thrpt   10   745325,414 ±  31819,541  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesConstructorCreation  thrpt   10  1545948,636 ±  71914,291  ops/s
MappingMongoConverterBenchmark.readObjectWithListAndMapsOfComplexType        thrpt   10   114421,125 ±   2570,836  ops/s
MappingMongoConverterBenchmark.writeObjectWith2PropertiesAnd1NestedObject    thrpt   10   990447,535 ±  18082,689  ops/s
MappingMongoConverterBenchmark.writeObjectWithListAndMapsOfComplexType       thrpt   10   150329,330 ±   1552,529  ops/s
```

**After optimizations** (without `DATACMNS-1366`)

```
Benchmark                                                                     Mode  Cnt        Score        Error  Units
MappingMongoConverterBenchmark.readObjectWith2Properties                     thrpt   10  1901418,878 ±  42860,397  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesAnd1NestedObject     thrpt   10   878169,600 ± 140822,915  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesConstructorCreation  thrpt   10  1691408,752 ±  29058,524  ops/s
MappingMongoConverterBenchmark.readObjectWithListAndMapsOfComplexType        thrpt   10   139606,761 ±   2933,151  ops/s
MappingMongoConverterBenchmark.writeObjectWith2PropertiesAnd1NestedObject    thrpt   10  1002344,779 ±  19669,362  ops/s
MappingMongoConverterBenchmark.writeObjectWithListAndMapsOfComplexType       thrpt   10   158590,534 ±   2457,356  ops/s
```

**After optimizations** (with `DATACMNS-1366`)

```
Benchmark                                                                     Mode  Cnt        Score       Error  Units
MappingMongoConverterBenchmark.readObjectWith2Properties                     thrpt   10  1952981,262 ± 29559,740  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesAnd1NestedObject     thrpt   10   964554,056 ±  7183,559  ops/s
MappingMongoConverterBenchmark.readObjectWith2PropertiesConstructorCreation  thrpt   10  1704016,207 ± 35992,424  ops/s
MappingMongoConverterBenchmark.readObjectWithListAndMapsOfComplexType        thrpt   10   148036,200 ±  1835,007  ops/s
MappingMongoConverterBenchmark.writeObjectWith2PropertiesAnd1NestedObject    thrpt   10  1048958,420 ±  8158,864  ops/s
MappingMongoConverterBenchmark.writeObjectWithListAndMapsOfComplexType       thrpt   10   160894,020 ±   952,022  ops/s
```

---

Related tickets: [DATACMNS-1366](https://jira.spring.io/browse/DATACMNS-1366), [DATACMNS-1366](https://jira.spring.io/browse/DATAMONGO-2046).