### PR TITLE
DATAMONGO-2075 - Open up MongoTransaction manager to allow transaction commit retry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2075-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/src/main/asciidoc/reference/client-session-transactions.adoc
+++ b/src/main/asciidoc/reference/client-session-transactions.adoc
@@ -315,6 +315,14 @@ MongoDB does *not* support collection operations, such as collection creation, w
 affects the on the fly collection creation that happens on first usage. Therefore make sure to have all required
 structures in place.
 
+*Transient Errors*
+
+MongoDB can add special labels to errors raised during a transactional execution. Those may indicate transient failures
+that might vanish by simply retrying the operation.
+We highly recommend https://github.com/spring-projects/spring-retry[Spring Retry] for those purposes. Nevertheless
+one may override `MongoTransactionManager#doCommit(MongoTransactionObject)` to implement a https://docs.mongodb.com/manual/core/transactions/#retry-commit-operation[Retry Commit Operation]
+behaviour as outlined in the MongoDB reference manual.
+
 *Count*
 
 MongoDB `count` operates upon collection statistics which may not reflect the actual situation within a transaction.


### PR DESCRIPTION
MongoDB can add special labels to errors raised during a transactional execution. Those may indicate transient failures that might vanish by simply retrying the operation.
We highly recommend [Spring Retry](https://github.com/spring-projects/spring-retry) for those purposes. Nevertheless one may override `MongoTransactionManager#doCommit(MongoTransactionObject)` to implement a [Retry Commit Operation](https://docs.mongodb.com/manual/core/transactions/#retry-commit-operation)
behavior as outlined in the MongoDB reference manual.

```java
@Bean
MongoTransactionManager txManager(MongoDbFactory dbFactory) {
  return new MongoTransactionManager(dbFactory) {
    @Override
    protected void doCommit(MongoTransactionObject transactionObject) throws Exception {
      int retries = 3;
      do {
        try {
          transactionObject.commitTransaction();
          break;
        } catch (MongoException ex) {
          if (!ex.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
            throw ex;
          }
        }
        Thread.sleep(500);
      } while (--retries > 0);
    }
  };
}
```