### PR TITLE
DATAMONGO-2080 - Support tailable cursors with the fluent reactive API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2080-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
@@ -86,16 +86,18 @@ public interface ReactiveFindOperation {
 		Flux<T> all();
 
 		/**
-		 * Get all matching elements using a tailable cursor.
+		 * Get all matching elements using a {@link com.mongodb.CursorType#TailableAwait tailable cursor}. The stream will
+		 * not be completed unless the {@link org.reactivestreams.Subscription} is
+		 * {@link org.reactivestreams.Subscription#cancel() canceled}.
 		 * <p />
-		 * The stream may become dead, or invalid, if either the query returns no match or the cursor returns the document
-		 * at the "end" of the collection and then the application deletes that document.
-		 * <p/>
+		 * However, the stream may become dead, or invalid, if either the query returns no match or the cursor returns the
+		 * document at the "end" of the collection and then the application deletes that document.
+		 * <p />
 		 * A stream that is no longer in use must be {@link reactor.core.Disposable#dispose()} disposed} otherwise the
 		 * streams will linger and exhaust resources. <br/>
 		 * <strong>NOTE:</strong> Requires a capped collection.
 		 *
-		 * @return never {@literal null}.
+		 * @return the {@link Flux} emitting converted objects.
 		 * @since 2.1
 		 */
 		Flux<T> tail();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
@@ -86,6 +86,21 @@ public interface ReactiveFindOperation {
 		Flux<T> all();
 
 		/**
+		 * Get all matching elements using a tailable cursor.
+		 * <p />
+		 * The stream may become dead, or invalid, if either the query returns no match or the cursor returns the document
+		 * at the "end" of the collection and then the application deletes that document.
+		 * <p/>
+		 * A stream that is no longer in use must be {@link reactor.core.Disposable#dispose()} disposed} otherwise the
+		 * streams will linger and exhaust resources. <br/>
+		 * <strong>NOTE:</strong> Requires a capped collection.
+		 *
+		 * @return never {@literal null}.
+		 * @since 2.1
+		 */
+		Flux<T> tail();
+
+		/**
 		 * Get the number of matching elements.
 		 *
 		 * @return {@link Mono} emitting total number of matching elements. Never {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupport.java
@@ -171,6 +171,15 @@ class ReactiveFindOperationSupport implements ReactiveFindOperation {
 
 		/*
 		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.ReactiveFindOperation.TerminatingFind#tail()
+		 */
+		@Override
+		public Flux<T> tail() {
+			return doFind(template.new TailingQueryFindPublisherPreparer(query, domainType));
+		}
+
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.mongodb.core.ReactiveFindOperation.FindWithQuery#near(org.springframework.data.mongodb.core.query.NearQuery)
 		 */
 		@Override

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
@@ -32,7 +32,6 @@ import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryExecu
 import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryExecution.GeoNearExecution;
 import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryExecution.ResultProcessingConverter;
 import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryExecution.ResultProcessingExecution;
-import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryExecution.TailExecution;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -146,7 +145,7 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 		} else if (method.isGeoNearQuery()) {
 			return new GeoNearExecution(operations, accessor, method.getReturnType());
 		} else if (isTailable(method)) {
-			return new TailExecution(operations, accessor.getPageable());
+			return (q, t, c) -> operation.matching(q.with(accessor.getPageable())).tail();
 		} else if (method.isCollectionQuery()) {
 			return (q, t, c) -> operation.matching(q.with(accessor.getPageable())).all();
 		} else if (isCountQuery()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
@@ -119,7 +119,7 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 
 		String collection = method.getEntityInformation().getCollectionName();
 
-		ReactiveMongoQueryExecution execution = getExecution(query, parameterAccessor,
+		ReactiveMongoQueryExecution execution = getExecution(parameterAccessor,
 				new ResultProcessingConverter(processor, operations, instantiators), find);
 
 		return execution.execute(query, processor.getReturnedType().getDomainType(), collection);
@@ -128,12 +128,11 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 	/**
 	 * Returns the execution instance to use.
 	 *
-	 * @param query must not be {@literal null}.
 	 * @param accessor must not be {@literal null}.
 	 * @param resultProcessing must not be {@literal null}.
 	 * @return
 	 */
-	private ReactiveMongoQueryExecution getExecution(Query query, MongoParameterAccessor accessor,
+	private ReactiveMongoQueryExecution getExecution(MongoParameterAccessor accessor,
 			Converter<Object, Object> resultProcessing, FindWithQuery<?> operation) {
 		return new ResultProcessingExecution(getExecutionToWrap(accessor, operation), resultProcessing);
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveMongoQueryExecution.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveMongoQueryExecution.java
@@ -52,23 +52,6 @@ interface ReactiveMongoQueryExecution {
 	Object execute(Query query, Class<?> type, String collection);
 
 	/**
-	 * {@link ReactiveMongoQueryExecution} for collection returning queries using tailable cursors.
-	 *
-	 * @author Mark Paluch
-	 */
-	@RequiredArgsConstructor
-	final class TailExecution implements ReactiveMongoQueryExecution {
-
-		private final @NonNull ReactiveMongoOperations operations;
-		private final Pageable pageable;
-
-		@Override
-		public Object execute(Query query, Class<?> type, String collection) {
-			return operations.tail(query.with(pageable), type, collection);
-		}
-	}
-
-	/**
 	 * {@link MongoQueryExecution} to execute geo-near queries.
 	 *
 	 * @author Mark Paluch

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
@@ -231,14 +231,14 @@ public class ReactiveMongoRepositoryTests implements BeanClassLoaderAware, BeanF
 	@Test // DATAMONGO-2080
 	public void shouldUseTailableCursorWithDtoProjection() {
 
-		StepVerifier.create(template.dropCollection(Capped.class) //
+		template.dropCollection(Capped.class) //
 				.then(template.createCollection(Capped.class, //
-						CollectionOptions.empty().size(1000).maxDocuments(100).capped()))) //
-				.expectNextCount(1) //
+						CollectionOptions.empty().size(1000).maxDocuments(100).capped())) //
+				.as(StepVerifier::create).expectNextCount(1) //
 				.verifyComplete();
 
-		StepVerifier.create(template.insert(new Capped("value", Math.random()))).expectNextCount(1).verifyComplete();
-		StepVerifier.create(cappedRepository.findDtoProjectionByKey("value")).expectNextCount(1).thenCancel().verify();
+		template.insert(new Capped("value", Math.random())).as(StepVerifier::create).expectNextCount(1).verifyComplete();
+		cappedRepository.findDtoProjectionByKey("value").as(StepVerifier::create).expectNextCount(1).thenCancel().verify();
 	}
 
 	@Test // DATAMONGO-1444


### PR DESCRIPTION
We now support queries to return a tailable cursor using the fluent reactive API.

```
 query(Human.class)
     .inCollection("star-wars")
     .as(Jedi.class)
     .matching(query(where("firstname").is("luke")))
     .tail();
```

---

Related ticket: [DATAMONGO-2080](https://jira.spring.io/browse/DATAMONGO-2080).