### PR TITLE
DATAMONGO-2086 - Fix Fluent API Kotlin extension generics to allow projections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.0.BUILD-SNAPSHOT</version>
+			<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATAMONGO-2086-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ fun <T : Any> ExecutableFindOperation.query(entityClass: KClass<T>): ExecutableF
 inline fun <reified T : Any> ExecutableFindOperation.query(): ExecutableFindOperation.ExecutableFind<T> =
 		query(T::class.java)
 
-
 /**
  * Extension for [ExecutableFindOperation.FindWithProjection. as] providing a [KClass] based variant.
  *
@@ -45,7 +44,7 @@ inline fun <reified T : Any> ExecutableFindOperation.query(): ExecutableFindOper
  * @author Mark Paluch
  * @since 2.0
  */
-fun <T : Any> ExecutableFindOperation.FindWithProjection<T>.asType(resultType: KClass<T>): ExecutableFindOperation.FindWithQuery<T> =
+fun <T : Any> ExecutableFindOperation.FindWithProjection<*>.asType(resultType: KClass<T>): ExecutableFindOperation.FindWithQuery<T> =
 		`as`(resultType.java)
 
 /**
@@ -55,7 +54,7 @@ fun <T : Any> ExecutableFindOperation.FindWithProjection<T>.asType(resultType: K
  * @author Mark Paluch
  * @since 2.0
  */
-inline fun <reified T : Any> ExecutableFindOperation.FindWithProjection<T>.asType(): ExecutableFindOperation.FindWithQuery<T> =
+inline fun <reified T : Any> ExecutableFindOperation.FindWithProjection<*>.asType(): ExecutableFindOperation.FindWithQuery<T> =
 		`as`(T::class.java)
 
 /**

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
@@ -65,3 +65,12 @@ inline fun <reified T : Any> ExecutableFindOperation.FindWithProjection<*>.asTyp
  */
 fun <T : Any> ExecutableFindOperation.DistinctWithProjection.asType(resultType: KClass<T>): ExecutableFindOperation.TerminatingDistinct<T> =
 		`as`(resultType.java);
+
+/**
+ * Extension for [ExecutableFindOperation.DistinctWithProjection. as] leveraging reified type parameters.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+inline fun <reified T : Any> ExecutableFindOperation.DistinctWithProjection.asType(): ExecutableFindOperation.DistinctWithProjection =
+		`as`(T::class.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensions.kt
@@ -41,7 +41,7 @@ inline fun <reified T : Any> ExecutableMapReduceOperation.mapReduce(): Executabl
  * @author Christoph Strobl
  * @since 2.1
  */
-fun <T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<T>.asType(resultType: KClass<T>): ExecutableMapReduceOperation.MapReduceWithQuery<T> =
+fun <T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<*>.asType(resultType: KClass<T>): ExecutableMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(resultType.java)
 
 /**
@@ -50,5 +50,5 @@ fun <T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<T>.asType(res
  * @author Christoph Strobl
  * @since 2.1
  */
-inline fun <reified T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<T>.asType(): ExecutableMapReduceOperation.MapReduceWithQuery<T> =
+inline fun <reified T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<*>.asType(): ExecutableMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(T::class.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ inline fun <reified T : Any> ReactiveFindOperation.query(): ReactiveFindOperatio
  * @author Mark Paluch
  * @since 2.0
  */
-fun <T : Any> ReactiveFindOperation.FindWithProjection<T>.asType(resultType: KClass<T>): ReactiveFindOperation.FindWithQuery<T> =
+fun <T : Any> ReactiveFindOperation.FindWithProjection<*>.asType(resultType: KClass<T>): ReactiveFindOperation.FindWithQuery<T> =
 		`as`(resultType.java)
 
 /**
@@ -50,7 +50,7 @@ fun <T : Any> ReactiveFindOperation.FindWithProjection<T>.asType(resultType: KCl
  * @author Mark Paluch
  * @since 2.0
  */
-inline fun <reified T : Any> ReactiveFindOperation.FindWithProjection<T>.asType(): ReactiveFindOperation.FindWithQuery<T> =
+inline fun <reified T : Any> ReactiveFindOperation.FindWithProjection<*>.asType(): ReactiveFindOperation.FindWithQuery<T> =
 		`as`(T::class.java)
 
 /**

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
@@ -61,3 +61,12 @@ inline fun <reified T : Any> ReactiveFindOperation.FindWithProjection<*>.asType(
  */
 fun <T : Any> ReactiveFindOperation.DistinctWithProjection.asType(resultType: KClass<T>): ReactiveFindOperation.TerminatingDistinct<T> =
 		`as`(resultType.java);
+
+/**
+ * Extension for [ReactiveFindOperation.DistinctWithProjection. as] leveraging reified type parameters.
+ *
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+inline fun <reified T : Any> ReactiveFindOperation.DistinctWithProjection.asType(): ReactiveFindOperation.DistinctWithProjection =
+		`as`(T::class.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensions.kt
@@ -41,7 +41,7 @@ inline fun <reified T : Any> ReactiveMapReduceOperation.mapReduce(): ReactiveMap
  * @author Christoph Strobl
  * @since 2.1
  */
-fun <T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<T>.asType(resultType: KClass<T>): ReactiveMapReduceOperation.MapReduceWithQuery<T> =
+fun <T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<*>.asType(resultType: KClass<T>): ReactiveMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(resultType.java)
 
 /**
@@ -50,5 +50,5 @@ fun <T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<T>.asType(resul
  * @author Christoph Strobl
  * @since 2.1
  */
-inline fun <reified T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<T>.asType(): ReactiveMapReduceOperation.MapReduceWithQuery<T> =
+inline fun <reified T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<*>.asType(): ReactiveMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(T::class.java)

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,24 +53,24 @@ class ExecutableFindOperationExtensionsTests {
         verify(operation).query(First::class.java)
     }
 
-    @Test // DATAMONGO-1689
+    @Test // DATAMONGO-1689, DATAMONGO-2086
     fun `ExecutableFindOperation#FindOperationWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-        operationWithProjection.asType(First::class)
-        verify(operationWithProjection).`as`(First::class.java)
+        operationWithProjection.asType(User::class)
+        verify(operationWithProjection).`as`(User::class.java)
     }
 
-    @Test // DATAMONGO-1689
+    @Test // DATAMONGO-1689, DATAMONGO-2086
     fun `ExecutableFindOperation#FindOperationWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
-        operationWithProjection.asType()
-        verify(operationWithProjection).`as`(First::class.java)
+        operationWithProjection.asType<User>()
+        verify(operationWithProjection).`as`(User::class.java)
     }
 
-    @Test // DATAMONGO-1761
+    @Test // DATAMONGO-1761, DATAMONGO-2086
     fun `ExecutableFindOperation#DistinctWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-        distinctWithProjection.asType(First::class)
-        verify(distinctWithProjection).`as`(First::class.java)
+        distinctWithProjection.asType(User::class)
+        verify(distinctWithProjection).`as`(User::class.java)
     }
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
@@ -73,4 +73,11 @@ class ExecutableFindOperationExtensionsTests {
         distinctWithProjection.asType(User::class)
         verify(distinctWithProjection).`as`(User::class.java)
     }
+
+    @Test // DATAMONGO-2086
+    fun `ExecutableFindOperation#DistinctWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
+
+        distinctWithProjection.asType<User>()
+        verify(distinctWithProjection).`as`(User::class.java)
+    }
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensionsTests.kt
@@ -49,17 +49,17 @@ class ExecutableMapReduceOperationExtensionsTests {
 		verify(operation).mapReduce(First::class.java)
 	}
 
-	@Test // DATAMONGO-1929
+	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ExecutableMapReduceOperation#MapReduceWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-		operationWithProjection.asType(First::class)
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType(User::class)
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 
-	@Test // DATAMONGO-1929
+	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ExecutableMapReduceOperation#MapReduceWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
-		operationWithProjection.asType()
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType<User>()
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
@@ -72,4 +72,11 @@ class ReactiveFindOperationExtensionsTests {
 		distinctWithProjection.asType(User::class)
 		verify(distinctWithProjection).`as`(User::class.java)
 	}
+
+	@Test // DATAMONGO-2086
+	fun `ReactiveFind#DistinctWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
+
+		distinctWithProjection.asType<User>()
+		verify(distinctWithProjection).`as`(User::class.java)
+	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,24 +52,24 @@ class ReactiveFindOperationExtensionsTests {
 		verify(operation).query(First::class.java)
 	}
 
-	@Test // DATAMONGO-1719
+	@Test // DATAMONGO-1719, DATAMONGO-2086
 	fun `ReactiveFind#FindOperatorWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-		operationWithProjection.asType(First::class)
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType(User::class)
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 
-	@Test // DATAMONGO-1719
+	@Test // DATAMONGO-1719, DATAMONGO-2086
 	fun `ReactiveFind#FindOperatorWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
-		operationWithProjection.asType()
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType<User>()
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 
-	@Test // DATAMONGO-1761
+	@Test // DATAMONGO-1761, DATAMONGO-2086
 	fun `ReactiveFind#DistinctWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-		distinctWithProjection.asType(First::class)
-		verify(distinctWithProjection).`as`(First::class.java)
+		distinctWithProjection.asType(User::class)
+		verify(distinctWithProjection).`as`(User::class.java)
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensionsTests.kt
@@ -52,14 +52,14 @@ class ReactiveMapReduceOperationExtensionsTests {
 	@Test // DATAMONGO-1929
 	fun `ReactiveMapReduceOperation#MapReduceWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
-		operationWithProjection.asType(First::class)
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType(User::class)
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 
 	@Test // DATAMONGO-1929
 	fun `ReactiveMapReduceOperation#MapReduceWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
-		operationWithProjection.asType()
-		verify(operationWithProjection).`as`(First::class.java)
+		operationWithProjection.asType<User>()
+		verify(operationWithProjection).`as`(User::class.java)
 	}
 }


### PR DESCRIPTION
We now fixed Kotlin extension generics to properly use projections by ignoring the source type of the Fluent API object. Previously, the source and target type were linked which prevented the use of a different result type.

---

Related ticket: [DATAMONGO-2086](https://jira.spring.io/browse/DATAMONGO-2086).