### PR TITLE
DATAMONGO-2087 - Typo in MongoRepository. Obvious Fix

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/MongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/MongoRepository.java
@@ -30,6 +30,7 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Khaled Baklouti
  */
 @NoRepositoryBean
 public interface MongoRepository<T, ID> extends PagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
@@ -39,7 +40,7 @@ public interface MongoRepository<T, ID> extends PagingAndSortingRepository<T, ID
 	 * @see org.springframework.data.repository.CrudRepository#saveAll(java.lang.Iterable)
 	 */
 	@Override
-	<S extends T> List<S> saveAll(Iterable<S> entites);
+	<S extends T> List<S> saveAll(Iterable<S> entities);
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
DATAMONGO-2087 - Typo in MongoRepository.
Obvious Fix.
in the interface org.springframework.data.mongodb.repository.MongoRepository.
line 43, change entites to entities. 