### PR TITLE
DATAMONGO-2101 - Fix DBObject to GeoJson conversion. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.0.11.BUILD-SNAPSHOT</version>
+	<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.11.BUILD-SNAPSHOT</version>
+		<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.11.BUILD-SNAPSHOT</version>
+		<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.0.11.BUILD-SNAPSHOT</version>
+			<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.11.BUILD-SNAPSHOT</version>
+		<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.0.11.BUILD-SNAPSHOT</version>
+		<version>2.0.11.DATAMONGO-2101-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -50,6 +50,7 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent;
 import org.springframework.data.mongodb.core.mapping.event.MongoMappingEvent;
+import org.springframework.data.mongodb.util.BsonUtils;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -207,6 +208,8 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 		if (conversions.hasCustomReadTarget(bson.getClass(), rawType)) {
 			return conversionService.convert(bson, rawType);
+		} else if (bson instanceof DBObject && conversions.hasCustomReadTarget(Document.class, rawType)) {
+			return conversionService.convert(new Document(BsonUtils.asMap(bson)), rawType);
 		}
 
 		if (DBObject.class.isAssignableFrom(rawType)) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Address.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Address.java
@@ -15,17 +15,27 @@
  */
 package org.springframework.data.mongodb.repository;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.data.mongodb.core.geo.GeoJson;
+
 import com.querydsl.core.annotations.QueryEmbeddable;
 
 /**
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 @QueryEmbeddable
+@Getter
+@Setter
 public class Address {
 
 	private String street;
 	private String zipCode;
 	private String city;
+
+	private GeoJson location;
 
 	protected Address() {
 
@@ -39,48 +49,6 @@ public class Address {
 	public Address(String street, String zipcode, String city) {
 		this.street = street;
 		this.zipCode = zipcode;
-		this.city = city;
-	}
-
-	/**
-	 * @return the street
-	 */
-	public String getStreet() {
-		return street;
-	}
-
-	/**
-	 * @param street the street to set
-	 */
-	public void setStreet(String street) {
-		this.street = street;
-	}
-
-	/**
-	 * @return the zipCode
-	 */
-	public String getZipCode() {
-		return zipCode;
-	}
-
-	/**
-	 * @param zipCode the zipCode to set
-	 */
-	public void setZipCode(String zipCode) {
-		this.zipCode = zipCode;
-	}
-
-	/**
-	 * @return the city
-	 */
-	public String getCity() {
-		return city;
-	}
-
-	/**
-	 * @param city the city to set
-	 */
-	public void setCity(String city) {
 		this.city = city;
 	}
 }


### PR DESCRIPTION
Querydsl still wraps MongoDB data in `DBObject` which causes trouble with the registered converters that deal with from `Document` conversion. Therefore we now try to extract the argument map from the `DBObject` transferring it to `Document` in order to have the converters kick in where applicable.

This issue applies to the 2.0.x line only as we added Querydsl support for `Document` in `2.1` and use `DBObject` in `1.x`.