### PR TITLE
DATAMONGO-2113 - Fix resumeTimestamp conversion for change streams.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2113-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamEvent.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamEvent.java
@@ -83,7 +83,9 @@ public class ChangeStreamEvent<T> {
 	 */
 	@Nullable
 	public Instant getTimestamp() {
-		return raw != null && raw.getClusterTime() != null ? Instant.ofEpochMilli(raw.getClusterTime().getValue()) : null;
+
+		return raw != null && raw.getClusterTime() != null
+				? converter.getConversionService().convert(raw.getClusterTime(), Instant.class) : null;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -1915,7 +1915,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		publisher = options.getResumeToken().map(BsonValue::asDocument).map(publisher::resumeAfter).orElse(publisher);
 		publisher = options.getCollation().map(Collation::toMongoCollation).map(publisher::collation).orElse(publisher);
-		publisher = options.getResumeTimestamp().map(it -> new BsonTimestamp(it.toEpochMilli()))
+		publisher = options.getResumeTimestamp().map(it -> new BsonTimestamp((int) it.getEpochSecond(), 0))
 				.map(publisher::startAtOperationTime).orElse(publisher);
 		publisher = publisher.fullDocument(options.getFullDocumentLookup().orElse(fullDocument));
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Currency;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.bson.types.Code;
@@ -86,6 +88,7 @@ abstract class MongoConverters {
 		converters.add(LongToAtomicLongConverter.INSTANCE);
 		converters.add(IntegerToAtomicIntegerConverter.INSTANCE);
 		converters.add(BinaryToByteArrayConverter.INSTANCE);
+		converters.add(BsonTimestampToInstantConverter.INSTANCE);
 
 		return converters;
 	}
@@ -463,6 +466,24 @@ abstract class MongoConverters {
 		@Override
 		public byte[] convert(Binary source) {
 			return source.getData();
+		}
+	}
+
+	/**
+	 * {@link Converter} implementation converting {@link BsonTimestamp} into {@link Instant}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.1.2
+	 */
+	@ReadingConverter
+	enum BsonTimestampToInstantConverter implements Converter<BsonTimestamp, Instant> {
+
+		INSTANCE;
+
+		@Nullable
+		@Override
+		public Instant convert(BsonTimestamp source) {
+			return Instant.ofEpochSecond(source.getTime(), 0);
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
@@ -115,7 +115,7 @@ class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>,
 					.orElseGet(() -> ClassUtils.isAssignable(Document.class, targetType) ? FullDocument.DEFAULT
 							: FullDocument.UPDATE_LOOKUP);
 
-			startAt = changeStreamOptions.getResumeTimestamp().map(Instant::toEpochMilli).map(BsonTimestamp::new)
+			startAt = changeStreamOptions.getResumeTimestamp().map(it -> new BsonTimestamp((int) it.getEpochSecond(), 0))
 					.orElse(null);
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1355,7 +1356,7 @@ public class ReactiveMongoTemplateTests {
 		}
 	}
 
-	@Test // DATAMONGO-2012
+	@Test // DATAMONGO-2012, DATAMONGO-2113
 	public void resumesAtTimestampCorrectly() throws InterruptedException {
 
 		Assumptions.assumeThat(ReplicaSet.required().runsAsReplicaSet()).isTrue();
@@ -1372,7 +1373,7 @@ public class ReactiveMongoTemplateTests {
 		Person person2 = new Person("Data", 37);
 		Person person3 = new Person("MongoDB", 39);
 
-		StepVerifier.create(template.save(person1)).expectNextCount(1).verifyComplete();
+		StepVerifier.create(template.save(person1).delayElement(Duration.ofSeconds(1))).expectNextCount(1).verifyComplete();
 		StepVerifier.create(template.save(person2)).expectNextCount(1).verifyComplete();
 
 		Thread.sleep(500); // just give it some time to link receive all events

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
@@ -19,10 +19,15 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Currency;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.assertj.core.data.TemporalUnitLessThanOffset;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
 import org.junit.Test;
 import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
@@ -32,14 +37,14 @@ import org.springframework.data.geo.Shape;
 import org.springframework.data.mongodb.core.convert.MongoConverters.AtomicIntegerToIntegerConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.AtomicLongToLongConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.BigDecimalToStringConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.BsonTimestampToInstantConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.CurrencyToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.IntegerToAtomicIntegerConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.LongToAtomicLongConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToCurrencyConverter;
 import org.springframework.data.mongodb.core.geo.Sphere;
-
-import org.bson.Document;
+import org.springframework.data.mongodb.test.util.Assertions;
 
 /**
  * Unit tests for {@link MongoConverters}.
@@ -145,4 +150,12 @@ public class MongoConvertersUnitTests {
 	public void convertsIntegerToAtomicIntegerCorrectly() {
 		assertThat(IntegerToAtomicIntegerConverter.INSTANCE.convert(100), is(instanceOf(AtomicInteger.class)));
 	}
+
+	@Test // DATAMONGO-2113
+	public void convertsBsonTimestampToInstantCorrectly() {
+		
+		Assertions.assertThat(BsonTimestampToInstantConverter.INSTANCE.convert(new BsonTimestamp(6615900307735969796L)))
+				.isCloseTo(Instant.ofEpochSecond(1540384327), new TemporalUnitLessThanOffset(100, ChronoUnit.MILLIS));
+	}
+
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.mongodb.core.convert;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -44,7 +43,6 @@ import org.springframework.data.mongodb.core.convert.MongoConverters.LongToAtomi
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToCurrencyConverter;
 import org.springframework.data.mongodb.core.geo.Sphere;
-import org.springframework.data.mongodb.test.util.Assertions;
 
 /**
  * Unit tests for {@link MongoConverters}.
@@ -60,10 +58,10 @@ public class MongoConvertersUnitTests {
 
 		BigDecimal bigDecimal = BigDecimal.valueOf(254, 1);
 		String value = BigDecimalToStringConverter.INSTANCE.convert(bigDecimal);
-		assertThat(value, is("25.4"));
+		assertThat(value).isEqualTo("25.4");
 
 		BigDecimal reference = StringToBigDecimalConverter.INSTANCE.convert(value);
-		assertThat(reference, is(bigDecimal));
+		assertThat(reference).isEqualTo(bigDecimal);
 	}
 
 	@Test // DATAMONGO-858
@@ -74,7 +72,7 @@ public class MongoConvertersUnitTests {
 		Document document = GeoConverters.BoxToDocumentConverter.INSTANCE.convert(box);
 		Shape shape = GeoConverters.DocumentToBoxConverter.INSTANCE.convert(document);
 
-		assertThat(shape, is((org.springframework.data.geo.Shape) box));
+		assertThat(shape).isEqualTo(box);
 	}
 
 	@Test // DATAMONGO-858
@@ -85,7 +83,7 @@ public class MongoConvertersUnitTests {
 		Document document = GeoConverters.CircleToDocumentConverter.INSTANCE.convert(circle);
 		Shape shape = GeoConverters.DocumentToCircleConverter.INSTANCE.convert(document);
 
-		assertThat(shape, is((org.springframework.data.geo.Shape) circle));
+		assertThat(shape).isEqualTo(circle);
 	}
 
 	@Test // DATAMONGO-858
@@ -96,7 +94,7 @@ public class MongoConvertersUnitTests {
 		Document document = GeoConverters.PolygonToDocumentConverter.INSTANCE.convert(polygon);
 		Shape shape = GeoConverters.DocumentToPolygonConverter.INSTANCE.convert(document);
 
-		assertThat(shape, is((org.springframework.data.geo.Shape) polygon));
+		assertThat(shape).isEqualTo(polygon);
 	}
 
 	@Test // DATAMONGO-858
@@ -107,7 +105,7 @@ public class MongoConvertersUnitTests {
 		Document document = GeoConverters.SphereToDocumentConverter.INSTANCE.convert(sphere);
 		org.springframework.data.geo.Shape shape = GeoConverters.DocumentToSphereConverter.INSTANCE.convert(document);
 
-		assertThat(shape, is((org.springframework.data.geo.Shape) sphere));
+		assertThat(shape).isEqualTo(sphere);
 	}
 
 	@Test // DATAMONGO-858
@@ -118,43 +116,43 @@ public class MongoConvertersUnitTests {
 		Document document = GeoConverters.PointToDocumentConverter.INSTANCE.convert(point);
 		org.springframework.data.geo.Point converted = GeoConverters.DocumentToPointConverter.INSTANCE.convert(document);
 
-		assertThat(converted, is((org.springframework.data.geo.Point) point));
+		assertThat(converted).isEqualTo(point);
 	}
 
 	@Test // DATAMONGO-1372
 	public void convertsCurrencyToStringCorrectly() {
-		assertThat(CurrencyToStringConverter.INSTANCE.convert(Currency.getInstance("USD")), is("USD"));
+		assertThat(CurrencyToStringConverter.INSTANCE.convert(Currency.getInstance("USD"))).isEqualTo("USD");
 	}
 
 	@Test // DATAMONGO-1372
 	public void convertsStringToCurrencyCorrectly() {
-		assertThat(StringToCurrencyConverter.INSTANCE.convert("USD"), is(Currency.getInstance("USD")));
+		assertThat(StringToCurrencyConverter.INSTANCE.convert("USD")).isEqualTo(Currency.getInstance("USD"));
 	}
 
 	@Test // DATAMONGO-1416
 	public void convertsAtomicLongToLongCorrectly() {
-		assertThat(AtomicLongToLongConverter.INSTANCE.convert(new AtomicLong(100L)), is(100L));
+		assertThat(AtomicLongToLongConverter.INSTANCE.convert(new AtomicLong(100L))).isEqualTo(100L);
 	}
 
 	@Test // DATAMONGO-1416
 	public void convertsAtomicIntegerToIntegerCorrectly() {
-		assertThat(AtomicIntegerToIntegerConverter.INSTANCE.convert(new AtomicInteger(100)), is(100));
+		assertThat(AtomicIntegerToIntegerConverter.INSTANCE.convert(new AtomicInteger(100))).isEqualTo(100);
 	}
 
 	@Test // DATAMONGO-1416
 	public void convertsLongToAtomicLongCorrectly() {
-		assertThat(LongToAtomicLongConverter.INSTANCE.convert(100L), is(instanceOf(AtomicLong.class)));
+		assertThat(LongToAtomicLongConverter.INSTANCE.convert(100L)).isInstanceOf(AtomicLong.class);
 	}
 
 	@Test // DATAMONGO-1416
 	public void convertsIntegerToAtomicIntegerCorrectly() {
-		assertThat(IntegerToAtomicIntegerConverter.INSTANCE.convert(100), is(instanceOf(AtomicInteger.class)));
+		assertThat(IntegerToAtomicIntegerConverter.INSTANCE.convert(100)).isInstanceOf(AtomicInteger.class);
 	}
 
 	@Test // DATAMONGO-2113
 	public void convertsBsonTimestampToInstantCorrectly() {
-		
-		Assertions.assertThat(BsonTimestampToInstantConverter.INSTANCE.convert(new BsonTimestamp(6615900307735969796L)))
+
+		assertThat(BsonTimestampToInstantConverter.INSTANCE.convert(new BsonTimestamp(6615900307735969796L)))
 				.isCloseTo(Instant.ofEpochSecond(1540384327), new TemporalUnitLessThanOffset(100, ChronoUnit.MILLIS));
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTests.java
@@ -405,7 +405,7 @@ public class ChangeStreamTests {
 				.append("user_name", "jellyBelly").append("age", 8).append("_class", User.class.getName()));
 	}
 
-	@Test // DATAMONGO-2012
+	@Test // DATAMONGO-2012, DATAMONGO-2113
 	public void resumeAtTimestampCorrectly() throws InterruptedException {
 
 		CollectingMessageListener<ChangeStreamDocument<Document>, User> messageListener1 = new CollectingMessageListener<>();
@@ -415,6 +415,9 @@ public class ChangeStreamTests {
 		awaitSubscription(subscription1);
 
 		template.save(jellyBelly);
+
+		Thread.sleep(1000); // cluster timestamp is in seconds, so we need to wait at least one.
+
 		template.save(sugarSplashy);
 
 		awaitMessages(messageListener1, 12);


### PR DESCRIPTION
We now use the first 32 bits of the `BsonTimestamp` to create the `Instant` and ignore the ordinal value.