### PR TITLE
DATAMONGO-2155 - Fix mapping of Map key/value pairs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2155-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
@@ -82,7 +82,21 @@ public class MappedDocument {
 		return Filters.eq(ID_FIELD, document.get(ID_FIELD));
 	}
 
-	public Update updateWithoutId() {
-		return Update.fromDocument(document, ID_FIELD);
+	public MappedUpdate updateWithoutId() {
+		return new MappedUpdate(Update.fromDocument(document, ID_FIELD));
+	}
+
+	public class MappedUpdate extends Update {
+
+		private final Update delegate;
+
+		public MappedUpdate(Update delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Document getUpdateObject() {
+			return delegate.getUpdateObject();
+		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.data.util.StreamUtils;
 
 import com.mongodb.client.model.Filters;
@@ -86,17 +87,55 @@ public class MappedDocument {
 		return new MappedUpdate(Update.fromDocument(document, ID_FIELD));
 	}
 
-	public class MappedUpdate extends Update {
+	/**
+	 * An {@link UpdateDefinition} that indicates that the {@link #getUpdateObject() update object} has already been
+	 * mapped to the specific domain type.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.2
+	 */
+	public class MappedUpdate implements UpdateDefinition {
 
 		private final Update delegate;
 
-		public MappedUpdate(Update delegate) {
+		MappedUpdate(Update delegate) {
 			this.delegate = delegate;
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#getUpdateObject()
+		 */
 		@Override
 		public Document getUpdateObject() {
 			return delegate.getUpdateObject();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#modifies(java.lang.String)
+		 */
+		@Override
+		public boolean modifies(String key) {
+			return delegate.modifies(key);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#incVersion(java.lang.String)
+		 */
+		@Override
+		public void incVersion(String version) {
+			delegate.incVersion(version);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#isIsolated()
+		 */
+		@Override
+		public Boolean isIsolated() {
+			return delegate.isIsolated();
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -94,6 +94,7 @@ import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.data.mongodb.core.validation.Validator;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.util.CloseableIterator;
@@ -1554,7 +1555,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		return doUpdate(collectionName, query, update, entityClass, false, true);
 	}
 
-	protected UpdateResult doUpdate(final String collectionName, final Query query, final Update update,
+	protected UpdateResult doUpdate(final String collectionName, final Query query, final UpdateDefinition update,
 			@Nullable final Class<?> entityClass, final boolean upsert, final boolean multi) {
 
 		Assert.notNull(collectionName, "CollectionName must not be null!");
@@ -1615,12 +1616,12 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		});
 	}
 
-	private void increaseVersionForUpdateIfNecessary(@Nullable MongoPersistentEntity<?> persistentEntity, Update update) {
+	private void increaseVersionForUpdateIfNecessary(@Nullable MongoPersistentEntity<?> persistentEntity, UpdateDefinition update) {
 
 		if (persistentEntity != null && persistentEntity.hasVersionProperty()) {
 			String versionFieldName = persistentEntity.getRequiredVersionProperty().getFieldName();
 			if (!update.modifies(versionFieldName)) {
-				update.inc(versionFieldName, 1L);
+				update.incVersion(versionFieldName);
 			}
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -60,6 +60,7 @@ import org.springframework.data.mongodb.SessionSynchronization;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.DefaultBulkOperations.BulkOperationContext;
 import org.springframework.data.mongodb.core.EntityOperations.AdaptibleEntity;
+import org.springframework.data.mongodb.core.MappedDocument.MappedUpdate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
@@ -1383,7 +1384,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		MappedDocument mapped = source.toMappedDocument(mongoConverter);
 
 		maybeEmitEvent(new BeforeSaveEvent<>(toSave, mapped.getDocument(), collectionName));
-		Update update = mapped.updateWithoutId();
+		MappedUpdate update = mapped.updateWithoutId();
 
 		UpdateResult result = doUpdate(collectionName, query, update, toSave.getClass(), false, false);
 
@@ -1579,7 +1580,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					query.getCollation().map(Collation::toMongoCollation).ifPresent(opts::collation);
 				}
 
-				Document updateObj = updateMapper.getMappedObject(update.getUpdateObject(), entity);
+				Document updateObj =  update instanceof MappedUpdate ? update.getUpdateObject() : updateMapper.getMappedObject(update.getUpdateObject(), entity);
 
 				if (multi && update.isIsolated() && !queryObj.containsKey("$isolated")) {
 					queryObj.put("$isolated", 1);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -91,6 +91,7 @@ import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.data.mongodb.core.validation.Validator;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.util.Optionals;
@@ -1614,7 +1615,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		return doUpdate(collectionName, query, update, entityClass, false, true);
 	}
 
-	protected Mono<UpdateResult> doUpdate(final String collectionName, Query query, @Nullable Update update,
+	protected Mono<UpdateResult> doUpdate(final String collectionName, Query query, @Nullable UpdateDefinition update,
 			@Nullable Class<?> entityClass, final boolean upsert, final boolean multi) {
 
 		MongoPersistentEntity<?> entity = entityClass == null ? null : getPersistentEntity(entityClass);
@@ -1671,12 +1672,13 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		return result.next();
 	}
 
-	private void increaseVersionForUpdateIfNecessary(@Nullable MongoPersistentEntity<?> persistentEntity, Update update) {
+	private void increaseVersionForUpdateIfNecessary(@Nullable MongoPersistentEntity<?> persistentEntity,
+			UpdateDefinition update) {
 
 		if (persistentEntity != null && persistentEntity.hasVersionProperty()) {
 			String versionFieldName = persistentEntity.getRequiredVersionProperty().getFieldName();
 			if (!update.modifies(versionFieldName)) {
-				update.inc(versionFieldName, 1L);
+				update.incVersion(versionFieldName);
 			}
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -20,7 +20,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
@@ -51,6 +53,7 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBList;
@@ -448,6 +451,23 @@ public class QueryMapper {
 
 		if (source instanceof BsonValue) {
 			return source;
+		}
+
+		if (source instanceof Map) {
+
+			LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+
+			((Map<String, Object>) source).entrySet().forEach(it -> {
+
+				String key = ObjectUtils.nullSafeToString(converter.convertToMongoType(it.getKey()));
+
+				if (it.getValue() instanceof Document) {
+					map.put(key, getMappedObject((Document) it.getValue(), entity));
+				} else {
+					map.put(key, delegateConvertToMongoType(it.getValue(), entity));
+				}
+			});
+			return map;
 		}
 
 		return delegateConvertToMongoType(source, entity);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -35,6 +35,7 @@ import org.springframework.data.domain.Example;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
@@ -816,13 +817,24 @@ public class QueryMapper {
 			return null;
 		}
 
+		/**
+		 * Returns whether the field references a {@link java.util.Map}.
+		 * 
+		 * @return {@literal true} if property information is available and references a {@link java.util.Map}.
+		 * @see PersistentProperty#isMap()
+		 * @since 2.2
+		 */
+		public boolean isMap() {
+			return getProperty() != null && getProperty().isMap();
+		}
+
 		public TypeInformation<?> getTypeHint() {
 			return ClassTypeInformation.OBJECT;
 		}
 	}
 
 	/**
-	 * Extension of {@link DocumentField} to be backed with mapping metadata.
+	 * Extension of {@link Field} to be backed with mapping metadata.
 	 *
 	 * @author Oliver Gierke
 	 * @author Thomas Darimont

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -15,17 +15,8 @@
  */
 package org.springframework.data.mongodb.core.convert;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 
 import org.bson.BsonValue;
 import org.bson.Document;
@@ -431,6 +422,7 @@ public class QueryMapper {
 	 * @return
 	 */
 	@Nullable
+	@SuppressWarnings("unchecked")
 	protected Object convertSimpleOrDocument(Object source, @Nullable MongoPersistentEntity<?> entity) {
 
 		if (source instanceof List) {
@@ -455,7 +447,7 @@ public class QueryMapper {
 
 		if (source instanceof Map) {
 
-			LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+			Map<String, Object> map = new LinkedHashMap<>();
 
 			((Map<String, Object>) source).entrySet().forEach(it -> {
 
@@ -467,6 +459,7 @@ public class QueryMapper {
 					map.put(key, delegateConvertToMongoType(it.getValue(), entity));
 				}
 			});
+
 			return map;
 		}
 
@@ -656,11 +649,11 @@ public class QueryMapper {
 	static class Keyword {
 
 		private static final String N_OR_PATTERN = "\\$.*or";
-		private static final Set<String> NON_DBREF_CONVERTING_KEYWORDS = new HashSet<>(Arrays.asList("$", "$size", "$slice", "$gt", "$lt"));
+		private static final Set<String> NON_DBREF_CONVERTING_KEYWORDS = new HashSet<>(
+				Arrays.asList("$", "$size", "$slice", "$gt", "$lt"));
 
 		private final String key;
 		private final Object value;
-
 
 		public Keyword(Bson source, String key) {
 			this.key = key;
@@ -723,7 +716,6 @@ public class QueryMapper {
 		}
 
 		/**
-		 *
 		 * @return {@literal true} if key may hold a DbRef.
 		 * @since 2.1.4
 		 */
@@ -842,7 +834,6 @@ public class QueryMapper {
 		 * 
 		 * @return {@literal true} if property information is available and references a {@link java.util.Map}.
 		 * @see PersistentProperty#isMap()
-		 * @since 2.2
 		 */
 		public boolean isMap() {
 			return getProperty() != null && getProperty().isMap();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.convert;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
 import org.bson.Document;
@@ -143,7 +144,9 @@ public class UpdateMapper extends QueryMapper {
 	protected Entry<String, Object> getMappedObjectForField(Field field, Object rawValue) {
 
 		if (isDocument(rawValue)) {
-			return createMapEntry(field, convertSimpleOrDocument(rawValue, field.getPropertyEntity()));
+
+			Object val = field.isMap() ? new LinkedHashMap<>((Document) rawValue) : rawValue; // unwrap to preserve field type
+			return createMapEntry(field, convertSimpleOrDocument(val, field.getPropertyEntity()));
 		}
 
 		if (isQuery(rawValue)) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Pavel Vodrazka
  */
-public class Update {
+public class Update implements UpdateDefinition {
 
 	public enum Position {
 		LAST, FIRST
@@ -153,6 +153,15 @@ public class Update {
 	public Update inc(String key, Number inc) {
 		addMultiFieldOperation("$inc", key, inc);
 		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#incVersion()
+	 */
+	@Override
+	public void incVersion(String key) {
+		inc(key, 1L);
 	}
 
 	/**
@@ -390,14 +399,18 @@ public class Update {
 		return this;
 	}
 
-	/**
-	 * @return {@literal true} if update isolated is set.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#isIsolated()
 	 */
 	public Boolean isIsolated() {
 		return isolated;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#getUpdateObject()
+	 */
 	public Document getUpdateObject() {
 		return new Document(modifierOps);
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query;
+
+import org.bson.Document;
+
+/**
+ * Interface fixing must have operations for {@literal updates} as implemented via {@link Update}.
+ *
+ * @author Christoph Strobl
+ * @since 2.2
+ */
+public interface UpdateDefinition {
+
+	/**
+	 * If {@literal true} prevents a write operation that affects <strong>multiple</strong> documents from yielding to
+	 * other reads or writes once the first document is written. <br />
+	 *
+	 * @return {@literal true} if update isolated is set.
+	 */
+	Boolean isIsolated();
+
+	/**
+	 * @return the actual update in its native {@link Document} format. Never {@literal null}.
+	 */
+	Document getUpdateObject();
+
+	/**
+	 * Check if a given {@literal key} is modified by applying the update.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal true} if the actual {@link UpdateDefinition} attempts to modify the given {@literal key}.
+	 */
+	boolean modifies(String key);
+
+	/**
+	 * Bump the version of a given {@literal key} by {@code 1}.
+	 *
+	 * @param key must not be {@literal null}.
+	 */
+	void incVersion(String key);
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -537,6 +537,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	@Test // DATAMONGO-1639
 	public void beforeConvertEventForUpdateSeesNextVersion() {
 
+		when(updateResult.getModifiedCount()).thenReturn(1L);
+
 		final VersionedEntity entity = new VersionedEntity();
 		entity.id = 1;
 		entity.version = 0;
@@ -553,15 +555,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 
 		template.setApplicationContext(context);
 
-		MongoTemplate spy = Mockito.spy(template);
-
-		UpdateResult result = mock(UpdateResult.class);
-		doReturn(1L).when(result).getModifiedCount();
-
-		doReturn(result).when(spy).doUpdate(anyString(), any(Query.class), any(Update.class), any(Class.class),
-				anyBoolean(), anyBoolean());
-
-		spy.save(entity);
+		template.save(entity);
 	}
 
 	@Test // DATAMONGO-1447

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -979,6 +979,31 @@ public class UpdateMapperUnitTests {
 				.doesNotContainKey("$set.concreteInnerList.[0]._class");
 	}
 
+	@Test // DATAMONGO-2155
+	public void shouldPreserveFieldNamesOfMapProperties() {
+
+		Update update = Update
+				.fromDocument(new Document("concreteMap", new Document("Name", new Document("name", "fooo"))));
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithObjectMap.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("concreteMap", new Document("Name", new Document("name", "fooo"))));
+	}
+
+	@Test // DATAMONGO-2155
+	public void shouldPreserveExplicitFieldNamesInsideMapProperties() {
+
+		Update update = Update
+				.fromDocument(new Document("map", new Document("Value", new Document("renamed-value", "fooo"))));
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithMapOfAliased.class));
+
+		assertThat(mappedUpdate)
+				.isEqualTo(new Document("map", new Document("Value", new Document("renamed-value", "fooo"))));
+	}
+
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
 		ListModelWrapper concreteTypeWithListAttributeOfInterfaceType;
 	}
@@ -1199,6 +1224,10 @@ public class UpdateMapperUnitTests {
 
 		@Field("renamed-value") Object value;
 		Object field;
+	}
+
+	static class EntityWithMapOfAliased {
+		Map<String, EntityWithAliasedObject> map;
 	}
 
 	static class EntityWithObjectMap {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/DocumentAssert.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/DocumentAssert.java
@@ -288,7 +288,7 @@ public class DocumentAssert extends AbstractMapAssert<DocumentAssert, Map<String
 
 			String key = it.next().replace("\\.", ".");
 
-			if (!(current instanceof Bson) && !key.startsWith("[")) {
+			if ((!(current instanceof Bson) && !(current instanceof Map)) && !key.startsWith("[")) {
 				return Lookup.found(null);
 			}
 
@@ -308,6 +308,17 @@ public class DocumentAssert extends AbstractMapAssert<DocumentAssert, Map<String
 				if (current instanceof Document) {
 
 					Document document = (Document) current;
+
+					if (!it.hasNext() && !document.containsKey(key)) {
+						return Lookup.notFound();
+					}
+
+					current = document.get(key);
+				}
+
+				else if (current instanceof Map) {
+
+					Map document = (Map) current;
 
 					if (!it.hasNext() && !document.containsKey(key)) {
 						return Lookup.notFound();


### PR DESCRIPTION
We now make sure to map key/value pairs of `Map` like properties to the values domain type, and apply potentially registered custom converters to the keys.

We also fixed an invalid test for [DATAMONGO-1423](https://jira.spring.io/browse/DATAMONGO-1423) as this one did not check the application of the registered converter and now bypass a 2nd round of (actually not needed) conversion when the update has been generated by the template API to persist a versioned entity.

