### PR TITLE
DATAMONGO-2193 - Fix String <> ObjectId conversion for non id properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.1.5.BUILD-SNAPSHOT</version>
+	<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.5.BUILD-SNAPSHOT</version>
+		<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.5.BUILD-SNAPSHOT</version>
+		<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.1.5.BUILD-SNAPSHOT</version>
+			<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.5.BUILD-SNAPSHOT</version>
+		<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.1.5.BUILD-SNAPSHOT</version>
+		<version>2.1.x.DATAMONGO-2193-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -907,8 +907,11 @@ public class QueryMapper {
 		@Override
 		public boolean isIdField() {
 
-			MongoPersistentProperty idProperty = (property != null && property.isIdProperty()) ? property
-					: entity.getIdProperty();
+			if(property != null) {
+				return property.isIdProperty();
+			}
+
+			MongoPersistentProperty idProperty = entity.getIdProperty();
 
 			if (idProperty != null) {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -819,6 +819,18 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject).containsEntry("className", "foo");
 	}
 
+	@Test // DATAMONGO-2193
+	public void shouldNotConvertHexStringToObjectIdForRenamedNestedIdField() {
+
+		String idHex = new ObjectId().toHexString();
+		Query query = new Query(where("nested.id").is(idHex));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(RootForClassWithExplicitlyRenamedIdField.class));
+
+		assertThat(document).isEqualTo(new org.bson.Document("nested.id", idHex));
+	}
+
 	@Document
 	public class Foo {
 		@Id private ObjectId id;


### PR DESCRIPTION
We now make sure to only convert valid `ObjectId` Strings if the property can be considered as _id _property.

----

Should be forward ported to master.