### PR TITLE
DATAMONGO-2072 - Support Range in repository between queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2072-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryCreatorUnitTests.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.data.domain.Range;
+import org.springframework.data.domain.Range.Bound;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
@@ -646,6 +647,16 @@ public class MongoQueryCreatorUnitTests {
 		PartTree tree = new PartTree("findByFirstNameRegex", Person.class);
 		MongoQueryCreator creator = new MongoQueryCreator(tree, getAccessor(converter, pattern), context);
 		assertThat(creator.createQuery()).isEqualTo(query(where("firstName").regex(".*", "iu")));
+	}
+
+	@Test // DATAMONGO-2071
+	public void betweenShouldAllowSingleRageParameter() {
+
+		PartTree tree = new PartTree("findByAgeBetween", Person.class);
+		MongoQueryCreator creator = new MongoQueryCreator(tree,
+				getAccessor(converter, Range.of(Bound.exclusive(10), Bound.exclusive(11))), context);
+
+		assertThat(creator.createQuery()).isEqualTo(query(where("age").gt(10).lt(11)));
 	}
 
 	interface PersonRepository extends Repository<Person, Long> {

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -188,8 +188,10 @@ The following table shows the keywords that are supported for query methods:
 | `{"age" : {"$lte" : age}}`
 
 | `Between`
-| `findByAgeBetween(int from, int to)`
-| `{"age" : {"$gt" : from, "$lt" : to}}`
+| `findByAgeBetween(int from, int to)` +
+`findByAgeBetween(Range<Integer> range)`
+| `{"age" : {"$gt" : from, "$lt" : to}}` +
+lower / upper bounds (`$gt` / `$gte` & `$lt` / `$lte`) according to `Range`
 
 | `In`
 | `findByAgeIn(Collection ages)`


### PR DESCRIPTION
We now support `o.s.d.domain.Range` as method parameter for _between_ queries. This allows more fine grained control over the inclusion/exclusion of the upper/lower bounds.
Up till now _between_ required 2 parameters which had been strictly bound to excluding bounds using `$gt` and `$lt`.