### PR TITLE
DATAMONGO-2206 - Migrate Kotlin tests to Mockk

### DIFF
--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -280,24 +280,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.nhaarman</groupId>
-			<artifactId>mockito-kotlin</artifactId>
-			<version>1.5.0</version>
+			<groupId>io.mockk</groupId>
+			<artifactId>mockk</artifactId>
+			<version>1.9.1</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-reflect</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mockito</groupId>
-					<artifactId>mockito-core</artifactId>
-				</exclusion>
-			</exclusions>
+
 		</dependency>
 
 	</dependencies>

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableAggregationOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableAggregationOperationExtensionsTests.kt
@@ -15,36 +15,30 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Sebastien Deleuze
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableAggregationOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ExecutableAggregationOperation
+	val operation = mockk<ExecutableAggregationOperation>(relaxed = true)
 
 	@Test // DATAMONGO-1689
 	fun `aggregateAndReturn(KClass) extension should call its Java counterpart`() {
 
 		operation.aggregateAndReturn(First::class)
-		verify(operation).aggregateAndReturn(First::class.java)
+		verify { operation.aggregateAndReturn(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `aggregateAndReturn() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.aggregateAndReturn<First>()
-		verify(operation).aggregateAndReturn(First::class.java)
+		verify { operation.aggregateAndReturn(First::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensionsTests.kt
@@ -15,69 +15,62 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Sebastien Deleuze
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableFindOperationExtensionsTests {
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var operation: ExecutableFindOperation
+    val operation = mockk<ExecutableFindOperation>(relaxed = true)
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var operationWithProjection: ExecutableFindOperation.FindWithProjection<First>
+    val operationWithProjection = mockk<ExecutableFindOperation.FindWithProjection<First>>(relaxed = true)
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var distinctWithProjection: ExecutableFindOperation.DistinctWithProjection
+    val distinctWithProjection = mockk<ExecutableFindOperation.DistinctWithProjection>(relaxed = true)
 
     @Test // DATAMONGO-1689
     fun `ExecutableFindOperation#query(KClass) extension should call its Java counterpart`() {
 
         operation.query(First::class)
-        verify(operation).query(First::class.java)
+        verify { operation.query(First::class.java) }
     }
 
     @Test // DATAMONGO-1689
     fun `ExecutableFindOperation#query() with reified type parameter extension should call its Java counterpart`() {
 
         operation.query<First>()
-        verify(operation).query(First::class.java)
+        verify { operation.query(First::class.java) }
     }
 
     @Test // DATAMONGO-1689, DATAMONGO-2086
     fun `ExecutableFindOperation#FindOperationWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
         operationWithProjection.asType(User::class)
-        verify(operationWithProjection).`as`(User::class.java)
+        verify { operationWithProjection.`as`(User::class.java) }
     }
 
     @Test // DATAMONGO-1689, DATAMONGO-2086
     fun `ExecutableFindOperation#FindOperationWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
         operationWithProjection.asType<User>()
-        verify(operationWithProjection).`as`(User::class.java)
+        verify { operationWithProjection.`as`(User::class.java) }
     }
 
     @Test // DATAMONGO-1761, DATAMONGO-2086
     fun `ExecutableFindOperation#DistinctWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
         distinctWithProjection.asType(User::class)
-        verify(distinctWithProjection).`as`(User::class.java)
+        verify { distinctWithProjection.`as`(User::class.java) }
     }
 
     @Test // DATAMONGO-2086
     fun `ExecutableFindOperation#DistinctWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
         distinctWithProjection.asType<User>()
-        verify(distinctWithProjection).`as`(User::class.java)
+        verify { distinctWithProjection.`as`(User::class.java) }
     }
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableInsertOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableInsertOperationExtensionsTests.kt
@@ -15,36 +15,31 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Sebastien Deleuze
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableInsertOperationExtensionsTests {
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var operation: ExecutableInsertOperation
+    val operation = mockk<ExecutableInsertOperation>(relaxed = true)
 
     @Test // DATAMONGO-1689
     fun `insert(KClass) extension should call its Java counterpart`() {
 
         operation.insert(First::class)
-        verify(operation).insert(First::class.java)
+        verify { operation.insert(First::class.java) }
     }
 
     @Test // DATAMONGO-1689
     fun `insert() with reified type parameter extension should call its Java counterpart`() {
 
         operation.insert<First>()
-        verify(operation).insert(First::class.java)
+        verify { operation.insert(First::class.java) }
     }
 
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensionsTests.kt
@@ -15,51 +15,45 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Christoph Strobl
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableMapReduceOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ExecutableMapReduceOperation
+	val operation = mockk<ExecutableMapReduceOperation>(relaxed = true)
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operationWithProjection: ExecutableMapReduceOperation.MapReduceWithProjection<First>
+	val operationWithProjection = mockk<ExecutableMapReduceOperation.MapReduceWithProjection<First>>(relaxed = true)
 
 	@Test // DATAMONGO-1929
 	fun `ExecutableMapReduceOperation#mapReduce(KClass) extension should call its Java counterpart`() {
 
 		operation.mapReduce(First::class)
-		verify(operation).mapReduce(First::class.java)
+		verify { operation.mapReduce(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1929
 	fun `ExecutableMapReduceOperation#mapReduce() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.mapReduce<First>()
-		verify(operation).mapReduce(First::class.java)
+		verify { operation.mapReduce(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ExecutableMapReduceOperation#MapReduceWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
 		operationWithProjection.asType(User::class)
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 
 	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ExecutableMapReduceOperation#MapReduceWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
 		operationWithProjection.asType<User>()
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableRemoveOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableRemoveOperationExtensionsTests.kt
@@ -15,36 +15,31 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Sebastien Deleuze
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableRemoveOperationExtensionsTests {
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var operation: ExecutableRemoveOperation
+    val operation = mockk<ExecutableRemoveOperation>(relaxed = true)
 
     @Test // DATAMONGO-1689
     fun `remove(KClass) extension should call its Java counterpart`() {
 
         operation.remove(First::class)
-        verify(operation).remove(First::class.java)
+        verify { operation.remove(First::class.java) }
     }
 
     @Test // DATAMONGO-1689
     fun `remove() with reified type parameter extension should call its Java counterpart`() {
 
         operation.remove<First>()
-        verify(operation).remove(First::class.java)
+        verify { operation.remove(First::class.java) }
     }
 
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableUpdateOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ExecutableUpdateOperationExtensionsTests.kt
@@ -15,36 +15,31 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
- * Unit tests for [ExecutableUpdateOperationExtensions].
+ * Unit tests for `ExecutableUpdateOperationExtensions.kt`.
  *
  * @author Christoph Strobl
  */
-@RunWith(MockitoJUnitRunner::class)
 class ExecutableUpdateOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ExecutableUpdateOperation
+	val operation = mockk<ExecutableUpdateOperation>(relaxed = true)
 
 	@Test // DATAMONGO-1719
 	fun `update(KClass) extension should call its Java counterpart`() {
 
 		operation.update(First::class)
-		verify(operation).update(First::class.java)
+		verify { operation.update(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719
 	fun `update() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.update<First>()
-		verify(operation).update(First::class.java)
+		verify { operation.update(First::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensionsTests.kt
@@ -15,15 +15,11 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.mock
 import example.first.First
 import example.second.Second
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode
 import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.mapreduce.GroupBy
@@ -38,79 +34,77 @@ import org.springframework.data.mongodb.core.query.Update
  * @author Mark Paluch
  * @author Christoph Strobl
  */
-@RunWith(MockitoJUnitRunner::class)
 class MongoOperationsExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operations: MongoOperations
+	val operations = mockk<MongoOperations>(relaxed = true)
 
 	@Test // DATAMONGO-1689
 	fun `getCollectionName(KClass) extension should call its Java counterpart`() {
 
 		operations.getCollectionName(First::class)
-		verify(operations).getCollectionName(First::class.java)
+		verify { operations.getCollectionName(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `getCollectionName() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.getCollectionName<First>()
-		verify(operations).getCollectionName(First::class.java)
+		verify { operations.getCollectionName(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `execute(CollectionCallback) with reified type parameter extension should call its Java counterpart`() {
 
-		val collectionCallback = mock<CollectionCallback<First>>()
+		val collectionCallback = mockk<CollectionCallback<First>>()
 		operations.execute(collectionCallback)
-		verify(operations).execute(First::class.java, collectionCallback)
+		verify { operations.execute(First::class.java, collectionCallback) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `stream(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		operations.stream<First>(query)
-		verify(operations).stream(query, First::class.java)
+		verify { operations.stream(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `stream(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 		operations.stream<First>(query, collectionName)
-		verify(operations).stream(query, First::class.java, collectionName)
+		verify { operations.stream(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(KClass) extension should call its Java counterpart`() {
 
 		operations.createCollection(First::class)
-		verify(operations).createCollection(First::class.java)
+		verify { operations.createCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(KClass, CollectionOptions) extension should call its Java counterpart`() {
 
-		val collectionOptions = mock<CollectionOptions>()
+		val collectionOptions = mockk<CollectionOptions>()
 		operations.createCollection(First::class, collectionOptions)
-		verify(operations).createCollection(First::class.java, collectionOptions)
+		verify { operations.createCollection(First::class.java, collectionOptions) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.createCollection<First>()
-		verify(operations).createCollection(First::class.java)
+		verify { operations.createCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(CollectionOptions) with reified type parameter extension should call its Java counterpart`() {
 
-		val collectionOptions = mock<CollectionOptions>()
+		val collectionOptions = mockk<CollectionOptions>()
 		operations.createCollection<First>(collectionOptions)
-		verify(operations).createCollection(First::class.java, collectionOptions)
+		verify { operations.createCollection(First::class.java, collectionOptions) }
 	}
 
 
@@ -118,42 +112,42 @@ class MongoOperationsExtensionsTests {
 	fun `collectionExists(KClass) extension should call its Java counterpart`() {
 
 		operations.collectionExists(First::class)
-		verify(operations).collectionExists(First::class.java)
+		verify { operations.collectionExists(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `collectionExists() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.collectionExists<First>()
-		verify(operations).collectionExists(First::class.java)
+		verify { operations.collectionExists(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `dropCollection(KClass) extension should call its Java counterpart`() {
 
 		operations.dropCollection(First::class)
-		verify(operations).dropCollection(First::class.java)
+		verify { operations.dropCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `dropCollection() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.dropCollection<First>()
-		verify(operations).dropCollection(First::class.java)
+		verify { operations.dropCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `indexOps(KClass) extension should call its Java counterpart`() {
 
 		operations.indexOps(First::class)
-		verify(operations).indexOps(First::class.java)
+		verify { operations.indexOps(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `indexOps() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.indexOps<First>()
-		verify(operations).indexOps(First::class.java)
+		verify { operations .indexOps(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -162,7 +156,7 @@ class MongoOperationsExtensionsTests {
 		val bulkMode = BulkMode.ORDERED
 
 		operations.bulkOps(bulkMode, First::class)
-		verify(operations).bulkOps(bulkMode, First::class.java)
+		verify { operations.bulkOps(bulkMode, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -172,7 +166,7 @@ class MongoOperationsExtensionsTests {
 		val collectionName = "foo"
 
 		operations.bulkOps(bulkMode, First::class, collectionName)
-		verify(operations).bulkOps(bulkMode, First::class.java, collectionName)
+		verify { operations.bulkOps(bulkMode, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -181,7 +175,7 @@ class MongoOperationsExtensionsTests {
 		val bulkMode = BulkMode.ORDERED
 
 		operations.bulkOps<First>(bulkMode)
-		verify(operations).bulkOps(bulkMode, First::class.java)
+		verify { operations.bulkOps(bulkMode, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -191,14 +185,14 @@ class MongoOperationsExtensionsTests {
 		val collectionName = "foo"
 
 		operations.bulkOps<First>(bulkMode, collectionName)
-		verify(operations).bulkOps(bulkMode, First::class.java, collectionName)
+		verify { operations.bulkOps(bulkMode, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAll() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.findAll<First>()
-		verify(operations).findAll(First::class.java)
+		verify { operations.findAll(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -207,66 +201,66 @@ class MongoOperationsExtensionsTests {
 		val collectionName = "foo"
 
 		operations.findAll<First>(collectionName)
-		verify(operations).findAll(First::class.java, collectionName)
+		verify { operations.findAll(First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `group(String, GroupBy) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val groupBy = mock<GroupBy>()
+		val groupBy = mockk<GroupBy>()
 
 		operations.group<First>(collectionName, groupBy)
-		verify(operations).group(collectionName, groupBy, First::class.java)
+		verify { operations.group(collectionName, groupBy, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `group(Criteria, String, GroupBy) with reified type parameter extension should call its Java counterpart`() {
 
-		val criteria = mock<Criteria>()
+		val criteria = mockk<Criteria>()
 		val collectionName = "foo"
-		val groupBy = mock<GroupBy>()
+		val groupBy = mockk<GroupBy>()
 
 		operations.group<First>(criteria, collectionName, groupBy)
-		verify(operations).group(criteria, collectionName, groupBy, First::class.java)
+		verify { operations.group(criteria, collectionName, groupBy, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `aggregate(Aggregation, KClass) with reified type parameter extension should call its Java counterpart`() {
 
-		val aggregation = mock<Aggregation>()
+		val aggregation = mockk<Aggregation>()
 
 		operations.aggregate<First>(aggregation, Second::class)
-		verify(operations).aggregate(aggregation, Second::class.java, First::class.java)
+		verify { operations.aggregate(aggregation, Second::class.java, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `aggregate(Aggregation, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val aggregation = mock<Aggregation>()
+		val aggregation = mockk<Aggregation>()
 		val collectionName = "foo"
 
 		operations.aggregate<First>(aggregation, collectionName)
-		verify(operations).aggregate(aggregation, collectionName, First::class.java)
+		verify { operations.aggregate(aggregation, collectionName, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `aggregateStream(Aggregation, KClass) with reified type parameter extension should call its Java counterpart`() {
 
-		val aggregation = mock<Aggregation>()
+		val aggregation = mockk<Aggregation>()
 
 		operations.aggregateStream<First>(aggregation, Second::class)
-		verify(operations).aggregateStream(aggregation, Second::class.java, First::class.java)
+		verify { operations.aggregateStream(aggregation, Second::class.java, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `aggregateStream(Aggregation, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val aggregation = mock<Aggregation>()
+		val aggregation = mockk<Aggregation>()
 		val collectionName = "foo"
 
 		operations.aggregateStream<First>(aggregation, collectionName)
-		verify(operations).aggregateStream(aggregation, collectionName, First::class.java)
+		verify { operations.aggregateStream(aggregation, collectionName, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -277,7 +271,7 @@ class MongoOperationsExtensionsTests {
 		val reduceFunction = "baz"
 
 		operations.mapReduce<First>(collectionName, mapFunction, reduceFunction)
-		verify(operations).mapReduce(collectionName, mapFunction, reduceFunction, First::class.java)
+		verify { operations.mapReduce(collectionName, mapFunction, reduceFunction, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -286,35 +280,35 @@ class MongoOperationsExtensionsTests {
 		val collectionName = "foo"
 		val mapFunction = "bar"
 		val reduceFunction = "baz"
-		val options = mock<MapReduceOptions>()
+		val options = mockk<MapReduceOptions>()
 
 		operations.mapReduce<First>(collectionName, mapFunction, reduceFunction, options)
-		verify(operations).mapReduce(collectionName, mapFunction, reduceFunction, options, First::class.java)
+		verify { operations.mapReduce(collectionName, mapFunction, reduceFunction, options, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `mapReduce(Query, String, String, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 		val mapFunction = "bar"
 		val reduceFunction = "baz"
 
 		operations.mapReduce<First>(query, collectionName, mapFunction, reduceFunction)
-		verify(operations).mapReduce(query, collectionName, mapFunction, reduceFunction, First::class.java)
+		verify { operations.mapReduce(query, collectionName, mapFunction, reduceFunction, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `mapReduce(Query, String, String, String, MapReduceOptions) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 		val mapFunction = "bar"
 		val reduceFunction = "baz"
-		val options = mock<MapReduceOptions>()
+		val options = mockk<MapReduceOptions>()
 
 		operations.mapReduce<First>(query, collectionName, mapFunction, reduceFunction, options)
-		verify(operations).mapReduce(query, collectionName, mapFunction, reduceFunction, options, First::class.java)
+		verify { operations.mapReduce(query, collectionName, mapFunction, reduceFunction, options, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -323,7 +317,7 @@ class MongoOperationsExtensionsTests {
 		val query = NearQuery.near(0.0, 0.0)
 
 		operations.geoNear<First>(query)
-		verify(operations).geoNear(query, First::class.java)
+		verify { operations.geoNear(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -333,63 +327,63 @@ class MongoOperationsExtensionsTests {
 		val query = NearQuery.near(0.0, 0.0)
 
 		operations.geoNear<First>(query, collectionName)
-		verify(operations).geoNear(query, First::class.java, collectionName)
+		verify { operations.geoNear(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findOne(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findOne<First>(query)
-		verify(operations).findOne(query, First::class.java)
+		verify { operations.findOne(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findOne(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findOne<First>(query, collectionName)
-		verify(operations).findOne(query, First::class.java, collectionName)
+		verify { operations.findOne(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `exists(Query, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.exists(query, First::class)
-		verify(operations).exists(query, First::class.java)
+		verify { operations.exists(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `exists(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.exists<First>(query)
-		verify(operations).exists(query, First::class.java)
+		verify { operations.exists(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `find(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.find<First>(query)
-		verify(operations).find(query, First::class.java)
+		verify { operations.find(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `find(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.find<First>(query, collectionName)
-		verify(operations).find(query, First::class.java, collectionName)
+		verify { operations.find(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -398,7 +392,7 @@ class MongoOperationsExtensionsTests {
 		val id = 1L
 
 		operations.findById<First>(id)
-		verify(operations).findById(id, First::class.java)
+		verify { operations.findById(id, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -408,94 +402,94 @@ class MongoOperationsExtensionsTests {
 		val id = 1L
 
 		operations.findById<First>(id, collectionName)
-		verify(operations).findById(id, First::class.java, collectionName)
+		verify { operations.findById(id, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndModify(Query, Update, FindAndModifyOptions) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
-		val options = mock<FindAndModifyOptions>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
+		val options = mockk<FindAndModifyOptions>()
 
 		operations.findAndModify<First>(query, update, options)
-		verify(operations).findAndModify(query, update, options, First::class.java)
+		verify { operations.findAndModify(query, update, options, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndModify(Query, Update, FindAndModifyOptions, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
-		val update = mock<Update>()
-		val options = mock<FindAndModifyOptions>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
+		val options = mockk<FindAndModifyOptions>()
 
 		operations.findAndModify<First>(query, update, options, collectionName)
-		verify(operations).findAndModify(query, update, options, First::class.java, collectionName)
+		verify { operations.findAndModify(query, update, options, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndRemove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findAndRemove<First>(query)
-		verify(operations).findAndRemove(query, First::class.java)
+		verify { operations.findAndRemove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndRemove(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.findAndRemove<First>(query, collectionName)
-		verify(operations).findAndRemove(query, First::class.java, collectionName)
+		verify { operations.findAndRemove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.count<First>()
-		verify(operations).count(any<Query>(), eq(First::class.java))
+		verify { operations.count(any<Query>(), eq(First::class.java)) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.count<First>(query)
-		verify(operations).count(query, First::class.java)
+		verify { operations.count(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.count<First>(query, collectionName)
-		verify(operations).count(query, First::class.java, collectionName)
+		verify { operations.count(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, KClass) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.count(query, First::class)
-		verify(operations).count(query, First::class.java)
+		verify { operations.count(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, KClass, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.count(query, First::class, collectionName)
-		verify(operations).count(query, First::class.java, collectionName)
+		verify { operations.count(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -504,231 +498,231 @@ class MongoOperationsExtensionsTests {
 		val collection = listOf(First(), First())
 
 		operations.insert(collection, First::class)
-		verify(operations).insert(collection, First::class.java)
+		verify { operations.insert(collection, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.upsert(query, update, First::class)
-		verify(operations).upsert(query, update, First::class.java)
+		verify { operations.upsert(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.upsert(query, update, First::class, collectionName)
-		verify(operations).upsert(query, update, First::class.java, collectionName)
+		verify { operations.upsert(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.upsert<First>(query, update)
-		verify(operations).upsert(query, update, First::class.java)
+		verify { operations.upsert(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.upsert<First>(query, update, collectionName)
-		verify(operations).upsert(query, update, First::class.java, collectionName)
+		verify { operations.upsert(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateFirst(query, update, First::class)
-		verify(operations).updateFirst(query, update, First::class.java)
+		verify { operations.updateFirst(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateFirst(query, update, First::class, collectionName)
-		verify(operations).updateFirst(query, update, First::class.java, collectionName)
+		verify { operations.updateFirst(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateFirst<First>(query, update)
-		verify(operations).updateFirst(query, update, First::class.java)
+		verify { operations.updateFirst(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateFirst<First>(query, update, collectionName)
-		verify(operations).updateFirst(query, update, First::class.java, collectionName)
+		verify { operations.updateFirst(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateMulti(query, update, First::class)
-		verify(operations).updateMulti(query, update, First::class.java)
+		verify { operations.updateMulti(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateMulti(query, update, First::class, collectionName)
-		verify(operations).updateMulti(query, update, First::class.java, collectionName)
+		verify { operations.updateMulti(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateMulti<First>(query, update)
-		verify(operations).updateMulti(query, update, First::class.java)
+		verify { operations.updateMulti(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateMulti<First>(query, update, collectionName)
-		verify(operations).updateMulti(query, update, First::class.java, collectionName)
+		verify { operations.updateMulti(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.remove(query, First::class)
-		verify(operations).remove(query, First::class.java)
+		verify { operations.remove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.remove(query, First::class, collectionName)
-		verify(operations).remove(query, First::class.java, collectionName)
+		verify { operations.remove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.remove<First>(query)
-		verify(operations).remove(query, First::class.java)
+		verify { operations.remove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.remove<First>(query, collectionName)
-		verify(operations).remove(query, First::class.java, collectionName)
+		verify { operations.remove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAllAndRemove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findAllAndRemove<First>(query)
-		verify(operations).findAllAndRemove(query, First::class.java)
+		verify { operations.findAllAndRemove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(String, KClass) should call java counterpart`() {
 
 		operations.findDistinct<String>("field", First::class)
-		verify(operations).findDistinct("field", First::class.java, String::class.java)
+		verify { operations.findDistinct("field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", First::class)
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, String, KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", "collection", First::class)
-		verify(operations).findDistinct(query, "field", "collection", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", "collection", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinctImplicit(Query, String) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String, First>(query, "field")
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, String) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String, First>(query, "field", "collection")
-		verify(operations).findDistinct(query, "field", "collection", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", "collection", First::class.java, String::class.java) }
 	}
 	
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String,  KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", First::class)
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveAggregationOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveAggregationOperationExtensionsTests.kt
@@ -15,35 +15,30 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveAggregationOperationExtensionsTests {
 
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    lateinit var operation: ReactiveAggregationOperation
+    val operation = mockk<ReactiveAggregationOperation>(relaxed = true)
 
     @Test // DATAMONGO-1719
     fun `aggregateAndReturn(KClass) extension should call its Java counterpart`() {
 
         operation.aggregateAndReturn(First::class)
-        verify(operation).aggregateAndReturn(First::class.java)
+        verify { operation.aggregateAndReturn(First::class.java) }
     }
 
     @Test // DATAMONGO-1719
     fun `aggregateAndReturn() with reified type parameter extension should call its Java counterpart`() {
 
         operation.aggregateAndReturn<First>()
-        verify(operation).aggregateAndReturn(First::class.java)
+        verify { operation.aggregateAndReturn(First::class.java) }
     }
 
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensionsTests.kt
@@ -15,68 +15,61 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveFindOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ReactiveFindOperation
+	val operation = mockk<ReactiveFindOperation>(relaxed = true)
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operationWithProjection: ReactiveFindOperation.FindWithProjection<First>
+	val operationWithProjection = mockk<ReactiveFindOperation.FindWithProjection<First>>(relaxed = true)
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var distinctWithProjection: ReactiveFindOperation.DistinctWithProjection
+	val distinctWithProjection = mockk<ReactiveFindOperation.DistinctWithProjection>(relaxed = true)
 
 	@Test // DATAMONGO-1719
 	fun `ReactiveFind#query(KClass) extension should call its Java counterpart`() {
 
 		operation.query(First::class)
-		verify(operation).query(First::class.java)
+		verify { operation.query(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719
 	fun `ReactiveFind#query() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.query<First>()
-		verify(operation).query(First::class.java)
+		verify { operation.query(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719, DATAMONGO-2086
 	fun `ReactiveFind#FindOperatorWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
 		operationWithProjection.asType(User::class)
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 
 	@Test // DATAMONGO-1719, DATAMONGO-2086
 	fun `ReactiveFind#FindOperatorWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
 		operationWithProjection.asType<User>()
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 
 	@Test // DATAMONGO-1761, DATAMONGO-2086
 	fun `ReactiveFind#DistinctWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
 		distinctWithProjection.asType(User::class)
-		verify(distinctWithProjection).`as`(User::class.java)
+		verify { distinctWithProjection.`as`(User::class.java) }
 	}
 
 	@Test // DATAMONGO-2086
 	fun `ReactiveFind#DistinctWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
 		distinctWithProjection.asType<User>()
-		verify(distinctWithProjection).`as`(User::class.java)
+		verify { distinctWithProjection.`as`(User::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveInsertOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveInsertOperationExtensionsTests.kt
@@ -15,34 +15,29 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveInsertOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ReactiveInsertOperation
+	val operation = mockk<ReactiveInsertOperation>(relaxed = true)
 
 	@Test // DATAMONGO-1719
 	fun `insert(KClass) extension should call its Java counterpart`() {
 
 		operation.insert(First::class)
-		verify(operation).insert(First::class.java)
+		verify { operation.insert(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719
 	fun `insert() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.insert<First>()
-		verify(operation).insert(First::class.java)
+		verify { operation.insert(First::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensionsTests.kt
@@ -15,51 +15,45 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Christoph Strobl
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveMapReduceOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ReactiveMapReduceOperation
+	val operation = mockk<ReactiveMapReduceOperation>(relaxed = true)
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operationWithProjection: ReactiveMapReduceOperation.MapReduceWithProjection<First>
+	val operationWithProjection = mockk<ReactiveMapReduceOperation.MapReduceWithProjection<First>>(relaxed = true)
 
 	@Test // DATAMONGO-1929
 	fun `ReactiveMapReduceOperation#mapReduce(KClass) extension should call its Java counterpart`() {
 
 		operation.mapReduce(First::class)
-		verify(operation).mapReduce(First::class.java)
+		verify { operation.mapReduce(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1929
 	fun `ReactiveMapReduceOperation#mapReduce() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.mapReduce<First>()
-		verify(operation).mapReduce(First::class.java)
+		verify { operation.mapReduce(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ReactiveMapReduceOperation#MapReduceWithProjection#asType(KClass) extension should call its Java counterpart`() {
 
 		operationWithProjection.asType(User::class)
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 
 	@Test // DATAMONGO-1929, DATAMONGO-2086
 	fun `ReactiveMapReduceOperation#MapReduceWithProjection#asType() with reified type parameter extension should call its Java counterpart`() {
 
 		operationWithProjection.asType<User>()
-		verify(operationWithProjection).`as`(User::class.java)
+		verify { operationWithProjection.`as`(User::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensionsTests.kt
@@ -15,14 +15,10 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.mock
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.data.mongodb.core.query.NearQuery
 import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.Update
@@ -33,100 +29,98 @@ import reactor.core.publisher.Mono
  * @author Christoph Strobl
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveMongoOperationsExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operations: ReactiveMongoOperations
+	val operations = mockk<ReactiveMongoOperations>(relaxed = true)
 
 	@Test // DATAMONGO-1689
 	fun `indexOps(KClass) extension should call its Java counterpart`() {
 
 		operations.indexOps(First::class)
-		verify(operations).indexOps(First::class.java)
+		verify { operations.indexOps(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `indexOps() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.indexOps<First>()
-		verify(operations).indexOps(First::class.java)
+		verify { operations.indexOps(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `execute(ReactiveCollectionCallback) with reified type parameter extension should call its Java counterpart`() {
 
-		val collectionCallback = mock<ReactiveCollectionCallback<First>>()
+		val collectionCallback = mockk<ReactiveCollectionCallback<First>>()
 
 		operations.execute(collectionCallback)
-		verify(operations).execute(First::class.java, collectionCallback)
+		verify { operations.execute(First::class.java, collectionCallback) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(KClass) extension should call its Java counterpart`() {
 
 		operations.createCollection(First::class)
-		verify(operations).createCollection(First::class.java)
+		verify { operations.createCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(KClass, CollectionOptions) extension should call its Java counterpart`() {
 
-		val collectionOptions = mock<CollectionOptions>()
+		val collectionOptions = mockk<CollectionOptions>()
 
 		operations.createCollection(First::class, collectionOptions)
-		verify(operations).createCollection(First::class.java, collectionOptions)
+		verify { operations.createCollection(First::class.java, collectionOptions) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.createCollection<First>()
-		verify(operations).createCollection(First::class.java)
+		verify { operations.createCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `createCollection(CollectionOptions) with reified type parameter extension should call its Java counterpart`() {
 
-		val collectionOptions = mock<CollectionOptions>()
+		val collectionOptions = mockk<CollectionOptions>()
 
 		operations.createCollection<First>(collectionOptions)
-		verify(operations).createCollection(First::class.java, collectionOptions)
+		verify { operations.createCollection(First::class.java, collectionOptions) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `collectionExists(KClass) extension should call its Java counterpart`() {
 
 		operations.collectionExists(First::class)
-		verify(operations).collectionExists(First::class.java)
+		verify { operations.collectionExists(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `collectionExists() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.collectionExists<First>()
-		verify(operations).collectionExists(First::class.java)
+		verify { operations.collectionExists(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `dropCollection(KClass) extension should call its Java counterpart`() {
 
 		operations.dropCollection(First::class)
-		verify(operations).dropCollection(First::class.java)
+		verify { operations.dropCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `dropCollection() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.dropCollection<First>()
-		verify(operations).dropCollection(First::class.java)
+		verify { operations.dropCollection(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAll() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.findAll<First>()
-		verify(operations).findAll(First::class.java)
+		verify { operations.findAll(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -135,63 +129,63 @@ class ReactiveMongoOperationsExtensionsTests {
 		val collectionName = "foo"
 
 		operations.findAll<First>(collectionName)
-		verify(operations).findAll(First::class.java, collectionName)
+		verify { operations.findAll(First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findOne(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findOne<First>(query)
-		verify(operations).findOne(query, First::class.java)
+		verify { operations.findOne(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findOne(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findOne<First>(query, collectionName)
-		verify(operations).findOne(query, First::class.java, collectionName)
+		verify { operations.findOne(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `exists(Query, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.exists(query, First::class)
-		verify(operations).exists(query, First::class.java)
+		verify { operations.exists(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `exists(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.exists<First>(query)
-		verify(operations).exists(query, First::class.java)
+		verify { operations.exists(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `find(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.find<First>(query)
-		verify(operations).find(query, First::class.java)
+		verify { operations.find(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `find(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.find<First>(query, collectionName)
-		verify(operations).find(query, First::class.java, collectionName)
+		verify { operations.find(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -200,7 +194,7 @@ class ReactiveMongoOperationsExtensionsTests {
 		val id = 1L
 
 		operations.findById<First>(id)
-		verify(operations).findById(id, First::class.java)
+		verify { operations.findById(id, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -210,7 +204,7 @@ class ReactiveMongoOperationsExtensionsTests {
 		val id = 1L
 
 		operations.findById<First>(id, collectionName)
-		verify(operations).findById(id, First::class.java, collectionName)
+		verify { operations.findById(id, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -219,7 +213,7 @@ class ReactiveMongoOperationsExtensionsTests {
 		val query = NearQuery.near(0.0, 0.0)
 
 		operations.geoNear<First>(query)
-		verify(operations).geoNear(query, First::class.java)
+		verify { operations.geoNear(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -229,94 +223,94 @@ class ReactiveMongoOperationsExtensionsTests {
 		val query = NearQuery.near(0.0, 0.0)
 
 		operations.geoNear<First>(query, collectionName)
-		verify(operations).geoNear(query, First::class.java, collectionName)
+		verify { operations.geoNear(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndModify(Query, Update, FindAndModifyOptions) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
-		val options = mock<FindAndModifyOptions>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
+		val options = mockk<FindAndModifyOptions>()
 
 		operations.findAndModify<First>(query, update, options)
-		verify(operations).findAndModify(query, update, options, First::class.java)
+		verify { operations.findAndModify(query, update, options, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndModify(Query, Update, FindAndModifyOptions, String) with reified type parameter extension should call its Java counterpart`() {
 
 		val collectionName = "foo"
-		val query = mock<Query>()
-		val update = mock<Update>()
-		val options = mock<FindAndModifyOptions>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
+		val options = mockk<FindAndModifyOptions>()
 
 		operations.findAndModify<First>(query, update, options, collectionName)
-		verify(operations).findAndModify(query, update, options, First::class.java, collectionName)
+		verify { operations.findAndModify(query, update, options, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndRemove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findAndRemove<First>(query)
-		verify(operations).findAndRemove(query, First::class.java)
+		verify { operations.findAndRemove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAndRemove(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.findAndRemove<First>(query, collectionName)
-		verify(operations).findAndRemove(query, First::class.java, collectionName)
+		verify { operations.findAndRemove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count() with reified type parameter extension should call its Java counterpart`() {
 
 		operations.count<First>()
-		verify(operations).count(any<Query>(), eq(First::class.java))
+		verify { operations.count(any<Query>(), eq(First::class.java)) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.count<First>(query)
-		verify(operations).count(query, First::class.java)
+		verify { operations.count(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.count<First>(query, collectionName)
-		verify(operations).count(query, First::class.java, collectionName)
+		verify { operations.count(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, KClass) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.count(query, First::class)
-		verify(operations).count(query, First::class.java)
+		verify { operations.count(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `count(Query, KClass, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.count(query, First::class, collectionName)
-		verify(operations).count(query, First::class.java, collectionName)
+		verify { operations.count(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -325,7 +319,7 @@ class ReactiveMongoOperationsExtensionsTests {
 		val collection = listOf(First(), First())
 
 		operations.insert(collection, First::class)
-		verify(operations).insert(collection, First::class.java)
+		verify { operations.insert(collection, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
@@ -334,251 +328,251 @@ class ReactiveMongoOperationsExtensionsTests {
 		val collection = Mono.just(listOf(First(), First()))
 
 		operations.insertAll(collection, First::class)
-		verify(operations).insertAll(collection, First::class.java)
+		verify { operations.insertAll(collection, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.upsert(query, update, First::class)
-		verify(operations).upsert(query, update, First::class.java)
+		verify { operations.upsert(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.upsert(query, update, First::class, collectionName)
-		verify(operations).upsert(query, update, First::class.java, collectionName)
+		verify { operations.upsert(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.upsert<First>(query, update)
-		verify(operations).upsert(query, update, First::class.java)
+		verify { operations.upsert(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.upsert<First>(query, update, collectionName)
-		verify(operations).upsert(query, update, First::class.java, collectionName)
+		verify { operations.upsert(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateFirst(query, update, First::class)
-		verify(operations).updateFirst(query, update, First::class.java)
+		verify { operations.updateFirst(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateFirst(query, update, First::class, collectionName)
-		verify(operations).updateFirst(query, update, First::class.java, collectionName)
+		verify { operations.updateFirst(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateFirst<First>(query, update)
-		verify(operations).updateFirst(query, update, First::class.java)
+		verify { operations.updateFirst(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateFirst(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateFirst<First>(query, update, collectionName)
-		verify(operations).updateFirst(query, update, First::class.java, collectionName)
+		verify { operations.updateFirst(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateMulti(query, update, First::class)
-		verify(operations).updateMulti(query, update, First::class.java)
+		verify { operations.updateMulti(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateMulti(query, update, First::class, collectionName)
-		verify(operations).updateMulti(query, update, First::class.java, collectionName)
+		verify { operations.updateMulti(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 
 		operations.updateMulti<First>(query, update)
-		verify(operations).updateMulti(query, update, First::class.java)
+		verify { operations.updateMulti(query, update, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `updateMulti(Query, Update, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
-		val update = mock<Update>()
+		val query = mockk<Query>()
+		val update = mockk<Update>()
 		val collectionName = "foo"
 
 		operations.updateMulti<First>(query, update, collectionName)
-		verify(operations).updateMulti(query, update, First::class.java, collectionName)
+		verify { operations.updateMulti(query, update, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, KClass) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.remove(query, First::class)
-		verify(operations).remove(query, First::class.java)
+		verify { operations.remove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, KClass, String) extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.remove(query, First::class, collectionName)
-		verify(operations).remove(query, First::class.java, collectionName)
+		verify { operations.remove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.remove<First>(query)
-		verify(operations).remove(query, First::class.java)
+		verify { operations.remove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `remove(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.remove<First>(query, collectionName)
-		verify(operations).remove(query, First::class.java, collectionName)
+		verify { operations.remove(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `findAllAndRemove(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findAllAndRemove<First>(query)
-		verify(operations).findAllAndRemove(query, First::class.java)
+		verify { operations.findAllAndRemove(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `tail(Query) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.tail<First>(query)
-		verify(operations).tail(query, First::class.java)
+		verify { operations.tail(query, First::class.java) }
 	}
 
 	@Test // DATAMONGO-1689
 	fun `tail(Query, String) with reified type parameter extension should call its Java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 		val collectionName = "foo"
 
 		operations.tail<First>(query, collectionName)
-		verify(operations).tail(query, First::class.java, collectionName)
+		verify { operations.tail(query, First::class.java, collectionName) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(String, KClass) should call java counterpart`() {
 
 		operations.findDistinct<String>("field", First::class)
-		verify(operations).findDistinct("field", First::class.java, String::class.java)
+		verify { operations.findDistinct("field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", First::class)
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, String, KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", "collection", First::class)
-		verify(operations).findDistinct(query, "field", "collection", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", "collection", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinctImplicit(Query, String) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String, First>(query, "field")
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String, String) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String, First>(query, "field", "collection")
-		verify(operations).findDistinct(query, "field", "collection", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", "collection", First::class.java, String::class.java) }
 	}
 
 	
 	@Test // DATAMONGO-1761
 	fun `findDistinct(Query, String,  KClass) should call java counterpart`() {
 
-		val query = mock<Query>()
+		val query = mockk<Query>()
 
 		operations.findDistinct<String>(query, "field", First::class)
-		verify(operations).findDistinct(query, "field", First::class.java, String::class.java)
+		verify { operations.findDistinct(query, "field", First::class.java, String::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveRemoveOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveRemoveOperationExtensionsTests.kt
@@ -15,34 +15,29 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveRemoveOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ReactiveRemoveOperation
+	val operation = mockk<ReactiveRemoveOperation>(relaxed = true)
 
 	@Test // DATAMONGO-1719
 	fun `remove(KClass) extension should call its Java counterpart`() {
 
 		operation.remove(First::class)
-		verify(operation).remove(First::class.java)
+		verify { operation.remove(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719
 	fun `remove() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.remove<First>()
-		verify(operation).remove(First::class.java)
+		verify { operation.remove(First::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveUpdateOperationExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveUpdateOperationExtensionsTests.kt
@@ -15,36 +15,31 @@
  */
 package org.springframework.data.mongodb.core
 
-import com.nhaarman.mockito_kotlin.verify
 import example.first.First
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
- * Unit tests for [ReactiveExecutableUpdateOperationExtensions].
+ * Unit tests for `ReactiveExecutableUpdateOperationExtensions.kt`.
  *
  * @author Mark Paluch
  */
-@RunWith(MockitoJUnitRunner::class)
 class ReactiveUpdateOperationExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var operation: ReactiveUpdateOperation
+	val operation = mockk<ReactiveUpdateOperation>(relaxed = true)
 
 	@Test // DATAMONGO-1719
 	fun `update(KClass) extension should call its Java counterpart`() {
 
 		operation.update(First::class)
-		verify(operation).update(First::class.java)
+		verify { operation.update(First::class.java) }
 	}
 
 	@Test // DATAMONGO-1719
 	fun `update() with reified type parameter extension should call its Java counterpart`() {
 
 		operation.update<First>()
-		verify(operation).update(First::class.java)
+		verify { operation.update(First::class.java) }
 	}
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/CriteriaExtensionsTests.kt
@@ -15,23 +15,18 @@
  */
 package org.springframework.data.mongodb.core.query
 
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.junit.MockitoJUnitRunner
 
 /**
  * @author Sebastien Deleuze
  * @author Tjeu Kayim
  */
-@RunWith(MockitoJUnitRunner::class)
 class CriteriaExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var criteria: Criteria
+	val criteria = mockk<Criteria>(relaxed = true)
 
 	@Test
 	fun `isEqualTo() extension should call its Java counterpart`() {
@@ -40,7 +35,7 @@ class CriteriaExtensionsTests {
 
 		criteria.isEqualTo(foo)
 
-		Mockito.verify(criteria, Mockito.times(1)).`is`(foo)
+		verify(exactly = 1) { criteria.`is`(foo) }
 	}
 
 	@Test
@@ -48,7 +43,7 @@ class CriteriaExtensionsTests {
 
 		criteria.isEqualTo(null)
 
-		Mockito.verify(criteria, Mockito.times(1)).`is`(null)
+		verify(exactly = 1) { criteria.`is`(null) }
 	}
 
 	@Test
@@ -59,7 +54,7 @@ class CriteriaExtensionsTests {
 
 		criteria.inValues(foo, bar)
 
-		Mockito.verify(criteria, Mockito.times(1)).`in`(foo, bar)
+		verify(exactly = 1) { criteria.`in`(foo, bar) }
 	}
 
 	@Test
@@ -67,7 +62,7 @@ class CriteriaExtensionsTests {
 
 		criteria.inValues(null, null)
 
-		Mockito.verify(criteria, Mockito.times(1)).`in`(null, null)
+		verify(exactly = 1) { criteria.`in`(null, null) }
 	}
 
 	@Test
@@ -77,7 +72,7 @@ class CriteriaExtensionsTests {
 
 		criteria.inValues(c)
 
-		Mockito.verify(criteria, Mockito.times(1)).`in`(c)
+		verify(exactly = 1) { criteria.`in`(c) }
 	}
 
 	@Test
@@ -87,7 +82,7 @@ class CriteriaExtensionsTests {
 
 		criteria.inValues(c)
 
-		Mockito.verify(criteria, Mockito.times(1)).`in`(c)
+		verify(exactly = 1) { criteria.`in`(c) }
 	}
 
 	@Test
@@ -95,7 +90,7 @@ class CriteriaExtensionsTests {
 
 		criteria.and(Book::title)
 
-		Mockito.verify(criteria, Mockito.times(1)).and("title")
+		verify(exactly = 1) { criteria.and("title") }
 	}
 
 	@Test
@@ -103,7 +98,7 @@ class CriteriaExtensionsTests {
 
 		criteria.and(Book::author / Author::name)
 
-		Mockito.verify(criteria, Mockito.times(1)).and("author.name")
+		verify(exactly = 1) { criteria.and("author.name") }
 	}
 
 	@Test


### PR DESCRIPTION
In order to be consistent with Spring Framework tests and recommendation to use [Mockk](https://mockk.io/) for Kotlin tests, and in order to be consistent with the upcoming Coroutines pull request that is ready to be integrated asap this one is merged.

See related spring-projects/spring-data-commons#338.