### PR TITLE
DATAMONGO-2208 - Deprecate Kotlin extensions providing a KClass overload.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2208-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableAggregationOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableAggregationOperationExtensions.kt
@@ -24,8 +24,9 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("aggregateAndReturn<T>()"))
 fun <T : Any> ExecutableAggregationOperation.aggregateAndReturn(entityClass: KClass<T>): ExecutableAggregationOperation.ExecutableAggregation<T> =
-        aggregateAndReturn(entityClass.java)
+		aggregateAndReturn(entityClass.java)
 
 /**
  * Extension for [ExecutableAggregationOperation.aggregateAndReturn] leveraging reified type parameters.
@@ -35,4 +36,4 @@ fun <T : Any> ExecutableAggregationOperation.aggregateAndReturn(entityClass: KCl
  * @since 2.0
  */
 inline fun <reified T : Any> ExecutableAggregationOperation.aggregateAndReturn(): ExecutableAggregationOperation.ExecutableAggregation<T> =
-        aggregateAndReturn(T::class.java)
+		aggregateAndReturn(T::class.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableFindOperationExtensions.kt
@@ -24,6 +24,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("query<T>()"))
 fun <T : Any> ExecutableFindOperation.query(entityClass: KClass<T>): ExecutableFindOperation.ExecutableFind<T> =
 		query(entityClass.java)
 
@@ -44,6 +45,7 @@ inline fun <reified T : Any> ExecutableFindOperation.query(): ExecutableFindOper
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ExecutableFindOperation.FindWithProjection<*>.asType(resultType: KClass<T>): ExecutableFindOperation.FindWithQuery<T> =
 		`as`(resultType.java)
 
@@ -63,6 +65,7 @@ inline fun <reified T : Any> ExecutableFindOperation.FindWithProjection<*>.asTyp
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ExecutableFindOperation.DistinctWithProjection.asType(resultType: KClass<T>): ExecutableFindOperation.TerminatingDistinct<T> =
 		`as`(resultType.java);
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableInsertOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableInsertOperationExtensions.kt
@@ -24,6 +24,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>()"))
 fun <T : Any> ExecutableInsertOperation.insert(entityClass: KClass<T>): ExecutableInsertOperation.ExecutableInsert<T> =
         insert(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableMapReduceOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("mapReduce<T>()"))
 fun <T : Any> ExecutableMapReduceOperation.mapReduce(entityClass: KClass<T>): ExecutableMapReduceOperation.MapReduceWithMapFunction<T> =
 		mapReduce(entityClass.java)
 
@@ -41,6 +42,7 @@ inline fun <reified T : Any> ExecutableMapReduceOperation.mapReduce(): Executabl
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ExecutableMapReduceOperation.MapReduceWithProjection<*>.asType(resultType: KClass<T>): ExecutableMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(resultType.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableRemoveOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableRemoveOperationExtensions.kt
@@ -24,6 +24,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("remove<T>()"))
 fun <T : Any> ExecutableRemoveOperation.remove(entityClass: KClass<T>): ExecutableRemoveOperation.ExecutableRemove<T> =
         remove(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableUpdateOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ExecutableUpdateOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Christoph Strobl
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>()"))
 fun <T : Any> ExecutableUpdateOperation.update(entityClass: KClass<T>): ExecutableUpdateOperation.ExecutableUpdate<T> =
 		update(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensions.kt
@@ -41,6 +41,7 @@ import kotlin.reflect.KClass
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("getCollectionName<T>()"))
 fun <T : Any> MongoOperations.getCollectionName(entityClass: KClass<T>): String =
 		getCollectionName(entityClass.java)
 
@@ -87,6 +88,7 @@ inline fun <reified T : Any> MongoOperations.stream(query: Query, collectionName
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("createCollection<T>(collectionOptions)"))
 fun <T : Any> MongoOperations.createCollection(entityClass: KClass<T>, collectionOptions: CollectionOptions? = null): MongoCollection<Document> =
 		if (collectionOptions != null) createCollection(entityClass.java, collectionOptions)
 		else createCollection(entityClass.java)
@@ -108,6 +110,7 @@ inline fun <reified T : Any> MongoOperations.createCollection(
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("collectionExists<T>()"))
 fun <T : Any> MongoOperations.collectionExists(entityClass: KClass<T>): Boolean =
 		collectionExists(entityClass.java)
 
@@ -126,6 +129,7 @@ inline fun <reified T : Any> MongoOperations.collectionExists(): Boolean =
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("dropCollection<T>()"))
 fun <T : Any> MongoOperations.dropCollection(entityClass: KClass<T>) {
 	dropCollection(entityClass.java)
 }
@@ -146,6 +150,7 @@ inline fun <reified T : Any> MongoOperations.dropCollection() {
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("indexOps<T>()"))
 fun <T : Any> MongoOperations.indexOps(entityClass: KClass<T>): IndexOperations =
 		indexOps(entityClass.java)
 
@@ -164,6 +169,7 @@ inline fun <reified T : Any> MongoOperations.indexOps(): IndexOperations =
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("bulkOps<T>(bulkMode, collectionName)"))
 fun <T : Any> MongoOperations.bulkOps(bulkMode: BulkMode, entityClass: KClass<T>, collectionName: String? = null): BulkOperations =
 		if (collectionName != null) bulkOps(bulkMode, entityClass.java, collectionName)
 		else bulkOps(bulkMode, entityClass.java)
@@ -212,6 +218,7 @@ inline fun <reified T : Any> MongoOperations.group(criteria: Criteria, inputColl
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("aggregate<T>(aggregation)"))
 inline fun <reified O : Any> MongoOperations.aggregate(aggregation: Aggregation, inputType: KClass<*>): AggregationResults<O> =
 		aggregate(aggregation, inputType.java, O::class.java)
 
@@ -230,6 +237,7 @@ inline fun <reified O : Any> MongoOperations.aggregate(aggregation: Aggregation,
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("aggregateStream<T>(aggregation)"))
 inline fun <reified O : Any> MongoOperations.aggregateStream(aggregation: Aggregation, inputType: KClass<*>): CloseableIterator<O> =
 		aggregateStream(aggregation, inputType.java, O::class.java)
 
@@ -287,6 +295,7 @@ inline fun <reified T : Any> MongoOperations.findOne(query: Query, collectionNam
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(query, collectionName)"))
 fun <T : Any> MongoOperations.exists(query: Query, entityClass: KClass<T>, collectionName: String? = null): Boolean =
 		if (collectionName != null) exists(query, entityClass.java, collectionName)
 		else exists(query, entityClass.java)
@@ -328,6 +337,7 @@ inline fun <reified T : Any> MongoOperations.findById(id: Any, collectionName: S
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(field)"))
 inline fun <reified T : Any> MongoOperations.findDistinct(field: String, entityClass: KClass<*>): List<T> =
 		findDistinct(field, entityClass.java, T::class.java);
 
@@ -337,6 +347,7 @@ inline fun <reified T : Any> MongoOperations.findDistinct(field: String, entityC
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(query, field)"))
 inline fun <reified T : Any> MongoOperations.findDistinct(query: Query, field: String, entityClass: KClass<*>): List<T> =
 		findDistinct(query, field, entityClass.java, T::class.java)
 
@@ -346,6 +357,7 @@ inline fun <reified T : Any> MongoOperations.findDistinct(query: Query, field: S
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(query, field, collectionName)"))
 inline fun <reified T : Any> MongoOperations.findDistinct(query: Query, field: String, collectionName: String, entityClass: KClass<*>): List<T> =
 		findDistinct(query, field, collectionName, entityClass.java, T::class.java)
 
@@ -386,6 +398,7 @@ inline fun <reified T : Any> MongoOperations.findAndRemove(query: Query, collect
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>(query, collectionName)"))
 fun <T : Any> MongoOperations.count(query: Query = Query(), entityClass: KClass<T>, collectionName: String? = null): Long =
 		if (collectionName != null) count(query, entityClass.java, collectionName)
 		else count(query, entityClass.java)
@@ -406,9 +419,19 @@ inline fun <reified T : Any> MongoOperations.count(query: Query = Query(), colle
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>(batchToSave)"))
 fun <T : Any> MongoOperations.insert(batchToSave: Collection<T>, entityClass: KClass<T>) {
 	insert(batchToSave, entityClass.java)
 }
+
+/**
+ * Extension for [MongoOperations.insert] leveraging reified type parameters.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> MongoOperations.insert(batchToSave: Collection<T>): Collection<T> = insert(batchToSave, T::class.java)
 
 /**
  * Extension for [MongoOperations.upsert] providing a [KClass] based variant.
@@ -416,6 +439,7 @@ fun <T : Any> MongoOperations.insert(batchToSave: Collection<T>, entityClass: KC
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("upsert<T>(query, update, collectionName)"))
 fun <T : Any> MongoOperations.upsert(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): UpdateResult =
 		if (collectionName != null) upsert(query, update, entityClass.java, collectionName)
 		else upsert(query, update, entityClass.java)
@@ -437,6 +461,7 @@ inline fun <reified T : Any> MongoOperations.upsert(query: Query, update: Update
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("updateFirst<T>(query, update, collectionName)"))
 fun <T : Any> MongoOperations.updateFirst(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): UpdateResult =
 		if (collectionName != null) updateFirst(query, update, entityClass.java, collectionName)
 		else updateFirst(query, update, entityClass.java)
@@ -458,6 +483,7 @@ inline fun <reified T : Any> MongoOperations.updateFirst(query: Query, update: U
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("updateMulti<T>(query, update, collectionName)"))
 fun <T : Any> MongoOperations.updateMulti(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): UpdateResult =
 		if (collectionName != null) updateMulti(query, update, entityClass.java, collectionName)
 		else updateMulti(query, update, entityClass.java)
@@ -479,6 +505,7 @@ inline fun <reified T : Any> MongoOperations.updateMulti(query: Query, update: U
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("remove<T>(query, collectionName)"))
 fun <T : Any> MongoOperations.remove(query: Query, entityClass: KClass<T>, collectionName: String? = null): DeleteResult =
 		if (collectionName != null) remove(query, entityClass.java, collectionName)
 		else remove(query, entityClass.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveAggregationOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveAggregationOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("aggregateAndReturn<T>()"))
 fun <T : Any> ReactiveAggregationOperation.aggregateAndReturn(entityClass: KClass<T>): ReactiveAggregationOperation.ReactiveAggregation<T> =
         aggregateAndReturn(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveFindOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("query<T>()"))
 fun <T : Any> ReactiveFindOperation.query(entityClass: KClass<T>): ReactiveFindOperation.ReactiveFind<T> =
 		query(entityClass.java)
 
@@ -41,6 +42,7 @@ inline fun <reified T : Any> ReactiveFindOperation.query(): ReactiveFindOperatio
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ReactiveFindOperation.FindWithProjection<*>.asType(resultType: KClass<T>): ReactiveFindOperation.FindWithQuery<T> =
 		`as`(resultType.java)
 
@@ -59,6 +61,7 @@ inline fun <reified T : Any> ReactiveFindOperation.FindWithProjection<*>.asType(
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ReactiveFindOperation.DistinctWithProjection.asType(resultType: KClass<T>): ReactiveFindOperation.TerminatingDistinct<T> =
 		`as`(resultType.java);
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveInsertOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveInsertOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>()"))
 fun <T : Any> ReactiveInsertOperation.insert(entityClass: KClass<T>): ReactiveInsertOperation.ReactiveInsert<T> =
 		insert(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMapReduceOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("mapReduce<T>()"))
 fun <T : Any> ReactiveMapReduceOperation.mapReduce(entityClass: KClass<T>): ReactiveMapReduceOperation.MapReduceWithMapFunction<T> =
 		mapReduce(entityClass.java)
 
@@ -41,6 +42,7 @@ inline fun <reified T : Any> ReactiveMapReduceOperation.mapReduce(): ReactiveMap
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ReactiveMapReduceOperation.MapReduceWithProjection<*>.asType(resultType: KClass<T>): ReactiveMapReduceOperation.MapReduceWithQuery<T> =
 		`as`(resultType.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensions.kt
@@ -34,6 +34,7 @@ import kotlin.reflect.KClass
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("indexOps<T>()"))
 fun <T : Any> ReactiveMongoOperations.indexOps(entityClass: KClass<T>): ReactiveIndexOperations =
 		indexOps(entityClass.java)
 
@@ -61,6 +62,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.execute(action: ReactiveCol
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("createCollection<T>(collectionOptions)"))
 fun <T : Any> ReactiveMongoOperations.createCollection(entityClass: KClass<T>, collectionOptions: CollectionOptions? = null): Mono<MongoCollection<Document>> =
 		if (collectionOptions != null) createCollection(entityClass.java, collectionOptions) else createCollection(entityClass.java)
 
@@ -79,6 +81,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.createCollection(collection
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("collectionExists<T>()"))
 fun <T : Any> ReactiveMongoOperations.collectionExists(entityClass: KClass<T>): Mono<Boolean> =
 		collectionExists(entityClass.java)
 
@@ -97,6 +100,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.collectionExists(): Mono<Bo
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("dropCollection<T>()"))
 fun <T : Any> ReactiveMongoOperations.dropCollection(entityClass: KClass<T>): Mono<Void> =
 		dropCollection(entityClass.java)
 
@@ -133,6 +137,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.findOne(query: Query, colle
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(query, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.exists(query: Query, entityClass: KClass<T>, collectionName: String? = null): Mono<Boolean> =
 		if (collectionName != null) exists(query, entityClass.java, collectionName) else exists(query, entityClass.java)
 
@@ -170,6 +175,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.findById(id: Any, collectio
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(field)"))
 inline fun <reified T : Any> ReactiveMongoOperations.findDistinct(field: String, entityClass: KClass<*>): Flux<T> =
 		findDistinct(field, entityClass.java, T::class.java);
 
@@ -179,6 +185,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.findDistinct(field: String,
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(query, field)"))
 inline fun <reified T : Any> ReactiveMongoOperations.findDistinct(query: Query, field: String, entityClass: KClass<*>): Flux<T> =
 		findDistinct(query, field, entityClass.java, T::class.java)
 
@@ -188,6 +195,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.findDistinct(query: Query, 
  * @author Christoph Strobl
  * @since 2.1
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("findDistinct<T, E>(query, field, collectionName)"))
 inline fun <reified T : Any> ReactiveMongoOperations.findDistinct(query: Query, field: String, collectionName: String, entityClass: KClass<*>): Flux<T> =
 		findDistinct(query, field, collectionName, entityClass.java, T::class.java)
 
@@ -236,6 +244,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.findAndRemove(query: Query,
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>(query, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.count(query: Query = Query(), entityClass: KClass<T>, collectionName: String? = null): Mono<Long> =
 		if (collectionName != null) count(query, entityClass.java, collectionName)
 		else count(query, entityClass.java)
@@ -257,8 +266,18 @@ inline fun <reified T : Any> ReactiveMongoOperations.count(query: Query = Query(
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>(batchToSave)"))
 fun <T : Any> ReactiveMongoOperations.insert(batchToSave: Collection<T>, entityClass: KClass<T>): Flux<T> =
 		insert(batchToSave, entityClass.java)
+
+/**
+ * Extension for [ReactiveMongoOperations.insert] leveraging reified type parameters.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> ReactiveMongoOperations.insert(batchToSave: Collection<T>): Flux<T> = insert(batchToSave, T::class.java)
 
 /**
  * Extension for [ReactiveMongoOperations.insertAll] providing a [KClass] based variant.
@@ -266,6 +285,7 @@ fun <T : Any> ReactiveMongoOperations.insert(batchToSave: Collection<T>, entityC
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insertAll<T>(batchToSave)"))
 fun <T : Any> ReactiveMongoOperations.insertAll(batchToSave: Mono<out Collection<T>>, entityClass: KClass<T>): Flux<T> =
 		insertAll(batchToSave, entityClass.java)
 
@@ -275,6 +295,7 @@ fun <T : Any> ReactiveMongoOperations.insertAll(batchToSave: Mono<out Collection
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("upsert<T>(query, update, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.upsert(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): Mono<UpdateResult> =
 		if (collectionName != null) upsert(query, update, entityClass.java, collectionName) else upsert(query, update, entityClass.java)
 
@@ -295,6 +316,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.upsert(query: Query, update
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("updateFirst<T>(query, update, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.updateFirst(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): Mono<UpdateResult> =
 		if (collectionName != null) updateFirst(query, update, entityClass.java, collectionName)
 		else updateFirst(query, update, entityClass.java)
@@ -316,6 +338,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.updateFirst(query: Query, u
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("updateMulti<T>(query, update, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.updateMulti(query: Query, update: Update, entityClass: KClass<T>, collectionName: String? = null): Mono<UpdateResult> =
 		if (collectionName != null) updateMulti(query, update, entityClass.java, collectionName)
 		else updateMulti(query, update, entityClass.java)
@@ -337,6 +360,7 @@ inline fun <reified T : Any> ReactiveMongoOperations.updateMulti(query: Query, u
  * @author Sebastien Deleuze
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("remove<T>(query, collectionName)"))
 fun <T : Any> ReactiveMongoOperations.remove(query: Query, entityClass: KClass<T>, collectionName: String? = null): Mono<DeleteResult> =
 		if (collectionName != null) remove(query, entityClass.java, collectionName)
 		else remove(query, entityClass.java)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveRemoveOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveRemoveOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("remove<T>()"))
 fun <T : Any> ReactiveRemoveOperation.remove(entityClass: KClass<T>): ReactiveRemoveOperation.ReactiveRemove<T> =
 		remove(entityClass.java)
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveUpdateOperationExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/ReactiveUpdateOperationExtensions.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
  * @author Mark Paluch
  * @since 2.0
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>()"))
 fun <T : Any> ReactiveUpdateOperation.update(entityClass: KClass<T>): ReactiveUpdateOperation.ReactiveUpdate<T> =
 		update(entityClass.java)
 

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/MongoOperationsExtensionsTests.kt
@@ -501,6 +501,15 @@ class MongoOperationsExtensionsTests {
 		verify { operations.insert(collection, First::class.java) }
 	}
 
+	@Test // DATAMONGO-2208
+	fun `insert(Collection) with reified type parameter extension should call its Java counterpart`() {
+
+		val collection = listOf(First(), First())
+
+		operations.insert<First>(collection)
+		verify { operations.insert(collection, First::class.java) }
+	}
+
 	@Test // DATAMONGO-1689
 	fun `upsert(Query, Update, KClass) extension should call its Java counterpart`() {
 

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/ReactiveMongoOperationsExtensionsTests.kt
@@ -322,6 +322,15 @@ class ReactiveMongoOperationsExtensionsTests {
 		verify { operations.insert(collection, First::class.java) }
 	}
 
+	@Test // DATAMONGO-2208
+	fun `insert(Collection) with reified type parameter extension should call its Java counterpart`() {
+
+		val collection = listOf(First(), First())
+
+		operations.insert<First>(collection)
+		verify { operations.insert(collection, First::class.java) }
+	}
+
 	@Test // DATAMONGO-1689
 	fun `insertAll(Mono, KClass) extension should call its Java counterpart`() {
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -9,6 +9,7 @@
 * Extended SpEL aggregation support for MongoDB 3.4 and MongoDB 4.0 operators (see <<mongo.aggregation.projection.expressions>>).
 * Template API delete by entity considers the version property in delete queries.
 * Repository deletes now throw `OptimisticLockingFailureException` when a versioned entity cannot be deleted.
+* Kotlin extension methods accepting `KClass` are deprecated now in favor of reified methods.
 
 [[new-features.2-1-0]]
 == What's New in Spring Data MongoDB 2.1


### PR DESCRIPTION
We promote the usage of reified Kotlin API usage (`myMethod<Person>()` instead of `myMethod(Person::class)`) to facilitate a single and more idiomatic approach to Kotlin API usage.

Extension methods accepting `KClass` are deprecated now.

---

Related ticket: [DATAMONGO-2208](https://jira.spring.io/browse/DATAMONGO-2208).