### PR TITLE
DATAMONGO-1783 - Apply query limit and offset to MongoOperations#count

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-1783-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1783-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1783-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-1783-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -1094,6 +1094,11 @@ public interface MongoOperations extends FluentMongoOperations {
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.
+	 * <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.
@@ -1105,7 +1110,11 @@ public interface MongoOperations extends FluentMongoOperations {
 	/**
 	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
 	 * must solely consist of document field references as we lack type information to map potential property references
-	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support.
+	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents.
 	 * @param collectionName must not be {@literal null} or empty.
@@ -1116,7 +1125,11 @@ public interface MongoOperations extends FluentMongoOperations {
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the given collection using the given entity
-	 * class to map the given {@link Query}.
+	 * class to map the given {@link Query}. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1145,6 +1145,13 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		CountOptions options = new CountOptions();
 		query.getCollation().map(Collation::toMongoCollation).ifPresent(options::collation);
 
+		if (query.getLimit() > 0) {
+			options.limit(query.getLimit());
+		}
+		if (query.getSkip() > 0) {
+			options.skip((int) query.getSkip());
+		}
+
 		Document document = queryMapper.getMappedObject(query.getQueryObject(),
 				Optional.ofNullable(entityClass).map(it -> mappingContext.getPersistentEntity(entityClass)));
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -880,6 +880,11 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.
+	 * <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.
@@ -891,7 +896,11 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	/**
 	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
 	 * must solely consist of document field references as we lack type information to map potential property references
-	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support.
+	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents.
 	 * @param collectionName must not be {@literal null} or empty.
@@ -902,7 +911,11 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the given collection using the given entity
-	 * class to map the given {@link Query}.
+	 * class to map the given {@link Query}. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -1171,6 +1171,13 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			CountOptions options = new CountOptions();
 			if (query != null) {
 				query.getCollation().map(Collation::toMongoCollation).ifPresent(options::collation);
+
+				if (query.getLimit() > 0) {
+					options.limit(query.getLimit());
+				}
+				if (query.getSkip() > 0) {
+					options.skip((int) query.getSkip());
+				}
 			}
 
 			if (LOGGER.isDebugEnabled()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -212,7 +212,7 @@ public class Meta {
 	 * @param key must not be {@literal null} or empty.
 	 * @param value
 	 */
-	private void setValue(String key, @Nullable Object value) {
+	void setValue(String key, @Nullable Object value) {
 
 		Assert.hasText(key, "Meta key must not be 'null' or blank.");
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -49,9 +49,23 @@ public class Meta {
 		}
 	}
 
-	private final Map<String, Object> values = new LinkedHashMap<String, Object>(2);
-	private final Set<CursorOption> flags = new LinkedHashSet<CursorOption>();
+	private final Map<String, Object> values = new LinkedHashMap<>(2);
+	private final Set<CursorOption> flags = new LinkedHashSet<>();
 	private Integer cursorBatchSize;
+
+	public Meta() {}
+
+	/**
+	 * Copy a {@link Meta} object.
+	 *
+	 * @since 2.2
+	 * @param source
+	 */
+	Meta(Meta source) {
+		this.values.putAll(source.values);
+		this.flags.addAll(source.flags);
+		this.cursorBatchSize = source.cursorBatchSize;
+	}
 
 	/**
 	 * @return {@literal null} if not set.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.bson.Document;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
@@ -373,7 +374,7 @@ public class Query {
 	 * Set the number of documents to return in each response batch. <br />
 	 * Use {@literal 0 (zero)} for no limit. A <strong>negative limit</strong> closes the cursor after returning a single
 	 * batch indicating to the server that the client will not ask for a subsequent one.
-	 * 
+	 *
 	 * @param batchSize The number of documents to return per batch.
 	 * @return this.
 	 * @see Meta#setCursorBatchSize(int)
@@ -432,7 +433,7 @@ public class Query {
 	}
 
 	/**
-	 * @return never {@literal null}.ø
+	 * @return never {@literal null}.
 	 * @since 1.6
 	 */
 	public Meta getMeta() {
@@ -519,11 +520,8 @@ public class Query {
 		target.collation = source.collation;
 		target.restrictedTypes.addAll(source.restrictedTypes);
 
-		if (source.getMeta() != null && source.getMeta().hasValues()) {
-
-			Meta meta = new Meta();
-			source.getMeta().values().forEach(it -> meta.setValue(it.getKey(), it.getValue()));
-			target.setMeta(meta);
+		if (source.getMeta().hasValues()) {
+			target.setMeta(new Meta(source.getMeta()));
 		}
 
 		return target;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryExecution.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryExecution.java
@@ -92,6 +92,7 @@ interface MongoQueryExecution {
 	 *
 	 * @author Oliver Gierke
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 */
 	@RequiredArgsConstructor
 	final class PagedExecution implements MongoQueryExecution {
@@ -120,7 +121,7 @@ interface MongoQueryExecution {
 
 			return PageableExecutionUtils.getPage(matching.all(), pageable, () -> {
 
-				long count = matching.count();
+				long count = operation.matching(Query.of(query).skip(-1).limit(-1)).count();
 				return overallLimit != 0 ? Math.min(count, overallLimit) : count;
 			});
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslFetchableMongodbQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/QuerydslFetchableMongodbQuery.java
@@ -147,7 +147,7 @@ abstract class QuerydslFetchableMongodbQuery<K, Q extends QuerydslFetchableMongo
 	 */
 	@Override
 	public long fetchCount() {
-		return find.matching(createQuery()).count();
+		return find.matching(Query.of(createQuery()).skip(-1).limit(-1)).count();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
@@ -282,11 +282,11 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		Assert.notNull(example, "Sample must not be null!");
 		Assert.notNull(pageable, "Pageable must not be null!");
 
-		Query q = new Query(new Criteria().alike(example)).with(pageable);
-		List<S> list = mongoOperations.find(q, example.getProbeType(), entityInformation.getCollectionName());
+		Query query = new Query(new Criteria().alike(example)).with(pageable);
+		List<S> list = mongoOperations.find(query, example.getProbeType(), entityInformation.getCollectionName());
 
 		return PageableExecutionUtils.getPage(list, pageable,
-				() -> mongoOperations.count(q, example.getProbeType(), entityInformation.getCollectionName()));
+				() -> mongoOperations.count(Query.of(query).limit(-1).skip(-1), example.getProbeType(), entityInformation.getCollectionName()));
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.util;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 
@@ -22,6 +23,7 @@ import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ObjectUtils;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
@@ -103,5 +105,28 @@ public class BsonUtils {
 			default:
 				return value;
 		}
+	}
+
+	/**
+	 * Merge the given {@link Document documents} into on in the given order. Keys contained within multiple documents are
+	 * overwritten by their follow ups.
+	 *
+	 * @param documents must not be {@literal null}. Can be empty.
+	 * @return the document containing all key value pairs.
+	 * @since 2.2
+	 */
+	public static Document merge(Document... documents) {
+
+		if (ObjectUtils.isEmpty(documents)) {
+			return new Document();
+		}
+
+		if (documents.length == 1) {
+			return documents[0];
+		}
+
+		Document target = new Document();
+		Arrays.asList(documents).forEach(target::putAll);
+		return target;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -1035,6 +1035,28 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 				is(equalTo(new Document("version", 11).append("_class", VersionedEntity.class.getName()))));
 	}
 
+	@Test // DATAMONGO-1783
+	public void usesQueryOffsetForCountOperation() {
+
+		template.count(new BasicQuery("{}").skip(100), AutogenerateableId.class);
+
+		ArgumentCaptor<CountOptions> options = ArgumentCaptor.forClass(CountOptions.class);
+		verify(collection).count(any(), options.capture());
+
+		assertThat(options.getValue().getSkip(), is(equalTo(100)));
+	}
+
+	@Test // DATAMONGO-1783
+	public void usesQueryLimitForCountOperation() {
+
+		template.count(new BasicQuery("{}").limit(10), AutogenerateableId.class);
+
+		ArgumentCaptor<CountOptions> options = ArgumentCaptor.forClass(CountOptions.class);
+		verify(collection).count(any(), options.capture());
+
+		assertThat(options.getValue().getLimit(), is(equalTo(10)));
+	}
+
 	@Test // DATAMONGO-2215
 	public void updateShouldApplyArrayFilters() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -55,6 +55,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -103,6 +104,7 @@ public class ReactiveMongoTemplateUnitTests {
 		when(collection.find(any(Document.class), any(Class.class))).thenReturn(findPublisher);
 		when(collection.aggregate(anyList())).thenReturn(aggregatePublisher);
 		when(collection.aggregate(anyList(), any(Class.class))).thenReturn(aggregatePublisher);
+		when(collection.count(any(), any(CountOptions.class))).thenReturn(Mono.just(0L));
 		when(collection.updateOne(any(), any(), any(UpdateOptions.class))).thenReturn(updatePublisher);
 		when(collection.findOneAndUpdate(any(), any(), any(FindOneAndUpdateOptions.class))).thenReturn(findAndUpdatePublisher);
 		when(findPublisher.projection(any())).thenReturn(findPublisher);
@@ -348,6 +350,28 @@ public class ReactiveMongoTemplateUnitTests {
 		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonExtended.class, null).subscribe();
 
 		verify(findPublisher, never()).projection(any());
+	}
+
+	@Test // DATAMONGO-1783
+	public void countShouldUseSkipFromQuery() {
+
+		template.count(new Query().skip(10), Person.class, "star-wars").subscribe();
+
+		ArgumentCaptor<CountOptions> options = ArgumentCaptor.forClass(CountOptions.class);
+		verify(collection).count(any(), options.capture());
+
+		assertThat(options.getValue().getSkip(), is(equalTo(10)));
+	}
+
+	@Test // DATAMONGO-1783
+	public void countShouldUseLimitFromQuery() {
+
+		template.count(new Query().limit(100), Person.class, "star-wars").subscribe();
+
+		ArgumentCaptor<CountOptions> options = ArgumentCaptor.forClass(CountOptions.class);
+		verify(collection).count(any(), options.capture());
+
+		assertThat(options.getValue().getLimit(), is(equalTo(100)));
 	}
 
 	@Test // DATAMONGO-2215

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -174,12 +174,12 @@ public class AbstractMongoQueryUnitTests {
 		ArgumentCaptor<Query> captor = ArgumentCaptor.forClass(Query.class);
 
 		verify(executableFind).as(Person.class);
-		verify(withQueryMock).matching(captor.capture());
+		verify(withQueryMock, atLeast(1)).matching(captor.capture());
 
 		assertThat(captor.getValue().getMeta().getComment(), is("comment"));
 	}
 
-	@Test // DATAMONGO-957
+	@Test // DATAMONGO-957, DATAMONGO-1783
 	public void metadataShouldBeAddedToStringBasedQueryCorrectly() {
 
 		MongoQueryFake query = createQueryForMethod("findByAnnotatedQuery", String.class, Pageable.class);

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -10,6 +10,7 @@
 * Template API delete by entity considers the version property in delete queries.
 * Repository deletes now throw `OptimisticLockingFailureException` when a versioned entity cannot be deleted.
 * Support `Range<T>` in repository between queries.
+* Changed behavior of `Reactive/MongoOperations#count` now limiting the range to count matches within by passing on _offset_ & _limit_ to the server.
 * Kotlin extension methods accepting `KClass` are deprecated now in favor of `reified` methods.
 * Support of array filters in `Update` operations.
 


### PR DESCRIPTION
We now pass on the range defined by `Query.skip` and `Query.limit` to the MongoDB server. This allows to count documents within a certain range so that it is possible to find the number of matches within eg. the first 10,000 documents.