### PR TITLE
Fix bug with mongo converter instantiation

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -272,8 +272,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		this.mongoDbFactory = dbFactory;
 		this.exceptionTranslator = that.exceptionTranslator;
 		this.sessionSynchronization = that.sessionSynchronization;
-		this.mongoConverter = that.mongoConverter instanceof MappingMongoConverter ? getDefaultMongoConverter(dbFactory)
-				: that.mongoConverter;
+		this.mongoConverter = that.mongoConverter instanceof MappingMongoConverter ? that.mongoConverter : getDefaultMongoConverter(dbFactory);
 		this.queryMapper = that.queryMapper;
 		this.updateMapper = that.updateMapper;
 		this.schemaMapper = that.schemaMapper;


### PR DESCRIPTION
Hi,

I noticed a bug in one of the MongoTemplate constructor while assigning the MappingMongoConverter. Here is the scenario to reproduce,

Create a MongoTemplate with ClientSession, internally it calls the mongotemplate and checks whether it has a valid MappingMongoConverter. If it's valid, it should set that, else create a default MongoConverter. But the condition is viceversa. I have raised a PR to fix this. Please check.
