### PR TITLE
DATAMONGO-2054 - Add support for array update operator $[].

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -289,7 +289,7 @@ public class UpdateMapper extends QueryMapper {
 		public MetadataBackedUpdateField(MongoPersistentEntity<?> entity, String key,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
-			super(key.replaceAll("\\.\\$", ""), entity, mappingContext);
+			super(key.replaceAll("\\.\\$(\\[.*\\])?", ""), entity, mappingContext);
 			this.key = key;
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -1029,6 +1029,28 @@ public class UpdateMapperUnitTests {
 		assertThat(mappedUpdate).isEqualTo(new Document("AValue", "a value"));
 	}
 
+	@Test // DATAMONGO-2054
+	public void mappingShouldAllowPositionAllParameter() {
+
+		Update update = new Update().inc("grades.$[]", 10);
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithListOfSimple.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$inc", new Document("grades.$[]", 10)));
+	}
+
+	@Test // DATAMONGO-2054
+	public void mappingShouldAllowPositionAllParameterWhenPopertyHasExplicitFieldName() {
+
+		Update update = new Update().inc("list.$[]", 10);
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(ParentClass.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$inc", new Document("aliased.$[]", 10)));
+	}
+
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
 		ListModelWrapper concreteTypeWithListAttributeOfInterfaceType;
 	}
@@ -1245,6 +1267,10 @@ public class UpdateMapperUnitTests {
 		List<EntityWithAliasedObject> list;
 	}
 
+	static class EntityWithListOfSimple {
+		List<Integer> grades;
+	}
+
 	static class EntityWithAliasedObject {
 
 		@Field("renamed-value") Object value;
@@ -1348,11 +1374,9 @@ public class UpdateMapperUnitTests {
 	@Data
 	static class TypeWithFieldNameThatCannotBeDecapitalized {
 
-		@Id
-		protected String id;
+		@Id protected String id;
 
-		@Field("AValue")
-		private Long aValue = 0L;
+		@Field("AValue") private Long aValue = 0L;
 
 	}
 


### PR DESCRIPTION
We now support the `$[]` array update operator when mapping `Update`. The mapper now takes potential `@Field` annotations into account and applies the field name correctly.