### PR TITLE
DATAMONGO-2218 - Add support for replaceOne operation in BulkOperations

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/BulkOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/BulkOperations.java
@@ -31,6 +31,7 @@ import com.mongodb.bulk.BulkWriteResult;
  *
  * @author Tobias Trelle
  * @author Oliver Gierke
+ * @author Minsu Kim
  * @since 1.9
  */
 public interface BulkOperations {
@@ -134,6 +135,15 @@ public interface BulkOperations {
 	 * @return the current {@link BulkOperations} instance with the removal added, will never be {@literal null}.
 	 */
 	BulkOperations remove(List<Query> removes);
+
+	/**
+	 * Add a single replace operation to the bulk operation.
+	 *
+	 * @param query Update criteria.
+	 * @param document the document to replace, must not be {@literal null}.
+	 * @return the current {@link BulkOperations} instance with the replace added, will never be {@literal null}.
+	 */
+	BulkOperations replaceOne(Query query, Object document);
 
 	/**
 	 * Execute all bulk operations using the default write concern.


### PR DESCRIPTION
About this ticket, (https://jira.spring.io/browse/DATAMONGO-2218)

I add replaceOne() method to BulkOperations