### PR TITLE
DATAMONGO-2215 - Add support for array filters to Update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.DATAMONGO-2054-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2215-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
@@ -137,5 +137,14 @@ public class MappedDocument {
 		public Boolean isIsolated() {
 			return delegate.isIsolated();
 		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#getArrayFilters()
+		 */
+		@Override
+		public List<ArrayFilter> getArrayFilters() {
+			return delegate.getArrayFilters();
+		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -289,7 +289,7 @@ public class UpdateMapper extends QueryMapper {
 		public MetadataBackedUpdateField(MongoPersistentEntity<?> entity, String key,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
-			super(key.replaceAll("\\.\\$", ""), entity, mappingContext);
+			super(key.replaceAll("\\.\\$(\\[.*\\])?", ""), entity, mappingContext);
 			this.key = key;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.query;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,6 +59,7 @@ public class Update implements UpdateDefinition {
 	private Set<String> keysToUpdate = new HashSet<>();
 	private Map<String, Object> modifierOps = new LinkedHashMap<>();
 	private Map<String, PushOperatorBuilder> pushCommandBuilders = new LinkedHashMap<>(1);
+	private List<ArrayFilter> arrayFilters = new ArrayList<>();
 
 	/**
 	 * Static factory method to create an Update using the provided key
@@ -399,6 +401,33 @@ public class Update implements UpdateDefinition {
 		return this;
 	}
 
+	/**
+	 * Filter elements in an array that match the given criteria for update.
+	 *
+	 * @param criteria must not be {@literal null}.
+	 * @return this.
+	 * @since 2.2
+	 */
+	public Update filterArray(CriteriaDefinition criteria) {
+
+		this.arrayFilters.add(() -> criteria.getCriteriaObject());
+		return this;
+	}
+
+	/**
+	 * Filter elements in an array that match the given criteria for update.
+	 *
+	 * @param identifier the positional operator identifier filter criteria name.
+	 * @param expression the positional operator filter expression.
+	 * @return this.
+	 * @since 2.2
+	 */
+	public Update filterArray(String identifier, Object expression) {
+
+		this.arrayFilters.add(() -> new Document(identifier, expression));
+		return this;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#isIsolated()
@@ -413,6 +442,14 @@ public class Update implements UpdateDefinition {
 	 */
 	public Document getUpdateObject() {
 		return new Document(modifierOps);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.query.UpdateDefinition#getArrayFilters()
+	 */
+	public List<ArrayFilter> getArrayFilters() {
+		return Collections.unmodifiableList(this.arrayFilters);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.mongodb.core.query;
 
+import java.util.List;
+
 import org.bson.Document;
 
 /**
@@ -53,4 +55,36 @@ public interface UpdateDefinition {
 	 * @param key must not be {@literal null}.
 	 */
 	void inc(String key);
+
+	/**
+	 * Get the specification which elements to modify in an array field.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.2
+	 */
+	List<ArrayFilter> getArrayFilters();
+
+	/**
+	 * @return {@literal true} if {@link UpdateDefinition} contains {@link #getArrayFilters() array filters}.
+	 * @since 2.2
+	 */
+	default boolean hasArrayFilters() {
+		return !getArrayFilters().isEmpty();
+	}
+
+	/**
+	 * A filter to specify which elements to modify in an array field.
+	 *
+	 * @since 2.2
+	 */
+	interface ArrayFilter {
+
+		/**
+		 * Get the {@link Document} representation of the filter to apply. The returned Document is subject to mapping
+		 * domain type filed names.
+		 *
+		 * @return never {@literal null}.
+		 */
+		Document asDocument();
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -1029,6 +1029,28 @@ public class UpdateMapperUnitTests {
 		assertThat(mappedUpdate).isEqualTo(new Document("AValue", "a value"));
 	}
 
+	@Test // DATAMONGO-2054
+	public void mappingShouldAllowPositionAllParameter() {
+
+		Update update = new Update().inc("grades.$[]", 10);
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithListOfSimple.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$inc", new Document("grades.$[]", 10)));
+	}
+
+	@Test // DATAMONGO-2054
+	public void mappingShouldAllowPositionAllParameterWhenPopertyHasExplicitFieldName() {
+
+		Update update = new Update().inc("list.$[]", 10);
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(ParentClass.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$inc", new Document("aliased.$[]", 10)));
+	}
+
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
 		ListModelWrapper concreteTypeWithListAttributeOfInterfaceType;
 	}
@@ -1245,6 +1267,10 @@ public class UpdateMapperUnitTests {
 		List<EntityWithAliasedObject> list;
 	}
 
+	static class EntityWithListOfSimple {
+		List<Integer> grades;
+	}
+
 	static class EntityWithAliasedObject {
 
 		@Field("renamed-value") Object value;
@@ -1348,11 +1374,9 @@ public class UpdateMapperUnitTests {
 	@Data
 	static class TypeWithFieldNameThatCannotBeDecapitalized {
 
-		@Id
-		protected String id;
+		@Id protected String id;
 
-		@Field("AValue")
-		private Long aValue = 0L;
+		@Field("AValue") private Long aValue = 0L;
 
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -1051,6 +1051,42 @@ public class UpdateMapperUnitTests {
 		assertThat(mappedUpdate).isEqualTo(new Document("$inc", new Document("aliased.$[]", 10)));
 	}
 
+	@Test // DATAMONGO-2215
+	public void mappingShouldAllowPositionParameterWithIdentifier() {
+
+		Update update = new Update().set("grades.$[element]", 10) //
+				.filterArray(Criteria.where("element").gte(100));
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithListOfSimple.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$set", new Document("grades.$[element]", 10)));
+	}
+
+	@Test // DATAMONGO-2215
+	public void mappingShouldAllowPositionParameterWithIdentifierWhenFieldHasExplicitFieldName() {
+
+		Update update = new Update().set("list.$[element]", 10) //
+				.filterArray(Criteria.where("element").gte(100));
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(ParentClass.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$set", new Document("aliased.$[element]", 10)));
+	}
+
+	@Test // DATAMONGO-2215
+	public void mappingShouldAllowNestedPositionParameterWithIdentifierWhenFieldHasExplicitFieldName() {
+
+		Update update = new Update().set("list.$[element].value", 10) //
+				.filterArray(Criteria.where("element").gte(100));
+
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(ParentClass.class));
+
+		assertThat(mappedUpdate).isEqualTo(new Document("$set", new Document("aliased.$[element].value", 10)));
+	}
+
 	static class DomainTypeWrappingConcreteyTypeHavingListOfInterfaceTypeAttributes {
 		ListModelWrapper concreteTypeWithListAttributeOfInterfaceType;
 	}


### PR DESCRIPTION
We now support filtered positional `$[<identifier>]` operator via `Updates`. This allows to specify a filter criteria chain for the elements in an array.

```java
new Update()
    .set("grades.$[element]", 100)
    .filterArray(Criteria.where("element").gte(100));
```
----

Depends on: #653 ([DATAMONGO-2054](https://jira.spring.io/browse/DATAMONGO-2054)) 