### PR TITLE
DATAMONGO-2221 - Fix mapping of Strings matching a valid ObjectId for unresolvable paths.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2221-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -831,6 +831,30 @@ public class QueryMapperUnitTests {
 		assertThat(document).isEqualTo(new org.bson.Document("nested.id", idHex));
 	}
 
+	@Test // DATAMONGO-2221
+	public void shouldNotConvertHexStringToObjectIdForRenamedDeeplyNestedIdField() {
+
+		String idHex = new ObjectId().toHexString();
+		Query query = new Query(where("nested.deeplyNested.id").is(idHex));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(RootForClassWithExplicitlyRenamedIdField.class));
+
+		assertThat(document).isEqualTo(new org.bson.Document("nested.deeplyNested.id", idHex));
+	}
+
+	@Test // DATAMONGO-2221
+	public void shouldNotConvertHexStringToObjectIdForUnresolvablePath() {
+
+		String idHex = new ObjectId().toHexString();
+		Query query = new Query(where("nested.unresolvablePath.id").is(idHex));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(RootForClassWithExplicitlyRenamedIdField.class));
+
+		assertThat(document).isEqualTo(new org.bson.Document("nested.unresolvablePath.id", idHex));
+	}
+
 	@Document
 	public class Foo {
 		@Id private ObjectId id;
@@ -925,6 +949,11 @@ public class QueryMapperUnitTests {
 
 	static class ClassWithExplicitlyRenamedField {
 
+		@Field("id") String id;
+		DeeplyNestedClassWithExplicitlyRenamedField deeplyNested;
+	}
+
+	static class DeeplyNestedClassWithExplicitlyRenamedField {
 		@Field("id") String id;
 	}
 


### PR DESCRIPTION
We now make sure we do **not** convert ``String``s that represent valid ``ObjectId``s into the such for paths that cannot be resolved to a `Property`.