### PR TITLE
DATAMONGO-2241 - Retain MongoConverter using MongoTemplate.withSession(…).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-cross-store/pom.xml
+++ b/spring-data-mongodb-cross-store/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>2.2.0.BUILD-SNAPSHOT</version>
+			<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 		</dependency>
 
 		<!-- reactive -->

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2241-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -276,17 +276,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		// we need to (re)create the MappingMongoConverter as we need to have it use a DbRefResolver that operates within
 		// the sames session. Otherwise loading referenced objects would happen outside of it.
-		if(that.mongoConverter instanceof MappingMongoConverter) {
-
-
-			MappingMongoConverter sourceConverter = (MappingMongoConverter) that.mongoConverter;
-			MappingMongoConverter targetConverter = new MappingMongoConverter(new DefaultDbRefResolver(dbFactory), that.mongoConverter.getMappingContext());
-
-			targetConverter.setInstantiators(sourceConverter.getEntityInstantiators());
-			targetConverter.setCustomConversions(sourceConverter.getCustomConversions());
-			targetConverter.afterPropertiesSet();
-
-			this.mongoConverter = targetConverter;
+		if (that.mongoConverter instanceof MappingMongoConverter) {
+			this.mongoConverter = ((MappingMongoConverter) that.mongoConverter).with(dbFactory);
 		} else {
 			this.mongoConverter = that.mongoConverter;
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -33,7 +33,6 @@ import org.bson.codecs.Codec;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -274,7 +273,24 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		this.mongoDbFactory = dbFactory;
 		this.exceptionTranslator = that.exceptionTranslator;
 		this.sessionSynchronization = that.sessionSynchronization;
-		this.mongoConverter = that.mongoConverter;
+
+		// we need to (re)create the MappingMongoConverter as we need to have it use a DbRefResolver that operates within
+		// the sames session. Otherwise loading referenced objects would happen outside of it.
+		if(that.mongoConverter instanceof MappingMongoConverter) {
+
+
+			MappingMongoConverter sourceConverter = (MappingMongoConverter) that.mongoConverter;
+			MappingMongoConverter targetConverter = new MappingMongoConverter(new DefaultDbRefResolver(dbFactory), that.mongoConverter.getMappingContext());
+
+			targetConverter.setInstantiators(sourceConverter.getEntityInstantiators());
+			targetConverter.setCustomConversions(sourceConverter.getCustomConversions());
+			targetConverter.afterPropertiesSet();
+
+			this.mongoConverter = targetConverter;
+		} else {
+			this.mongoConverter = that.mongoConverter;
+		}
+
 		this.queryMapper = that.queryMapper;
 		this.updateMapper = that.updateMapper;
 		this.schemaMapper = that.schemaMapper;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -33,6 +33,7 @@ import org.bson.codecs.Codec;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -273,8 +274,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		this.mongoDbFactory = dbFactory;
 		this.exceptionTranslator = that.exceptionTranslator;
 		this.sessionSynchronization = that.sessionSynchronization;
-		this.mongoConverter = that.mongoConverter instanceof MappingMongoConverter ? getDefaultMongoConverter(dbFactory)
-				: that.mongoConverter;
+		this.mongoConverter = that.mongoConverter;
 		this.queryMapper = that.queryMapper;
 		this.updateMapper = that.updateMapper;
 		this.schemaMapper = that.schemaMapper;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -29,7 +29,9 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityInstantiator;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.convert.TypeMapper;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
@@ -1595,6 +1597,26 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	 */
 	List<Document> bulkReadRefs(List<DBRef> references) {
 		return dbRefResolver.bulkFetch(references);
+	}
+
+	/**
+	 * Get the {@link EntityInstantiators} used by the converter.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.1.6
+	 */
+	public EntityInstantiators getEntityInstantiators() {
+		return instantiators;
+	}
+
+	/**
+	 * Get the {@link CustomConversions} used by the converter.
+	 *
+	 * @return ever {@literal null}.
+	 * @since 2.1.6
+	 */
+	public CustomConversions getCustomConversions() {
+		return conversions;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -1599,24 +1599,24 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		return dbRefResolver.bulkFetch(references);
 	}
 
-	/**
-	 * Get the {@link EntityInstantiators} used by the converter.
-	 *
-	 * @return never {@literal null}.
-	 * @since 2.1.6
-	 */
-	public EntityInstantiators getEntityInstantiators() {
-		return instantiators;
-	}
 
 	/**
-	 * Get the {@link CustomConversions} used by the converter.
+	 * Create a new {@link MappingMongoConverter} using the given {@link MongoDbFactory} when loading {@link DBRef}.
 	 *
-	 * @return ever {@literal null}.
+	 * @return new instance of {@link MappingMongoConverter}. Never {@literal null}.
 	 * @since 2.1.6
 	 */
-	public CustomConversions getCustomConversions() {
-		return conversions;
+	public MappingMongoConverter with(MongoDbFactory dbFactory) {
+
+		MappingMongoConverter target = new MappingMongoConverter(new DefaultDbRefResolver(dbFactory), mappingContext);
+		target.applicationContext = applicationContext;
+		target.conversions = conversions;
+		target.spELContext = spELContext;
+		target.setInstantiators(instantiators);
+		target.typeMapper = typeMapper;
+		target.afterPropertiesSet();
+
+		return target;
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ClientSessionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ClientSessionTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.mongodb.test.util.MongoVersion;
 import org.springframework.data.mongodb.test.util.MongoVersionRule;
 import org.springframework.data.mongodb.test.util.ReplicaSet;
 import org.springframework.data.util.Version;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoClient;
@@ -100,8 +101,10 @@ public class ClientSessionTests {
 				.cast(template.withSession(() -> session).execute(MongoOperations::getConverter));
 
 		assertThat(sessionTemplateConverter.getMappingContext()).isSameAs(source.getMappingContext());
-		assertThat(sessionTemplateConverter.getCustomConversions()).isSameAs(source.getCustomConversions());
-		assertThat(sessionTemplateConverter.getEntityInstantiators()).isSameAs(source.getEntityInstantiators());
+		assertThat(ReflectionTestUtils.getField(sessionTemplateConverter, "conversions"))
+				.isSameAs(ReflectionTestUtils.getField(source, "conversions"));
+		assertThat(ReflectionTestUtils.getField(sessionTemplateConverter, "instantiators"))
+				.isSameAs(ReflectionTestUtils.getField(source, "instantiators"));
 	}
 
 	@Test // DATAMONGO-1920


### PR DESCRIPTION
We now reuse the `MongoConverter` instance that is associated with a `MongoTemplate` when using `withSession(…)` instead of creating a new converter instance.
In consequence, we're reusing PersistentEntity instances, EntityInstantiators and generated accessor classes.

---

Related ticket: [DATAMONGO-2241](https://jira.spring.io/browse/DATAMONGO-2241).