### PR TITLE
DATAMONGO-2261 - Use Entity Callback API for auditing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2261-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2261-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2261-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2261-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bson.Document;
-
 import org.springframework.core.convert.ConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.IdentifierAccessor;
@@ -51,6 +50,7 @@ import org.springframework.util.MultiValueMap;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  * @see MongoTemplate
  * @see ReactiveMongoTemplate
@@ -673,22 +673,19 @@ class EntityOperations {
 		public T populateIdIfNecessary(@Nullable Object id) {
 
 			if (id == null) {
-				return null;
+				return propertyAccessor.getBean();
 			}
 
-			T bean = propertyAccessor.getBean();
 			MongoPersistentProperty idProperty = entity.getIdProperty();
-
 			if (idProperty == null) {
-				return bean;
+				return propertyAccessor.getBean();
 			}
 
 			if (identifierAccessor.getIdentifier() != null) {
-				return bean;
+				return propertyAccessor.getBean();
 			}
 
 			propertyAccessor.setProperty(idProperty, id);
-
 			return propertyAccessor.getBean();
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -59,6 +59,7 @@ import org.springframework.data.geo.Metric;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.context.MappingContextEvent;
 import org.springframework.data.mongodb.MongoDbFactory;
@@ -97,6 +98,8 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.MongoMappingEvent;
+import org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeConvertCallback;
+import org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeSaveCallback;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Meta;
@@ -198,6 +201,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	private WriteResultChecking writeResultChecking = WriteResultChecking.NONE;
 	private @Nullable ReadPreference readPreference;
 	private @Nullable ApplicationEventPublisher eventPublisher;
+	private @Nullable ReactiveEntityCallbacks entityCallbacks;
 	private @Nullable ReactiveMongoPersistentEntityIndexCreator indexCreator;
 
 	private SessionSynchronization sessionSynchronization = SessionSynchronization.ON_ACTUAL_TRANSACTION;
@@ -354,6 +358,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		prepareIndexCreator(applicationContext);
 
 		eventPublisher = applicationContext;
+		entityCallbacks = new ReactiveEntityCallbacks(applicationContext);
 		if (mappingContext instanceof ApplicationEventPublisherAware) {
 			((ApplicationEventPublisherAware) mappingContext).setApplicationEventPublisher(eventPublisher);
 		}
@@ -1320,23 +1325,27 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 			BeforeConvertEvent<T> event = new BeforeConvertEvent<>(objectToSave, collectionName);
 			T toConvert = maybeEmitEvent(event).getSource();
+			return maybeCallBeforeConvert(toConvert, collectionName).flatMap(toSave -> {
 
-			AdaptibleEntity<T> entity = operations.forEntity(toConvert, mongoConverter.getConversionService());
-			entity.assertUpdateableIdIfNotSet();
+				AdaptibleEntity<T> entity = operations.forEntity(toConvert, mongoConverter.getConversionService());
+				entity.assertUpdateableIdIfNotSet();
 
-			T initialized = entity.initializeVersionProperty();
-			Document dbDoc = entity.toMappedDocument(writer).getDocument();
+				T initialized = entity.initializeVersionProperty();
+				Document dbDoc = entity.toMappedDocument(writer).getDocument();
 
-			maybeEmitEvent(new BeforeSaveEvent<>(initialized, dbDoc, collectionName));
+				maybeEmitEvent(new BeforeSaveEvent<>(initialized, dbDoc, collectionName));
+				return maybeCallBeforeSave(initialized, dbDoc, collectionName).flatMap(it -> {
 
-			Mono<T> afterInsert = insertDocument(collectionName, dbDoc, initialized.getClass()).map(id -> {
+					Mono<T> afterInsert = insertDocument(collectionName, dbDoc, it.getClass()).map(id -> {
 
-				T saved = entity.populateIdIfNecessary(id);
-				maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName));
-				return saved;
+						T saved = entity.populateIdIfNecessary(id);
+						maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName));
+						return saved;
+					});
+
+					return afterInsert;
+				});
 			});
-
-			return afterInsert;
 		});
 	}
 
@@ -1397,20 +1406,23 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		Assert.notNull(writer, "MongoWriter must not be null!");
 
 		Mono<List<Tuple2<AdaptibleEntity<T>, Document>>> prepareDocuments = Flux.fromIterable(batchToSave)
-				.map(uninitialized -> {
+				.flatMap(uninitialized -> {
 
 					BeforeConvertEvent<T> event = new BeforeConvertEvent<>(uninitialized, collectionName);
 					T toConvert = maybeEmitEvent(event).getSource();
 
-					AdaptibleEntity<T> entity = operations.forEntity(toConvert, mongoConverter.getConversionService());
-					entity.assertUpdateableIdIfNotSet();
+					return maybeCallBeforeConvert(toConvert, collectionName).flatMap(it -> {
 
-					T initialized = entity.initializeVersionProperty();
-					Document dbDoc = entity.toMappedDocument(writer).getDocument();
+						AdaptibleEntity<T> entity = operations.forEntity(it, mongoConverter.getConversionService());
+						entity.assertUpdateableIdIfNotSet();
 
-					maybeEmitEvent(new BeforeSaveEvent<>(initialized, dbDoc, collectionName));
+						T initialized = entity.initializeVersionProperty();
+						Document dbDoc = entity.toMappedDocument(writer).getDocument();
 
-					return Tuples.of(entity, dbDoc);
+						maybeEmitEvent(new BeforeSaveEvent<>(initialized, dbDoc, collectionName));
+
+						return maybeCallBeforeSave(initialized, dbDoc, collectionName).thenReturn(Tuples.of(entity, dbDoc));
+					});
 				}).collectList();
 
 		Flux<Tuple2<AdaptibleEntity<T>, Document>> insertDocuments = prepareDocuments.flatMapMany(tuples -> {
@@ -1496,17 +1508,21 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			source.assertUpdateableIdIfNotSet();
 
 			BeforeConvertEvent<T> event = new BeforeConvertEvent<>(toSave, collectionName);
-			T afterEvent = ReactiveMongoTemplate.this.maybeEmitEvent(event).getSource();
+			T afterEvent = maybeEmitEvent(event).getSource();
 
-			MappedDocument mapped = operations.forEntity(toSave).toMappedDocument(mongoConverter);
-			Document document = mapped.getDocument();
+			return maybeCallBeforeConvert(afterEvent, collectionName).flatMap(toConvert -> {
 
-			ReactiveMongoTemplate.this.maybeEmitEvent(new BeforeSaveEvent<>(afterEvent, document, collectionName));
+				MappedDocument mapped = operations.forEntity(toSave).toMappedDocument(mongoConverter);
+				Document document = mapped.getDocument();
 
-			return doUpdate(collectionName, query, mapped.updateWithoutId(), afterEvent.getClass(), false, false)
-					.map(result -> {
-						return maybeEmitEvent(new AfterSaveEvent<T>(afterEvent, document, collectionName)).getSource();
+				maybeEmitEvent(new BeforeSaveEvent<>(toConvert, document, collectionName));
+				return maybeCallBeforeSave(toConvert, document, collectionName).flatMap(it -> {
+
+					return doUpdate(collectionName, query, mapped.updateWithoutId(), it.getClass(), false, false).map(result -> {
+						return maybeEmitEvent(new AfterSaveEvent<T>(it, document, collectionName)).getSource();
 					});
+				});
+			});
 		});
 	}
 
@@ -1518,14 +1534,20 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 			T toSave = maybeEmitEvent(new BeforeConvertEvent<T>(objectToSave, collectionName)).getSource();
 
-			AdaptibleEntity<T> entity = operations.forEntity(toSave, mongoConverter.getConversionService());
-			Document dbDoc = entity.toMappedDocument(writer).getDocument();
-			maybeEmitEvent(new BeforeSaveEvent<T>(toSave, dbDoc, collectionName));
+			return maybeCallBeforeConvert(toSave, collectionName).flatMap(toConvert -> {
 
-			return saveDocument(collectionName, dbDoc, toSave.getClass()).map(id -> {
+				AdaptibleEntity<T> entity = operations.forEntity(toConvert, mongoConverter.getConversionService());
+				Document dbDoc = entity.toMappedDocument(writer).getDocument();
+				maybeEmitEvent(new BeforeSaveEvent<T>(toConvert, dbDoc, collectionName));
 
-				T saved = entity.populateIdIfNecessary(id);
-				return maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName)).getSource();
+				return maybeCallBeforeSave(toConvert, dbDoc, collectionName).flatMap(it -> {
+
+					return saveDocument(collectionName, dbDoc, it.getClass()).map(id -> {
+
+						T saved = entity.populateIdIfNecessary(id);
+						return maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName)).getSource();
+					});
+				});
 			});
 		});
 	}
@@ -2494,9 +2516,13 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 			maybeEmitEvent(new BeforeSaveEvent<>(replacement, replacement, collectionName));
 
-			return executeFindOneInternal(
-					new FindAndReplaceCallback(mappedQuery, mappedFields, mappedSort, replacement, collation, options),
-					new ProjectingReadCallback<>(this.mongoConverter, entityType, resultType, collectionName), collectionName);
+			return maybeCallBeforeSave(replacement, replacement, collectionName).flatMap(it -> {
+
+				return executeFindOneInternal(
+						new FindAndReplaceCallback(mappedQuery, mappedFields, mappedSort, it, collation, options),
+						new ProjectingReadCallback<>(this.mongoConverter, entityType, resultType, collectionName), collectionName);
+
+			});
 		});
 	}
 
@@ -2507,6 +2533,28 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		}
 
 		return event;
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <T> Mono<T> maybeCallBeforeConvert(T object, String collection) {
+
+		if (null != entityCallbacks) {
+			return entityCallbacks.callbackLater(object, ReactiveBeforeConvertCallback.class,
+					(cb, t) -> cb.onBeforeConvert(t, collection));
+		}
+
+		return Mono.just(object);
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <T> Mono<T> maybeCallBeforeSave(T object, Document document, String collection) {
+
+		if (null != entityCallbacks) {
+			return entityCallbacks.callbackLater(object, ReactiveBeforeSaveCallback.class,
+					(cb, t) -> cb.onBeforeSave(t, document, collection));
+		}
+
+		return Mono.just(object);
 	}
 
 	private MongoCollection<Document> getAndPrepareCollection(MongoDatabase db, String collectionName) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AuditingEntityCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AuditingEntityCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,44 +16,42 @@
 package org.springframework.data.mongodb.core.mapping.event;
 
 import org.springframework.beans.factory.ObjectFactory;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.util.Assert;
 
 /**
- * Event listener to populate auditing related fields on an entity about to be saved.
+ * {@link EntityCallback} to populate auditing related fields on an entity about to be saved.
  *
- * @author Oliver Gierke
- * @author Thomas Darimont
- * @deprecated since 2.2, use {@link AuditingEntityCallback}.
+ * @author Mark Paluch
+ * @since 2.2
  */
-@Deprecated
-public class AuditingEventListener implements ApplicationListener<BeforeConvertEvent<Object>>, Ordered {
+public class AuditingEntityCallback implements BeforeConvertCallback<Object>, Ordered {
 
 	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
 
 	/**
-	 * Creates a new {@link AuditingEventListener} using the given {@link MappingContext} and {@link AuditingHandler}
+	 * Creates a new {@link AuditingEntityCallback} using the given {@link MappingContext} and {@link AuditingHandler}
 	 * provided by the given {@link ObjectFactory}.
 	 *
 	 * @param auditingHandlerFactory must not be {@literal null}.
 	 */
-	public AuditingEventListener(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
+	public AuditingEntityCallback(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
 
 		Assert.notNull(auditingHandlerFactory, "IsNewAwareAuditingHandler must not be null!");
 		this.auditingHandlerFactory = auditingHandlerFactory;
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.context.ApplicationListener#onApplicationEvent(org.springframework.context.ApplicationEvent)
+	 * @see org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback#onBeforeConvert(java.lang.Object, java.lang.String)
 	 */
 	@Override
-	public void onApplicationEvent(BeforeConvertEvent<Object> event) {
-		event.mapSource(it -> auditingHandlerFactory.getObject().markAudited(it));
+	public Object onBeforeConvert(Object entity, String collection) {
+		return auditingHandlerFactory.getObject().markAudited(entity);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.SimpleEntityCallbacks;
+
+/**
+ * Callback being invoked before a domain object is converted to be persisted.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ * @see SimpleEntityCallbacks
+ */
+@FunctionalInterface
+public interface BeforeConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is converted to be persisted. Can return either the same of a
+	 * modified instance of the domain object.
+	 *
+	 * @param entity the domain object to save.
+	 * @param collection name of the collection.
+	 * @return the domain object to be persisted.
+	 */
+	T onBeforeConvert(T entity, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeConvertCallback.java
@@ -16,20 +16,18 @@
 package org.springframework.data.mongodb.core.mapping.event;
 
 import org.springframework.data.mapping.callback.EntityCallback;
-import org.springframework.data.mapping.callback.SimpleEntityCallbacks;
 
 /**
  * Callback being invoked before a domain object is converted to be persisted.
  *
  * @author Mark Paluch
  * @since 2.2
- * @see SimpleEntityCallbacks
  */
 @FunctionalInterface
 public interface BeforeConvertCallback<T> extends EntityCallback<T> {
 
 	/**
-	 * Entity callback method invoked before a domain object is converted to be persisted. Can return either the same of a
+	 * Entity callback method invoked before a domain object is converted to be persisted. Can return either the same or a
 	 * modified instance of the domain object.
 	 *
 	 * @param entity the domain object to save.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.SimpleEntityCallbacks;
+
+/**
+ * Entity callback triggered before save of a document.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ * @see SimpleEntityCallbacks
+ */
+@FunctionalInterface
+public interface BeforeSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is saved. Can return either the same of a modified instance
+	 * of the domain object and can modify {@link Document} contents. This method called after converting the
+	 * {@code entity} to {@link Document} so effectively the document is used as outcome of invoking this callback.
+	 *
+	 * @param entity the domain object to save.
+	 * @param document {@link Document} representing the {@code entity}.
+	 * @param collection name of the collection.
+	 * @return the domain object to be persisted.
+	 */
+	T onBeforeSave(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/BeforeSaveCallback.java
@@ -16,22 +16,19 @@
 package org.springframework.data.mongodb.core.mapping.event;
 
 import org.bson.Document;
-
 import org.springframework.data.mapping.callback.EntityCallback;
-import org.springframework.data.mapping.callback.SimpleEntityCallbacks;
 
 /**
  * Entity callback triggered before save of a document.
  *
  * @author Mark Paluch
  * @since 2.2
- * @see SimpleEntityCallbacks
  */
 @FunctionalInterface
 public interface BeforeSaveCallback<T> extends EntityCallback<T> {
 
 	/**
-	 * Entity callback method invoked before a domain object is saved. Can return either the same of a modified instance
+	 * Entity callback method invoked before a domain object is saved. Can return either the same or a modified instance
 	 * of the domain object and can modify {@link Document} contents. This method called after converting the
 	 * {@code entity} to {@link Document} so effectively the document is used as outcome of invoking this callback.
 	 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAuditingEntityCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAuditingEntityCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,45 +15,46 @@
  */
 package org.springframework.data.mongodb.core.mapping.event;
 
+import reactor.core.publisher.Mono;
+
+import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.ObjectFactory;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.util.Assert;
 
 /**
- * Event listener to populate auditing related fields on an entity about to be saved.
+ * Reactive {@link EntityCallback} to populate auditing related fields on an entity about to be saved.
  *
- * @author Oliver Gierke
- * @author Thomas Darimont
- * @deprecated since 2.2, use {@link AuditingEntityCallback}.
+ * @author Mark Paluch
+ * @since 2.2
  */
-@Deprecated
-public class AuditingEventListener implements ApplicationListener<BeforeConvertEvent<Object>>, Ordered {
+public class ReactiveAuditingEntityCallback implements ReactiveBeforeConvertCallback<Object>, Ordered {
 
 	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
 
 	/**
-	 * Creates a new {@link AuditingEventListener} using the given {@link MappingContext} and {@link AuditingHandler}
-	 * provided by the given {@link ObjectFactory}.
+	 * Creates a new {@link ReactiveAuditingEntityCallback} using the given {@link MappingContext} and
+	 * {@link AuditingHandler} provided by the given {@link ObjectFactory}.
 	 *
 	 * @param auditingHandlerFactory must not be {@literal null}.
 	 */
-	public AuditingEventListener(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
+	public ReactiveAuditingEntityCallback(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
 
 		Assert.notNull(auditingHandlerFactory, "IsNewAwareAuditingHandler must not be null!");
 		this.auditingHandlerFactory = auditingHandlerFactory;
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.context.ApplicationListener#onApplicationEvent(org.springframework.context.ApplicationEvent)
+	 * @see org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeConvertCallback#onBeforeConvert(java.lang.Object, java.lang.String)
 	 */
 	@Override
-	public void onApplicationEvent(BeforeConvertEvent<Object> event) {
-		event.mapSource(it -> auditingHandlerFactory.getObject().markAudited(it));
+	public Publisher<Object> onBeforeConvert(Object entity, String collection) {
+		return Mono.just(auditingHandlerFactory.getObject().markAudited(entity));
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeConvertCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Callback being invoked before a domain object is converted to be persisted.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ * @see ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface ReactiveBeforeConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is converted to be persisted. Can return either the same of a
+	 * modified instance of the domain object.
+	 *
+	 * @param entity the domain object to save.
+	 * @param collection name of the collection.
+	 * @return a {@link Publisher} emitting the domain object to be persisted.
+	 */
+	Publisher<T> onBeforeConvert(T entity, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeSaveCallback.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Entity callback triggered before save of a document.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ * @see ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface ReactiveBeforeSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is saved. Can return either the same of a modified instance
+	 * of the domain object and can modify {@link Document} contents. This method is called after converting the
+	 * {@code entity} to {@link Document} so effectively the document is used as outcome of invoking this callback.
+	 *
+	 * @param entity the domain object to save.
+	 * @param document {@link Document} representing the {@code entity}.
+	 * @param collection name of the collection.
+	 * @return a {@link Publisher} emitting the domain object to be persisted.
+	 */
+	Publisher<T> onBeforeSave(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveBeforeSaveCallback.java
@@ -32,7 +32,7 @@ import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 public interface ReactiveBeforeSaveCallback<T> extends EntityCallback<T> {
 
 	/**
-	 * Entity callback method invoked before a domain object is saved. Can return either the same of a modified instance
+	 * Entity callback method invoked before a domain object is saved. Can return either the same or a modified instance
 	 * of the domain object and can modify {@link Document} contents. This method is called after converting the
 	 * {@code entity} to {@link Document} so effectively the document is used as outcome of invoking this callback.
 	 *

--- a/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-data-mongodb/src/main/resources/META-INF/spring.schemas
@@ -9,4 +9,5 @@ http\://www.springframework.org/schema/data/mongo/spring-mongo-1.8.xsd=org/sprin
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.10.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-1.10.2.xsd=org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
 http\://www.springframework.org/schema/data/mongo/spring-mongo-2.0.xsd=org/springframework/data/mongodb/config/spring-mongo-2.0.xsd
-http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-2.0.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo-2.2.xsd=org/springframework/data/mongodb/config/spring-mongo-2.0.xsd
+http\://www.springframework.org/schema/data/mongo/spring-mongo.xsd=org/springframework/data/mongodb/config/spring-mongo-2.2.xsd

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-2.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-2.2.xsd
@@ -1,0 +1,687 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xsd:schema xmlns="http://www.springframework.org/schema/data/mongo"
+						xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+						xmlns:beans="http://www.springframework.org/schema/beans"
+						xmlns:tool="http://www.springframework.org/schema/tool"
+						xmlns:repository="http://www.springframework.org/schema/data/repository"
+						targetNamespace="http://www.springframework.org/schema/data/mongo"
+						elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/context" />
+	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
+				schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+
+	<xsd:element name="mongo-client" type="mongoClientType">
+	  <xsd:annotation>
+		<xsd:documentation source="org.springframework.data.mongodb.core.MongoClientFactoryBean"><![CDATA[
+Defines a MongoClient instance used for accessing MongoDB.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.mongodb.MongoClient"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="db-factory">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoDbFactory for connecting to a specific database
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MongoDbFactory definition (by default "mongoDbFactory").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a MongoClient instance. If not configured a default com.mongodb.MongoClient instance will be created.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="dbname" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the database to connect to. Default is 'db'.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="client-uri" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The MongoClientURI string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="mongo-repository-attributes">
+		<xsd:attribute name="mongo-template-ref" type="mongoTemplateRef" default="mongoTemplate">
+			<xsd:annotation>
+				<xsd:documentation>
+					The reference to a MongoTemplate. Will default to 'mongoTemplate'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="create-query-indexes" default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Enables creation of indexes for queries that get derived from the method name
+					and thus reference domain class properties. Defaults to false.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:element name="repositories">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="repository:repositories">
+					<xsd:attributeGroup ref="mongo-repository-attributes"/>
+					<xsd:attributeGroup ref="repository:repository-attributes"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mapping-converter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[Defines a MongoConverter for getting rich mapping functionality.]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:exports type="org.springframework.data.mongodb.core.convert.MappingMongoConverter" />
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="custom-converters" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+		Top-level element that contains one or more custom converters to be used for mapping
+		domain objects to and from Mongo's Document]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="converter" type="customConverterType" minOccurs="0" maxOccurs="unbounded"/>
+						</xsd:sequence>
+						<xsd:attribute name="base-package" type="xsd:string" />
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MappingMongoConverter instance (by default "mappingConverter").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="base-package" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The base package in which to scan for entities annotated with @Document
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="type-mapper-ref" type="typeMapperRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a MongoTypeMapper to be used by this MappingMongoConverter.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mapping.model.MappingContext">
+						The reference to a MappingContext. Will default to 'mappingContext'.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="disable-validation" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener">
+						Disables JSR-303 validation on MongoDB documents before they are saved. By default it is set to false.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="abbreviate-field-names" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.CamelCaseAbbreviatingFieldNamingStrategy">
+						Enables abbreviating the field names for domain class properties to the
+						first character of their camel case names, e.g. fooBar -> fb. Defaults to false.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="field-naming-strategy-ref" type="fieldNamingStrategyRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation source="org.springframework.data.mongodb.core.mapping.FieldNamingStrategy">
+						The reference to a FieldNamingStrategy.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="jmx">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a JMX Model MBeans for monitoring a MongoDB server'.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="mongo-ref" type="mongoRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MongoClient object that determines what server to monitor. (by default "mongoClient").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="auditing">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.data.mongodb.core.mapping.event.AuditingEntityCallback" />
+					<tool:exports type="org.springframework.data.auditing.IsNewAwareAuditingHandler" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="repository:auditing-attributes" />
+			<xsd:attribute name="mapping-context-ref" type="mappingContextRef" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="typeMapperRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoTypeMapper"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mappingContextRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mapping.model.MappingContext"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="fieldNamingStrategyRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.mapping.FieldNamingStrategy"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoTemplateRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.MongoTemplate"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="mongoRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.MongoClientFactoryBean"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="sslSocketFactoryRef">
+	<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="javax.net.ssl.SSLSocketFactory"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="writeConcernEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="NONE" />
+			<xsd:enumeration value="NORMAL" />
+			<xsd:enumeration value="SAFE" />
+			<xsd:enumeration value="FSYNC_SAFE" />
+			<xsd:enumeration value="REPLICAS_SAFE" />
+			<xsd:enumeration value="JOURNAL_SAFE" />
+			<xsd:enumeration value="MAJORITY" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="readPreferenceEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="PRIMARY" />
+			<xsd:enumeration value="PRIMARY_PREFERRED" />
+			<xsd:enumeration value="SECONDARY" />
+			<xsd:enumeration value="SECONDARY_PREFERRED" />
+			<xsd:enumeration value="NEAREST" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="booleanType">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="true" />
+			<xsd:enumeration value="false" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="mongoClientType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClient' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence minOccurs="0" maxOccurs="1">
+			<xsd:element name="client-options" type="clientOptionsType">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The Mongo driver options
+							]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation>
+							<tool:exports type="com.mongodb.MongoClientOptions"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The name of the MongoClient definition (by default "mongoClient").]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="port" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The port to connect to MongoDB server.  Default is 27017
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="host" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The host to connect to a MongoDB server.  Default is localhost
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="replica-set" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of host:port entries to use for replica set/pairs.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="credentials" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The comma delimited list of username:password@database entries to use for authentication. Appending ?uri.authMechanism allows to specify the authentication challenge mechanism. If the credential you're trying to pass contains a comma itself, quote it with single quotes: '…'.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="clientOptionsType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Configuration options for 'MongoClientOptions' - @since 1.7
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="description" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The MongoClient description.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The minimum number of connections per host.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connections-per-host" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The number of connections allowed per host.  Will block if run out.	 Default is 100.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="threads-allowed-to-block-for-connection-multiplier" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-wait-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The max wait time of a blocking thread for a connection. Default is 120000 ms (2 minutes).
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-connection-idle-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum idle time for a pooled connection.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-connection-life-time" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The maximum life time for a pooled connection.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout in milliseconds. 0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout.  0 is default and infinite.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="socket-keep-alive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="server-selection-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The server selection timeout in milliseconds, which defines how long the driver will wait for server selection to succeed before throwing an exception. Default is 30 seconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="read-preference">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The read preference.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="readPreferenceEnumeration xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="write-concern">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-frequency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This is the frequency that the driver will attempt to determine the current state of each server in the cluster.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-heartbeat-frequency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-connect-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The connect timeout for connections used for the cluster heartbeat.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="heartbeat-socket-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The socket timeout for connections used for the cluster heartbeat.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ssl" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+This controls if the driver should us an SSL connection.  Defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="booleanType xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ssl-socket-factory-ref" type="sslSocketFactoryRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:group name="beanElementGroup">
+		<xsd:choice>
+			<xsd:element ref="beans:bean"/>
+			<xsd:element ref="beans:ref"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:complexType name="customConverterType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Element defining a custom converter.
+	]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="beanElementGroup" minOccurs="0" maxOccurs="1"/>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					A reference to a custom converter.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref"/>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:simpleType name="converterRef">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a MongoTemplate.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the MongoTemplate definition (by default "mongoTemplate").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a MappingMongoConverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string"
+				use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to
+								type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="write-concern">
+				<xsd:annotation>
+					<xsd:documentation>
+					The WriteConcern that will be the default value used when asking the MongoDbFactory for a DB object
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="gridFsTemplate">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Defines a GridFsTemplate.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The name of the GridFsTemplate definition (by default "gridFsTemplate").]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="converter-ref" type="converterRef" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The reference to a MappingMongoConverter instance.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.core.convert.MongoConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-factory-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The reference to a DbFactory.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:assignable-to type="org.springframework.data.mongodb.MongoDbFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="bucket" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The GridFs bucket string.]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AuditingIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AuditingIntegrationTests.java
@@ -20,13 +20,12 @@ import static org.junit.Assert.*;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
-
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mapping.callback.SimpleEntityCallbacks;
+import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
 
@@ -38,7 +37,7 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback
  */
 public class AuditingIntegrationTests {
 
-	@Test // DATAMONGO-577, DATAMONGO-800, DATAMONGO-883, 2261
+	@Test // DATAMONGO-577, DATAMONGO-800, DATAMONGO-883, DATAMONGO-2261
 	public void enablesAuditingAndSetsPropertiesAccordingly() throws Exception {
 
 		AbstractApplicationContext context = new ClassPathXmlApplicationContext("auditing.xml", getClass());
@@ -46,10 +45,10 @@ public class AuditingIntegrationTests {
 		MongoMappingContext mappingContext = context.getBean(MongoMappingContext.class);
 		mappingContext.getPersistentEntity(Entity.class);
 
-		SimpleEntityCallbacks callbacks = new SimpleEntityCallbacks(context);
+		EntityCallbacks callbacks = EntityCallbacks.create(context);
 
 		Entity entity = new Entity();
-		entity = callbacks.callback(entity, BeforeConvertCallback.class, (cb, e) -> cb.onBeforeConvert(e, "collection-1"));
+		entity = callbacks.callback(BeforeConvertCallback.class, entity, "collection-1");
 
 		assertThat(entity.created, is(notNullValue()));
 		assertThat(entity.modified, is(entity.created));
@@ -57,7 +56,7 @@ public class AuditingIntegrationTests {
 		Thread.sleep(10);
 		entity.id = 1L;
 
-		entity = callbacks.callback(entity, BeforeConvertCallback.class, (cb, e) -> cb.onBeforeConvert(e, "collection-1"));
+		entity = callbacks.callback(BeforeConvertCallback.class, entity, "collection-1");
 
 		assertThat(entity.created, is(notNullValue()));
 		assertThat(entity.modified, is(not(entity.created)));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsIntegrationTests.java
@@ -72,19 +72,19 @@ public class DefaultBulkOperationsIntegrationTests {
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-934
 	public void rejectsNullMongoOperations() {
 		new DefaultBulkOperations(null, COLLECTION_NAME,
-				new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null));
+				new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null, null));
 
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-934
 	public void rejectsNullCollectionName() {
 		new DefaultBulkOperations(operations, null,
-				new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null));
+				new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null, null));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-934
 	public void rejectsEmptyCollectionName() {
-		new DefaultBulkOperations(operations, "", new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null));
+		new DefaultBulkOperations(operations, "", new BulkOperationContext(BulkMode.ORDERED, Optional.empty(), null, null, null));
 	}
 
 	@Test // DATAMONGO-934
@@ -341,7 +341,7 @@ public class DefaultBulkOperationsIntegrationTests {
 				: Optional.empty();
 
 		BulkOperationContext bulkOperationContext = new BulkOperationContext(mode, entity,
-				new QueryMapper(operations.getConverter()), new UpdateMapper(operations.getConverter()));
+				new QueryMapper(operations.getConverter()), new UpdateMapper(operations.getConverter()), null);
 
 		DefaultBulkOperations bulkOps = new DefaultBulkOperations(operations, COLLECTION_NAME, bulkOperationContext);
 		bulkOps.setDefaultWriteConcern(WriteConcern.ACKNOWLEDGED);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationUnitTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.EntityOperations.AdaptibleEntity;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+/**
+ * @author Christoph Strobl
+ */
+public class EntityOperationUnitTests {
+
+	EntityOperations ops;
+	MongoMappingContext mappingContext = new MongoMappingContext();
+	ConversionService conversionService = new DefaultConversionService();
+
+	@Before
+	public void setUp() {
+		ops = new EntityOperations(mappingContext);
+	}
+
+	@Test // DATAMONGO-2293
+	public void populateIdShouldReturnTargetBeanWhenIdIsNull() {
+		assertThat(initAdaptibleEntity(new DomainTypeWithIdProperty()).populateIdIfNecessary(null)).isNotNull();
+	}
+
+	<T> AdaptibleEntity<T> initAdaptibleEntity(T source) {
+		return ops.forEntity(source, conversionService);
+	}
+
+	private static class DomainTypeWithIdProperty {
+
+		@Id String id;
+		String value;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AuditingEntityCallbackUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/AuditingEntityCallbackUnitTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Wither;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.core.Ordered;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+/**
+ * Unit tests for {@link AuditingEntityCallback}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AuditingEntityCallbackUnitTests {
+
+	IsNewAwareAuditingHandler handler;
+	AuditingEntityCallback callback;
+
+	@Before
+	public void setUp() {
+
+		MongoMappingContext mappingContext = new MongoMappingContext();
+		mappingContext.getPersistentEntity(Sample.class);
+
+		handler = spy(new IsNewAwareAuditingHandler(new PersistentEntities(Arrays.asList(mappingContext))));
+
+		doAnswer(AdditionalAnswers.returnsArgAt(0)).when(handler).markCreated(any());
+		doAnswer(AdditionalAnswers.returnsArgAt(0)).when(handler).markModified(any());
+
+		callback = new AuditingEntityCallback(() -> handler);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATAMONGO-2261
+	public void rejectsNullAuditingHandler() {
+		new AuditingEntityCallback(null);
+	}
+
+	@Test // DATAMONGO-2261
+	public void triggersCreationMarkForObjectWithEmptyId() {
+
+		Sample sample = new Sample();
+		callback.onBeforeConvert(sample, "foo");
+
+		verify(handler, times(1)).markCreated(sample);
+		verify(handler, times(0)).markModified(any());
+	}
+
+	@Test // DATAMONGO-2261
+	public void triggersModificationMarkForObjectWithSetId() {
+
+		Sample sample = new Sample();
+		sample.id = "id";
+		callback.onBeforeConvert(sample, "foo");
+
+		verify(handler, times(0)).markCreated(any());
+		verify(handler, times(1)).markModified(sample);
+	}
+
+	@Test // DATAMONGO-2261
+	public void hasExplicitOrder() {
+
+		assertThat(callback, is(instanceOf(Ordered.class)));
+		assertThat(callback.getOrder(), is(100));
+	}
+
+	@Test // DATAMONGO-2261
+	public void propagatesChangedInstanceToEvent() {
+
+		ImmutableSample sample = new ImmutableSample();
+
+		ImmutableSample newSample = new ImmutableSample();
+		IsNewAwareAuditingHandler handler = mock(IsNewAwareAuditingHandler.class);
+		doReturn(newSample).when(handler).markAudited(eq(sample));
+
+		AuditingEntityCallback listener = new AuditingEntityCallback(() -> handler);
+		Object result = listener.onBeforeConvert(sample, "foo");
+
+		assertThat(result).isSameAs(newSample);
+	}
+
+	static class Sample {
+
+		@Id String id;
+		@CreatedDate Date created;
+		@LastModifiedDate Date modified;
+	}
+
+	@Value
+	@Wither
+	@AllArgsConstructor
+	@NoArgsConstructor(force = true)
+	static class ImmutableSample {
+
+		@Id String id;
+		@CreatedDate Date created;
+		@LastModifiedDate Date modified;
+	}
+}

--- a/src/main/asciidoc/reference/mongo-entity-callbacks.adoc
+++ b/src/main/asciidoc/reference/mongo-entity-callbacks.adoc
@@ -1,0 +1,30 @@
+= Store specific EntityCallbacks
+
+Spring Data MongoDB uses the `EntityCallback` API for its auditing support and reacts on the following callbacks.
+
+.Supported Entity Callbacks
+[%header,cols="4"]
+|===
+| Callback
+| Method
+| Description
+| Order
+
+| Reactive/BeforeConvertCallback
+| onBeforeConvert(T entity, String collection)
+| Invoked before a domain object is converted to `org.bson.Document`.
+| `Ordered.LOWEST_PRECEDENCE`
+
+| Reactive/AuditingEntityCallback
+| onBeforeConvert(Object entity, String collection)
+| Marks an auditable entity _created_ or _modified_
+| 100
+
+| Reactive/BeforeSaveCallback
+| onBeforeSave(T entity, org.bson.Document target, String collection)
+| Invoked before a domain object is saved. +
+ Can modify the target, to be persisted, `Document` containing all mapped entity information.
+| `Ordered.LOWEST_PRECEDENCE`
+
+|===
+

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -3159,6 +3159,11 @@ The following callback methods are present in `AbstractMappingEventListener`:
 
 NOTE: Lifecycle events are only emitted for root level types. Complex types used as properties within a document root are not subject to event publication unless they are document references annotated with `@DBRef`.
 
+WARNING: Lifecycle events depend on an `ApplicationEventMulticaster`, which in case of the `SimpleApplicationEventMulticaster` can be configured with a `TaskExecutor`, and therefore gives no guarantees when an Event is processed.
+
+include::../{spring-data-commons-docs}/entity-callbacks.adoc[leveloffset=+1]
+include::./mongo-entity-callbacks.adoc[leveloffset=+2]
+
 [[mongo.exception]]
 == Exception Translation
 


### PR DESCRIPTION
We now use `EntityCallback` to invoke callback actions on entities before saving/before conversion to provide hooks that potentially modify an entity before persisting it.

We also provide a reactive variant of entity callbacks allowing to consume Reactor `Context` and to defer the actual activity.

---

Related ticket: [DATAMONGO-2261](https://jira.spring.io/browse/DATAMONGO-2261).
Depends on: [DATACMNS-1467](https://jira.spring.io/browse/DATACMNS-1467), spring-projects/spring-data-commons#332.