### PR TITLE
DATAMONGO-2264 - Support upcoming MongoDB 4.2 Server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ before_install:
 
 env:
   matrix:
-    - PROFILE=ci
+    - MONGO_VERSION=4.1.10
+    - MONGO_VERSION=4.0.4
+    - MONGO_VERSION=3.6.12
+    - MONGO_VERSION=3.4.20
   global:
-    - MONGO_VERSION=4.0.0
+    - PROFILE=ci
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2264-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2264-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2264-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2264-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultScriptOperations.java
@@ -42,13 +42,15 @@ import com.mongodb.MongoException;
 import com.mongodb.client.MongoDatabase;
 
 /**
- * Default implementation of {@link ScriptOperations} capable of saving and executing {@link ServerSideJavaScript}.
+ * Default implementation of {@link ScriptOperations} capable of saving and executing {@link ExecutableMongoScript}.
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Mark Paluch
  * @since 1.7
+ * @deprecated since 2.2. The {@code eval} command has been removed in MongoDB Server 4.2.0.
  */
+@Deprecated
 class DefaultScriptOperations implements ScriptOperations {
 
 	private static final String SCRIPT_COLLECTION_NAME = "system.js";

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bson.Document;
-
 import org.springframework.core.convert.ConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.IdentifierAccessor;
@@ -45,6 +44,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Common operations performed on an entity in the context of it's mapping metadata.
@@ -162,6 +162,28 @@ class EntityOperations {
 		}
 
 		return ID_FIELD;
+	}
+
+	/**
+	 * Return the name used for {@code $geoNear.distanceField} avoiding clashes with potentially existing properties.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return the name of the distanceField to use. {@literal dis} by default.
+	 * @since 2.2
+	 */
+	public String nearQueryDistanceFieldName(Class<?> domainType) {
+
+		if (!context.hasPersistentEntityFor(domainType)
+				|| context.getPersistentEntity(domainType).getPersistentProperty("dis") == null) {
+			return "dis";
+		}
+
+		String distanceFieldName = "calculated-distance";
+		while (context.getPersistentEntity(domainType).getPersistentProperty(distanceFieldName) != null) {
+			distanceFieldName += "-" + ObjectUtils.getIdentityHexString(new Object());
+		}
+
+		return distanceFieldName;
 	}
 
 	private static Document parse(String source) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bson.Document;
+
 import org.springframework.core.convert.ConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.IdentifierAccessor;
@@ -44,7 +45,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.ObjectUtils;
 
 /**
  * Common operations performed on an entity in the context of it's mapping metadata.
@@ -173,14 +173,15 @@ class EntityOperations {
 	 */
 	public String nearQueryDistanceFieldName(Class<?> domainType) {
 
-		if (!context.hasPersistentEntityFor(domainType)
-				|| context.getPersistentEntity(domainType).getPersistentProperty("dis") == null) {
+		MongoPersistentEntity<?> persistentEntity = context.getPersistentEntity(domainType);
+		if (persistentEntity == null || persistentEntity.getPersistentProperty("dis") == null) {
 			return "dis";
 		}
 
 		String distanceFieldName = "calculated-distance";
-		while (context.getPersistentEntity(domainType).getPersistentProperty(distanceFieldName) != null) {
-			distanceFieldName += "-" + ObjectUtils.getIdentityHexString(new Object());
+		int counter = 0;
+		while (persistentEntity.getPersistentProperty(distanceFieldName) != null) {
+			distanceFieldName += "-" + (counter++);
 		}
 
 		return distanceFieldName;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -355,7 +355,9 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *
 	 * @return
 	 * @since 1.7
+	 * @deprecated since 2.2. The {@code eval} command has been removed without replacement in MongoDB Server 4.2.0.
 	 */
+	@Deprecated
 	ScriptOperations scriptOps();
 
 	/**
@@ -427,7 +429,11 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *          reduce function.
 	 * @param entityClass The parametrized type of the returned list
 	 * @return The results of the group operation
+	 * @deprecated since 2.2. The {@code group} command has been removed in MongoDB Server 4.2.0. <br />
+	 *             Please use {@link #aggregate(TypedAggregation, String, Class) } with a
+	 *             {@link org.springframework.data.mongodb.core.aggregation.GroupOperation} instead.
 	 */
+	@Deprecated
 	<T> GroupByResults<T> group(String inputCollectionName, GroupBy groupBy, Class<T> entityClass);
 
 	/**
@@ -442,7 +448,12 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *          reduce function.
 	 * @param entityClass The parametrized type of the returned list
 	 * @return The results of the group operation
+	 * @deprecated since 2.2. The {@code group} command has been removed in MongoDB Server 4.2.0. <br />
+	 *             Please use {@link #aggregate(TypedAggregation, String, Class) } with a
+	 *             {@link org.springframework.data.mongodb.core.aggregation.GroupOperation} and
+	 *             {@link org.springframework.data.mongodb.core.aggregation.MatchOperation} instead.
 	 */
+	@Deprecated
 	<T> GroupByResults<T> group(@Nullable Criteria criteria, String inputCollectionName, GroupBy groupBy,
 			Class<T> entityClass);
 
@@ -1147,8 +1158,8 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 * <p/>
 	 * <p/>
 	 * Insert is used to initially store the object into the database. To update an existing object use the save method.
@@ -1209,8 +1220,8 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 *
 	 * @param objectToSave the object to store in the collection. Must not be {@literal null}.
 	 * @return the saved object.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.bson.Document;
+
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -641,24 +642,52 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * information to determine the collection the query is ran against. Note, that MongoDB limits the number of results
 	 * by default. Make sure to add an explicit limit to the {@link NearQuery} if you expect a particular number of
 	 * results.
+	 * <p>
+	 * MongoDB 4.2 has removed the {@code geoNear} command. This method uses since version 2.2 aggregations and the
+	 * {@code $geoNear} aggregation command to emulate {@code geoNear} command functionality. We recommend using
+	 * aggregations directly:
+	 * </p>
+	 *
+	 * <pre class="code">
+	 * TypedAggregation&lt;T&gt; geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, "dis"))
+	 * 		.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
+	 * AggregationResults&lt;Document&gt; results = aggregate(geoNear, Document.class);
+	 * </pre>
 	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @return
+	 * @deprecated since 2.2. The {@code eval} command has been removed in MongoDB Server 4.2.0. Use Aggregations with
+	 *             {@link Aggregation#geoNear(NearQuery, String)} instead.
 	 */
+	@Deprecated
 	<T> GeoResults<T> geoNear(NearQuery near, Class<T> entityClass);
 
 	/**
 	 * Returns {@link GeoResults} for all entities matching the given {@link NearQuery}. Note, that MongoDB limits the
 	 * number of results by default. Make sure to add an explicit limit to the {@link NearQuery} if you expect a
 	 * particular number of results.
+	 * <p>
+	 * MongoDB 4.2 has removed the {@code geoNear} command. This method uses since version 2.2 aggregations and the
+	 * {@code $geoNear} aggregation command to emulate {@code geoNear} command functionality. We recommend using
+	 * aggregations directly:
+	 * </p>
+	 *
+	 * <pre class="code">
+	 * TypedAggregation&lt;T&gt; geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, "dis"))
+	 * 		.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
+	 * AggregationResults&lt;Document&gt; results = aggregate(geoNear, Document.class);
+	 * </pre>
 	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @param collectionName the collection to trigger the query against. If no collection name is given the entity class
 	 *          will be inspected. Must not be {@literal null} nor empty.
 	 * @return
+	 * @deprecated since 2.2. The {@code eval} command has been removed in MongoDB Server 4.2.0. Use Aggregations with
+	 *             {@link Aggregation#geoNear(NearQuery, String)} instead.
 	 */
+	@Deprecated
 	<T> GeoResults<T> geoNear(NearQuery near, Class<T> entityClass, String collectionName);
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -35,6 +35,7 @@ import org.bson.codecs.Codec;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -3302,9 +3303,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 			double distance = Double.NaN;
 			if (object.containsKey(distanceField)) {
-
-				distance = NumberUtils.convertNumberToTargetClass(object.get(distanceField, Number.class), Double.class)
-						.doubleValue();
+				distance = NumberUtils.convertNumberToTargetClass(object.get(distanceField, Number.class), Double.class);
 			}
 
 			T doWith = delegate.doWith(object);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import org.bson.Document;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
+
 import org.springframework.data.geo.GeoResult;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -612,24 +613,52 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * entity mapping information to determine the collection the query is ran against. Note, that MongoDB limits the
 	 * number of results by default. Make sure to add an explicit limit to the {@link NearQuery} if you expect a
 	 * particular number of results.
+	 * <p>
+	 * MongoDB 4.2 has removed the {@code geoNear} command. This method uses since version 2.2 aggregations and the
+	 * {@code $geoNear} aggregation command to emulate {@code geoNear} command functionality. We recommend using
+	 * aggregations directly:
+	 * </p>
+	 *
+	 * <pre class="code">
+	 * TypedAggregation&lt;T&gt; geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, "dis"))
+	 * 		.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
+	 * Flux&lt;Document&gt; results = aggregate(geoNear, Document.class);
+	 * </pre>
 	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @return the converted {@link GeoResult}s.
+	 * @deprecated since 2.2. The {@code eval} command has been removed in MongoDB Server 4.2.0. Use Aggregations with
+	 *             {@link Aggregation#geoNear(NearQuery, String)} instead.
 	 */
+	@Deprecated
 	<T> Flux<GeoResult<T>> geoNear(NearQuery near, Class<T> entityClass);
 
 	/**
 	 * Returns {@link Flux} of {@link GeoResult} for all entities matching the given {@link NearQuery}. Note, that MongoDB
 	 * limits the number of results by default. Make sure to add an explicit limit to the {@link NearQuery} if you expect
 	 * a particular number of results.
+	 * <p>
+	 * MongoDB 4.2 has removed the {@code geoNear} command. This method uses since version 2.2 aggregations and the
+	 * {@code $geoNear} aggregation command to emulate {@code geoNear} command functionality. We recommend using
+	 * aggregations directly:
+	 * </p>
+	 *
+	 * <pre class="code">
+	 * TypedAggregation&lt;T&gt; geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, "dis"))
+	 * 		.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
+	 * Flux&lt;Document&gt; results = aggregate(geoNear, Document.class);
+	 * </pre>
 	 *
 	 * @param near must not be {@literal null}.
 	 * @param entityClass must not be {@literal null}.
 	 * @param collectionName the collection to trigger the query against. If no collection name is given the entity class
 	 *          will be inspected.
 	 * @return the converted {@link GeoResult}s.
+	 * @deprecated since 2.2. The {@code eval} command has been removed in MongoDB Server 4.2.0. Use Aggregations with
+	 *             {@link Aggregation#geoNear(NearQuery, String)} instead.
 	 */
+	@Deprecated
 	<T> Flux<GeoResult<T>> geoNear(NearQuery near, Class<T> entityClass, String collectionName);
 
 	/**
@@ -933,8 +962,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 * <p/>
 	 * <p/>
 	 * Insert is used to initially store the object into the database. To update an existing object use the save method.
@@ -993,8 +1022,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 * <p/>
 	 * <p/>
 	 * Insert is used to initially store the object into the database. To update an existing object use the save method.
@@ -1041,8 +1070,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 *
 	 * @param objectToSave the object to store in the collection. Must not be {@literal null}.
 	 * @return the saved object.
@@ -1078,8 +1107,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * If you object has an "Id' property, it will be set with the generated Id from MongoDB. If your Id property is a
 	 * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
-	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's Type
-	 * Conversion"</a> for more details.
+	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
+	 * Type Conversion"</a> for more details.
 	 *
 	 * @param objectToSave the object to store in the collection. Must not be {@literal null}.
 	 * @return the saved object.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -1055,7 +1055,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		GeoNearResultDocumentCallback<T> callback = new GeoNearResultDocumentCallback<>(distanceField,
 				new ProjectingReadCallback<>(mongoConverter, entityClass, returnType, collection), near.getMetric());
 
-		Aggregation $geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, "dis"))
+		Aggregation $geoNear = TypedAggregation.newAggregation(entityClass, Aggregation.geoNear(near, distanceField))
 				.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
 
 		return aggregate($geoNear, collection, Document.class) //
@@ -3040,9 +3040,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 			double distance = Double.NaN;
 			if (object.containsKey(distanceField)) {
-
-				distance = NumberUtils.convertNumberToTargetClass(object.get(distanceField, Number.class), Double.class)
-						.doubleValue();
+				distance = NumberUtils.convertNumberToTargetClass(object.get(distanceField, Number.class), Double.class);
 			}
 
 			T doWith = delegate.doWith(object);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ScriptOperations.java
@@ -29,7 +29,9 @@ import com.mongodb.DB;
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @since 1.7
+ * @deprecated since 2.2. The {@code eval} command has been removed without replacement in MongoDB Server 4.2.0.
  */
+@Deprecated
 public interface ScriptOperations {
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -612,7 +612,7 @@ public class Aggregation {
 	}
 
 	/**
-	 * Creates a new {@link GeoNearOperation} instance from the given {@link NearQuery} and the{@code distanceField}. The
+	 * Creates a new {@link GeoNearOperation} instance from the given {@link NearQuery} and the {@code distanceField}. The
 	 * {@code distanceField} defines output field that contains the calculated distance.
 	 *
 	 * @param query must not be {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperation.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.bson.Document;
 
 /**
@@ -32,7 +35,23 @@ public interface AggregationOperation {
 	 * Turns the {@link AggregationOperation} into a {@link Document} by using the given
 	 * {@link AggregationOperationContext}.
 	 *
+	 * @param context the {@link AggregationOperationContext} to operate within. Must not be {@literal null}.
 	 * @return the Document
+	 * @deprecated since 2.2 in favor of {@link #toPipelineStages(AggregationOperationContext)}.
 	 */
+	@Deprecated
 	Document toDocument(AggregationOperationContext context);
+
+	/**
+	 * Turns the {@link AggregationOperation} into list of {@link Document stages} by using the given
+	 * {@link AggregationOperationContext}. This allows a single {@link AggregationOptions} to add additional stages for
+	 * eg. {@code $sort} or {@code $limit}.
+	 *
+	 * @param context the {@link AggregationOperationContext} to operate within. Must not be {@literal null}.
+	 * @return the pipeline stages to run through. Never {@literal null}.
+	 * @since 2.2
+	 */
+	default List<Document> toPipelineStages(AggregationOperationContext context) {
+		return Collections.singletonList(toDocument(context));
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
@@ -52,7 +52,7 @@ class AggregationOperationRenderer {
 
 		for (AggregationOperation operation : operations) {
 
-			operationDocuments.add(operation.toDocument(contextToUse));
+			operationDocuments.addAll(operation.toPipelineStages(contextToUse));
 
 			if (operation instanceof FieldsExposingAggregationOperation) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GraphLookupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GraphLookupOperation.java
@@ -128,7 +128,13 @@ public class GraphLookupOperation implements InheritsFieldsAggregationOperation 
 	 */
 	@Override
 	public ExposedFields getFields() {
-		return ExposedFields.from(new ExposedField(as, true));
+
+		List<ExposedField> fields = new ArrayList<>(2);
+		fields.add(new ExposedField(as, true));
+		if(depthField != null) {
+			fields.add(new ExposedField(depthField, true));
+		}
+		return ExposedFields.from(fields.toArray(new ExposedField[0]));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
@@ -79,8 +79,6 @@ public class TypeBasedAggregationOperationContext implements AggregationOperatio
 	 */
 	@Override
 	public FieldReference getReference(Field field) {
-
-		PropertyPath.from(field.getTarget(), type);
 		return getReferenceFor(field);
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupBy.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupBy.java
@@ -29,7 +29,9 @@ import org.springframework.lang.Nullable;
  * @author Mark Pollack
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @deprecated since 2.2. The {@code group} command has been removed in MongoDB Server 4.2.0.
  */
+@Deprecated
 public class GroupBy {
 
 	private @Nullable Document initialDocument;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupByResults.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapreduce/GroupByResults.java
@@ -29,7 +29,9 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @param <T> The class in which the results are mapped onto, accessible via an {@link Iterator}.
+ * @deprecated since 2.2. The {@code group} command has been removed in MongoDB Server 4.2.0.
  */
+@Deprecated
 public class GroupByResults<T> implements Iterable<T> {
 
 	private final List<T> mappedResults;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -110,8 +110,10 @@ public class Meta {
 
 	/**
 	 * @return {@literal null} if not set.
+	 * @deprecated since 2.2. {@code $maxScan} has been removed without replacement in MongoDB 4.2.
 	 */
 	@Nullable
+	@Deprecated
 	public Long getMaxScan() {
 		return getValue(MetaKey.MAX_SCAN.key);
 	}
@@ -120,7 +122,7 @@ public class Meta {
 	 * Only scan the specified number of documents.
 	 *
 	 * @param maxScan
-	 * @deprecated since 2.1 due to deprecation in MongoDB 4.0.
+	 * @deprecated since 2.1. {@code $maxScan} has been removed without replacement in MongoDB 4.2.
 	 */
 	@Deprecated
 	public void setMaxScan(long maxScan) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -179,7 +179,7 @@ public final class NearQuery {
 	private @Nullable Distance minDistance;
 	private Metric metric;
 	private boolean spherical;
-	private @Nullable Long num;
+	private @Nullable Long limit;
 	private @Nullable Long skip;
 
 	/**
@@ -269,9 +269,22 @@ public final class NearQuery {
 	 *
 	 * @param num
 	 * @return
+	 * @deprecated since 2.2. Please use {@link #limit(long)} instead.
 	 */
+	@Deprecated
 	public NearQuery num(long num) {
-		this.num = num;
+		return limit(num);
+	}
+
+	/**
+	 * Configures the maximum number of results to return.
+	 *
+	 * @param limit
+	 * @return
+	 * @since 2.2
+	 */
+	public NearQuery limit(long limit) {
+		this.limit = limit;
 		return this;
 	}
 
@@ -296,8 +309,8 @@ public final class NearQuery {
 
 		Assert.notNull(pageable, "Pageable must not be 'null'.");
 		if (pageable.isPaged()) {
-			this.num = pageable.getOffset() + pageable.getPageSize();
 			this.skip = pageable.getOffset();
+			this.limit = (long) pageable.getPageSize();
 		}
 		return this;
 	}
@@ -530,7 +543,7 @@ public final class NearQuery {
 		this.skip = query.getSkip();
 
 		if (query.getLimit() != 0) {
-			this.num = (long) query.getLimit();
+			this.limit = (long) query.getLimit();
 		}
 		return this;
 	}
@@ -541,6 +554,17 @@ public final class NearQuery {
 	@Nullable
 	public Long getSkip() {
 		return skip;
+	}
+
+	/**
+	 * Get the {@link Collation} to use along with the {@link #query(Query)}.
+	 * 
+	 * @return the {@link Collation} if set. {@literal null} otherwise.
+	 * @since 2.2
+	 */
+	@Nullable
+	public Collation getCollation() {
+		return query != null ? query.getCollation().orElse(null) : null;
 	}
 
 	/**
@@ -570,8 +594,8 @@ public final class NearQuery {
 			document.put("distanceMultiplier", getDistanceMultiplier());
 		}
 
-		if (num != null) {
-			document.put("num", num);
+		if (limit != null) {
+			document.put("num", limit);
 		}
 
 		if (usesGeoJson()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/ExecutableMongoScript.java
@@ -23,7 +23,9 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @since 1.7
+ * @deprecated since 2.2. The {@code eval} command has been removed without replacement in MongoDB Server 4.2.0.
  */
+@Deprecated
 public class ExecutableMongoScript {
 
 	private final String code;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/NamedMongoScript.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/script/NamedMongoScript.java
@@ -25,7 +25,9 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @since 1.7
+ * @deprecated since 2.2. The {@code eval} command has been removed without replacement in MongoDB Server 4.2.0.
  */
+@Deprecated
 public class NamedMongoScript {
 
 	private final @Id String name;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/OperationCounters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/monitor/OperationCounters.java
@@ -19,6 +19,7 @@ import org.bson.Document;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.jmx.support.MetricType;
+import org.springframework.util.NumberUtils;
 
 import com.mongodb.MongoClient;
 
@@ -66,6 +67,6 @@ public class OperationCounters extends AbstractMonitor {
 
 	private int getOpCounter(String key) {
 		Document opCounters = (Document) getServerStatus().get("opcounters");
-		return (Integer) opCounters.get(key);
+		return NumberUtils.convertNumberToTargetClass((Number) opCounters.get(key), Integer.class);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
@@ -46,7 +46,9 @@ public @interface Meta {
 	 * Only scan the specified number of documents.
 	 *
 	 * @return
+	 * @deprecated since 2.2. {@code $maxScan} has been removed without replacement in MongoDB 4.2.
 	 */
+	@Deprecated
 	long maxScanDocuments() default -1;
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultScriptOperationsTests.java
@@ -23,6 +23,7 @@ import static org.springframework.data.mongodb.core.query.Query.*;
 
 import org.bson.Document;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,8 @@ import org.springframework.dao.UncategorizedDataAccessException;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
 import org.springframework.data.mongodb.core.script.NamedMongoScript;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
+import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -47,6 +50,8 @@ import com.mongodb.MongoClient;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class DefaultScriptOperationsTests {
+
+	public static @ClassRule MongoVersionRule REQUIRES_AT_MOST_4_0 = MongoVersionRule.atMost(Version.parse("4.0.999"));
 
 	@Configuration
 	static class Config {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -40,7 +40,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.MongoTemplateUnitTests.AutogenerateableId;
@@ -299,16 +298,13 @@ public class ReactiveMongoTemplateUnitTests {
 		verify(mapReducePublisher).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
 	}
 
-	@Test // DATAMONGO-1518
+	@Test // DATAMONGO-1518, DATAMONGO-2264
 	public void geoNearShouldUseCollationWhenPresent() {
 
 		NearQuery query = NearQuery.near(0D, 0D).query(new BasicQuery("{}").collation(Collation.of("fr")));
 		template.geoNear(query, AutogenerateableId.class).subscribe();
 
-		ArgumentCaptor<Document> cmd = ArgumentCaptor.forClass(Document.class);
-		verify(db).runCommand(cmd.capture(), any(Class.class));
-
-		assertThat(cmd.getValue().get("collation", Document.class), equalTo(new Document("locale", "fr")));
+		verify(aggregatePublisher).collation(eq(com.mongodb.client.model.Collation.builder().locale("fr").build()));
 	}
 
 	@Test // DATAMONGO-1719

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -136,7 +136,6 @@ public class ReactiveMongoTemplateUnitTests {
 		this.mappingContext = new MongoMappingContext();
 		this.converter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, mappingContext);
 		this.template = new ReactiveMongoTemplate(factory, converter);
-
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1444

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
@@ -30,7 +30,6 @@ import org.bson.Document;
 import org.bson.codecs.BsonValueCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -257,21 +256,12 @@ public class ReactiveSessionBoundMongoTemplateUnitTests {
 		verify(collection).distinct(eq(clientSession), anyString(), any(), any());
 	}
 
-	@Test // DATAMONGO-1880
+	@Test // DATAMONGO-1880, DATAMONGO-2264
 	public void geoNearShouldUseProxiedDatabase() {
 
 		template.geoNear(NearQuery.near(new Point(0, 0), Metrics.NEUTRAL), Person.class).subscribe();
 
-		verify(database).runCommand(eq(clientSession), any(), eq(Document.class));
-	}
-
-	@Test // DATAMONGO-1880, DATAMONGO-1889
-	@Ignore("No group by yet - DATAMONGO-1889")
-	public void groupShouldUseProxiedDatabase() {
-
-		// template.group(COLLECTION_NAME, GroupBy.key("firstName"), Person.class).subscribe();
-
-		verify(database).runCommand(eq(clientSession), any(), eq(Document.class));
+		verify(collection).aggregate(eq(clientSession), anyList(), eq(Document.class));
 	}
 
 	@Test // DATAMONGO-1880, DATAMONGO-1890, DATAMONGO-257

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
@@ -258,14 +258,14 @@ public class SessionBoundMongoTemplateUnitTests {
 		verify(collection).distinct(eq(clientSession), anyString(), any(), any());
 	}
 
-	@Test // DATAMONGO-1880
+	@Test // DATAMONGO-1880, DATAMONGO-2264
 	public void geoNearShouldUseProxiedDatabase() {
 
 		when(database.runCommand(any(ClientSession.class), any(), eq(Document.class)))
 				.thenReturn(new Document("results", Collections.emptyList()));
 		template.geoNear(NearQuery.near(new Point(0, 0), Metrics.NEUTRAL), Person.class);
 
-		verify(database).runCommand(eq(clientSession), any(), eq(Document.class));
+		verify(collection).aggregate(eq(clientSession), anyList(), eq(Document.class));
 	}
 
 	@Test // DATAMONGO-1880

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/GroupByTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/GroupByTests.java
@@ -24,10 +24,13 @@ import org.bson.Document;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
+import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -43,6 +46,8 @@ import com.mongodb.client.MongoCollection;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:infrastructure.xml")
 public class GroupByTests {
+
+	public static @ClassRule MongoVersionRule REQUIRES_AT_MOST_4_0 = MongoVersionRule.atMost(Version.parse("4.0.999"));
 
 	@Autowired MongoTemplate mongoTemplate;
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/NearQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/NearQueryUnitTests.java
@@ -89,15 +89,14 @@ public class NearQueryUnitTests {
 		assertThat(query.getMetric(), is((Metric) Metrics.MILES));
 	}
 
-	@Test // DATAMONGO-445
+	@Test // DATAMONGO-445, DATAMONGO-2264
 	public void shouldTakeSkipAndLimitSettingsFromGivenPageable() {
 
 		Pageable pageable = PageRequest.of(3, 5);
 		NearQuery query = NearQuery.near(new Point(1, 1)).with(pageable);
 
 		assertThat(query.getSkip(), is((long) pageable.getPageNumber() * pageable.getPageSize()));
-		assertThat((Long) query.toDocument().get("num"),
-				is((long) (pageable.getPageNumber() + 1) * pageable.getPageSize()));
+		assertThat(query.toDocument().get("num"), is((long) pageable.getPageSize()));
 	}
 
 	@Test // DATAMONGO-445
@@ -112,7 +111,7 @@ public class NearQueryUnitTests {
 		assertThat((Long) query.toDocument().get("num"), is((long) limit));
 	}
 
-	@Test // DATAMONGO-445
+	@Test // DATAMONGO-445, DATAMONGO-2264
 	public void shouldTakeSkipAndLimitSettingsFromPageableEvenIfItWasSpecifiedOnQuery() {
 
 		int limit = 10;
@@ -122,8 +121,7 @@ public class NearQueryUnitTests {
 				.query(Query.query(Criteria.where("foo").is("bar")).limit(limit).skip(skip)).with(pageable);
 
 		assertThat(query.getSkip(), is((long) pageable.getPageNumber() * pageable.getPageSize()));
-		assertThat((Long) query.toDocument().get("num"),
-				is((long) (pageable.getPageNumber() + 1) * pageable.getPageSize()));
+		assertThat(query.toDocument().get("num"), is((long) pageable.getPageSize()));
 	}
 
 	@Test // DATAMONGO-829

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ComplexIdRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ComplexIdRepositoryIntegrationTests.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.test.util.MongoVersion;
+import org.springframework.data.mongodb.test.util.MongoVersionRule;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -45,6 +48,8 @@ import com.mongodb.MongoClient;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class ComplexIdRepositoryIntegrationTests {
+
+	public @Rule MongoVersionRule mongoVersionRule = MongoVersionRule.any();
 
 	@Configuration
 	@EnableMongoRepositories
@@ -129,6 +134,7 @@ public class ComplexIdRepositoryIntegrationTests {
 	}
 
 	@Test // DATAMONGO-1373
+	@MongoVersion(until = "4.0.999")
 	public void composedAnnotationFindMetaShouldWorkWhenUsingComplexId() {
 
 		repo.save(userWithId);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
@@ -321,11 +321,14 @@ public class ReactiveMongoRepositoryTests {
 	}
 
 	@Test // DATAMONGO-1444
-	public void findsPeoplePageableGeoresultByLocationWithinBox() {
+	public void findsPeoplePageableGeoresultByLocationWithinBox() throws InterruptedException {
 
 		Point point = new Point(-73.99171, 40.738868);
 		dave.setLocation(point);
 		StepVerifier.create(repository.save(dave)).expectNextCount(1).verifyComplete();
+
+		// Allow for index creation
+		Thread.sleep(500);
 
 		StepVerifier.create(repository.findByLocationNear(new Point(-73.99, 40.73), //
 				new Distance(2000, Metrics.KILOMETERS), //
@@ -338,11 +341,14 @@ public class ReactiveMongoRepositoryTests {
 	}
 
 	@Test // DATAMONGO-1444
-	public void findsPeopleByLocationWithinBox() {
+	public void findsPeopleByLocationWithinBox() throws InterruptedException {
 
 		Point point = new Point(-73.99171, 40.738868);
 		dave.setLocation(point);
 		StepVerifier.create(repository.save(dave)).expectNextCount(1).verifyComplete();
+
+		// Allow for index creation
+		Thread.sleep(500);
 
 		StepVerifier.create(repository.findPersonByLocationNear(new Point(-73.99, 40.73), //
 				new Distance(2000, Metrics.KILOMETERS))) //

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/DocumentAssert.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/DocumentAssert.java
@@ -289,20 +289,14 @@ public class DocumentAssert extends AbstractMapAssert<DocumentAssert, Map<String
 	@SuppressWarnings("unchecked")
 	private static <T> Lookup<T> lookup(Bson source, String path) {
 
-		String[] fragments = path.split("(?<!\\\\)\\.");
+		Document lookupDocument = (Document) source;
+		String pathToUse = path.replace("\\.", ".");
 
-		if (fragments.length == 1) {
-
-			Document document = (Document) source;
-			String pathToUse = path.replace("\\.", ".");
-
-			if (document.containsKey(pathToUse)) {
-				return Lookup.found((T) document.get(pathToUse));
-			}
-
-			return Lookup.notFound();
+		if (lookupDocument.containsKey(pathToUse)) {
+			return Lookup.found((T) lookupDocument.get(pathToUse));
 		}
 
+		String[] fragments = path.split("(?<!\\\\)\\.");
 		Iterator<String> it = Arrays.asList(fragments).iterator();
 
 		Object current = source;
@@ -311,7 +305,7 @@ public class DocumentAssert extends AbstractMapAssert<DocumentAssert, Map<String
 			String key = it.next().replace("\\.", ".");
 
 			if ((!(current instanceof Bson) && !(current instanceof Map)) && !key.startsWith("[")) {
-				return Lookup.found(null);
+				return Lookup.notFound();
 			}
 
 			if (key.startsWith("[")) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoTestUtils.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoTestUtils.java
@@ -18,6 +18,8 @@ package org.springframework.data.mongodb.test.util;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
+
 import org.bson.Document;
 
 import com.mongodb.MongoClientURI;
@@ -78,8 +80,9 @@ public class MongoTestUtils {
 		com.mongodb.reactivestreams.client.MongoDatabase database = client.getDatabase(dbName)
 				.withWriteConcern(WriteConcern.MAJORITY).withReadPreference(ReadPreference.primary());
 
-		return Mono.from(database.getCollection(collectionName).drop())
-				.then(Mono.from(database.createCollection(collectionName)));
+		return Mono.from(database.getCollection(collectionName).drop()) //
+				.then(Mono.from(database.createCollection(collectionName))) //
+				.delayElement(Duration.ofMillis(10)); // server replication time
 	}
 
 	/**

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,7 @@
 
 [[new-features.2-2-0]]
 == What's New in Spring Data MongoDB 2.2
+* Compatible with MongoDB 4.2.
 * <<mongo.query.kotlin-support,Type-safe Queries for Kotlin>>
 * <<mongodb.reactive.repositories.queries.type-safe,Querydsl support for reactive repositories>> via `ReactiveQuerydslPredicateExecutor`.
 * <<reactive.gridfs,Reactive GridFS support>>.

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,7 +3,7 @@
 
 [[new-features.2-2-0]]
 == What's New in Spring Data MongoDB 2.2
-* Compatible with MongoDB 4.2.
+* Compatibility with MongoDB 4.2 deprecating `eval`, `group` and `geoNear` Template API methods.
 * <<mongo.query.kotlin-support,Type-safe Queries for Kotlin>>
 * <<mongodb.reactive.repositories.queries.type-safe,Querydsl support for reactive repositories>> via `ReactiveQuerydslPredicateExecutor`.
 * <<reactive.gridfs,Reactive GridFS support>>.

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1333,6 +1333,33 @@ List<Venue> venues =
 [[mongo.geo-near]]
 ==== Geo-near Queries
 
+[WARNING]
+====
+*Changed in 2.2!* +
+https://docs.mongodb.com/master/release-notes/4.2-compatibility/[MongoDB 4.2] removed support for the
+`geoNear` command which had been previously used to run the `NearQuery`.
+
+Spring Data MongoDB 2.2 `MongoOperations#geoNear` uses the `$geoNear` https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/[aggregation]
+instead of the `geoNear` command to run a `NearQuery`.
+
+The calculated distance (the `dis` when using a geoNear command) previously returned within a wrapper type now is embedded
+into the resulting document. If the given domain type already contains a property with equal name, the calculated distance
+is named `calculated-distance` or if that name is taken as well, postfixed with a random hash.
+
+Target types may contain a property named after the returned distance to (additionally) read it back directly into the domain
+type as shown below.
+
+[source,java]
+----
+GeoResults<VenueWithDisField> = template.query(Venue.class) <1>
+    .as(VenueWithDisField.class) <2>
+    .near(NearQuery.near(new GeoJsonPoint(-73.99, 40.73), KILOMETERS))
+    .all();
+----
+<1> Domain type used to identify the target collection and potential query mapping.
+<2> Target type containing a `dis` field of type `Number`.
+====
+
 MongoDB supports querying the database for geo locations and calculating the distance from a given origin at the same time. With geo-near queries, you can express queries such as "find all restaurants in the surrounding 10 miles". To let you do so, `MongoOperations` provides `geoNear(…)` methods that take a `NearQuery` as an argument (as well as the already familiar entity type and collection), as shown in the following example:
 
 [source,java]
@@ -2225,6 +2252,13 @@ Note that you can specify additional limit and sort values on the query, but you
 
 [[mongo.server-side-scripts]]
 == Script Operations
+
+[WARNING]
+====
+https://docs.mongodb.com/master/release-notes/4.2-compatibility/[MongoDB 4.2] removed support for the `eval` command used
+by `ScriptOperations`. +
+There is no replacement for the removed functionallity.
+====
 
 MongoDB allows executing JavaScript functions on the server by either directly sending the script or calling a stored one. `ScriptOperations` can be accessed through `MongoTemplate` and provides basic abstraction for `JavaScript` usage. The following example shows how to us the `ScriptOperations` class:
 

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1343,16 +1343,16 @@ Spring Data MongoDB 2.2 `MongoOperations#geoNear` uses the `$geoNear` https://do
 instead of the `geoNear` command to run a `NearQuery`.
 
 The calculated distance (the `dis` when using a geoNear command) previously returned within a wrapper type now is embedded
-into the resulting document. If the given domain type already contains a property with equal name, the calculated distance
-is named `calculated-distance` or if that name is taken as well, postfixed with a random hash.
+into the resulting document.
+If the given domain type already contains a property with that name, the calculated distance
+is named `calculated-distance` with a potentially random postfix.
 
-Target types may contain a property named after the returned distance to (additionally) read it back directly into the domain
-type as shown below.
+Target types may contain a property named after the returned distance to (additionally) read it back directly into the domain type as shown below.
 
 [source,java]
 ----
 GeoResults<VenueWithDisField> = template.query(Venue.class) <1>
-    .as(VenueWithDisField.class) <2>
+    .as(VenueWithDisField.class)                            <2>
     .near(NearQuery.near(new GeoJsonPoint(-73.99, 40.73), KILOMETERS))
     .all();
 ----


### PR DESCRIPTION
Deprecate and guard tests for removed commands/options:
- eval
- group
- maxScan

Transition from removed `geoNear` command to `$geoNear` aggregation pipeline stage.
This allows users to still use `NearQuery` along with the `MongoOperations.near(...)` that now transforms the given query into a `GeoNearOperation` applying `$skip` (previously in memory skipping) and `$limit` (previous num parameter) as additional aggregation pipeline stages.

---

Tested against:
- 4.1.10
- 4.0.4
- 3.6.12
- 4.4.20