### PR TITLE
DATAMONGO-2252 - Update Javadoc for Reactive/MongoOperations#getCollection(String)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2252-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2252-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2252-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2252-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.bson.Document;
-
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -58,6 +57,10 @@ import com.mongodb.client.result.UpdateResult;
  * Interface that specifies a basic set of MongoDB operations. Implemented by {@link MongoTemplate}. Not often used but
  * a useful option for extensibility and testability (as it can be easily mocked, stubbed, or be the target of a JDK
  * proxy).
+ * <p />
+ * <strong>NOTE:</strong> Some operations cannot be executed within a MongoDB transaction. Please refer to the MongoDB
+ * specific documentation to learn more about <a href="https://docs.mongodb.com/manual/core/transactions/">Multi
+ * Document Transactions</a>.
  *
  * @author Thomas Risberg
  * @author Mark Pollack
@@ -290,12 +293,15 @@ public interface MongoOperations extends FluentMongoOperations {
 	Set<String> getCollectionNames();
 
 	/**
-	 * Get a collection by name, creating it if it doesn't exist.
+	 * Get a {@link MongoCollection} by its name. The returned collection may not exists yet (except in local memory) and
+	 * is created on first interaction with the server. Collections can be explicitly created via
+	 * {@link #createCollection(Class)}. Please make sure to check if the collection {@link #collectionExists(Class)
+	 * exists} first.
 	 * <p/>
 	 * Translate any exceptions as necessary.
 	 *
 	 * @param collectionName name of the collection. Must not be {@literal null}.
-	 * @return an existing collection or a newly created one.
+	 * @return an existing collection or one created on first server interaction.
 	 */
 	MongoCollection<Document> getCollection(String collectionName);
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 import org.bson.Document;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-
 import org.springframework.data.geo.GeoResult;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -58,6 +57,10 @@ import com.mongodb.reactivestreams.client.MongoCollection;
  * Implemented by {@link ReactiveMongoTemplate}. Not often used but a useful option for extensibility and testability
  * (as it can be easily mocked, stubbed, or be the target of a JDK proxy). Command execution using
  * {@link ReactiveMongoOperations} is deferred until subscriber subscribes to the {@link Publisher}.
+ * <p />
+ * <strong>NOTE:</strong> Some operations cannot be executed within a MongoDB transaction. Please refer to the MongoDB
+ * specific documentation to learn more about <a href="https://docs.mongodb.com/manual/core/transactions/">Multi
+ * Document Transactions</a>.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -283,12 +286,15 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	Flux<String> getCollectionNames();
 
 	/**
-	 * Get a collection by name, creating it if it doesn't exist.
+	 * Get a {@link MongoCollection} by name. The returned collection may not exists yet (except in local memory) and is
+	 * created on first interaction with the server. Collections can be explicitly created via
+	 * {@link #createCollection(Class)}. Please make sure to check if the collection {@link #collectionExists(Class)
+	 * exists} first.
 	 * <p/>
 	 * Translate any exceptions as necessary.
 	 *
 	 * @param collectionName name of the collection.
-	 * @return an existing collection or a newly created one.
+	 * @return an existing collection or one created on first server interaction.
 	 */
 	MongoCollection<Document> getCollection(String collectionName);
 


### PR DESCRIPTION
Mention that the `MongoCollection` must not exist on the MongoDB server when calling `getCollection`. 
Also add a hint to the multi document transaction reference.