### PR TITLE
DATAMONGO-2200 - Derive fields for aggregation $project stage from a given type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2200-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2200-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2200-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2200-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -245,6 +245,19 @@ public class Aggregation {
 	}
 
 	/**
+	 * Creates a new {@link ProjectionOperation} including all top level fields of the given given {@link Class}.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return new instance of {@link ProjectionOperation}.
+	 * @since 2.2
+	 */
+	public static ProjectionOperation project(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+		return new ProjectionOperation(type);
+	}
+
+	/**
 	 * Factory method to create a new {@link UnwindOperation} for the field with the given name.
 	 *
 	 * @param field must not be {@literal null} or empty.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
@@ -15,9 +15,18 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.bson.Document;
+import org.springframework.beans.BeanUtils;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * The context for an {@link AggregationOperation}.
@@ -66,4 +75,32 @@ public interface AggregationOperationContext {
 	 * @return
 	 */
 	FieldReference getReference(String name);
+
+	/**
+	 * Returns the {@link Fields} exposed by the type. May be a {@literal class} or an {@literal interface}.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.2
+	 */
+	default Fields getFields(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
+		List<String> fields = Arrays.stream(BeanUtils.getPropertyDescriptors(type)) //
+				.filter(it -> { // object and default methods
+					Method method = it.getReadMethod();
+					if (method == null) {
+						return false;
+					}
+					if (ReflectionUtils.isObjectMethod(method)) {
+						return false;
+					}
+					return !method.isDefault();
+				}) //
+				.map(PropertyDescriptor::getName) //
+				.collect(Collectors.toList());
+
+		return Fields.fields(fields.toArray(new String[0]));
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
@@ -81,6 +81,15 @@ class ExposedFieldsAggregationOperationContext implements AggregationOperationCo
 		return getReference(null, name);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperationContext#getFields(java.lang.Class)
+	 */
+	@Override
+	public Fields getFields(Class<?> type) {
+		return rootContext.getFields(type);
+	}
+
 	/**
 	 * Returns a {@link FieldReference} to the given {@link Field} with the given {@code name}.
 	 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/NestedDelegatingExpressionAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/NestedDelegatingExpressionAggregationOperationContext.java
@@ -78,4 +78,13 @@ class NestedDelegatingExpressionAggregationOperationContext implements Aggregati
 	public FieldReference getReference(String name) {
 		return new ExpressionFieldReference(delegate.getReference(name));
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperationContext#getFields(java.lang.Class)
+	 */
+	@Override
+	public Fields getFields(Class<?> type) {
+		return delegate.getFields(type);
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
@@ -91,6 +91,15 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 		return delegate.getReference(name);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperationContext#getFields(java.lang.Class)
+	 */
+	@Override
+	public Fields getFields(Class<?> type) {
+		return delegate.getFields(type);
+	}
+
 	@SuppressWarnings("unchecked")
 	private Document doPrefix(Document source) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -1737,8 +1737,9 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 		public Document toDocument(AggregationOperationContext context) {
 
 			Document projections = new Document();
-			ReflectionUtils.doWithFields(type, it -> projections.append(it.getName(), 1));
 
+			Fields fields = context.getFields(type);
+			fields.asList().forEach(it -> projections.append(it.getName(), 1));
 			return context.getMappedObject(projections, type);
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
@@ -17,9 +17,12 @@ package org.springframework.data.mongodb.core.aggregation;
 
 import static org.springframework.data.mongodb.core.aggregation.Fields.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bson.Document;
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.mapping.SimplePropertyHandler;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.DirectFieldReference;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.ExposedField;
@@ -99,6 +102,23 @@ public class TypeBasedAggregationOperationContext implements AggregationOperatio
 	@Override
 	public FieldReference getReference(String name) {
 		return getReferenceFor(field(name));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.core.aggregation.AggregationOperationContext#getFields(java.lang.Class)
+	 */
+	@Override
+	public Fields getFields(Class<?> type) {
+
+		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(type);
+		if (entity == null) {
+			return AggregationOperationContext.super.getFields(type);
+		}
+
+		List<String> fields = new ArrayList<>();
+		entity.doWithProperties((SimplePropertyHandler) it -> fields.add(it.getName()));
+		return Fields.fields(fields.toArray(new String[fields.size()]));
 	}
 
 	private FieldReference getReferenceFor(Field field) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -27,7 +27,6 @@ import lombok.Data;
 import java.util.Arrays;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 import org.springframework.data.domain.Range;
@@ -2114,7 +2113,7 @@ public class ProjectionOperationUnitTests {
 		Document document = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
 		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
 
-		Assertions.assertThat(projectClause) //
+		assertThat(projectClause) //
 				.hasSize(2) //
 				.containsEntry("title", 1) //
 				.containsEntry("author", 1);
@@ -2130,10 +2129,34 @@ public class ProjectionOperationUnitTests {
 				.toDocument(new TypeBasedAggregationOperationContext(Book.class, mappingContext, new QueryMapper(converter)));
 		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
 
-		Assertions.assertThat(projectClause) //
+		assertThat(projectClause) //
 				.hasSize(2) //
 				.containsEntry("ti_tl_e", 1) //
 				.containsEntry("author", 1);
+	}
+
+	@Test // DATAMONGO-2200
+	public void typeProjectionShouldIncludeInterfaceProjectionValues() {
+
+		ProjectionOperation operation = Aggregation.project(ProjectionInterface.class);
+
+		Document document = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
+		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
+
+		assertThat(projectClause) //
+				.hasSize(1) //
+				.containsEntry("title", 1);
+	}
+
+	@Test // DATAMONGO-2200
+	public void typeProjectionShouldBeEmptyIfNoPropertiesFound() {
+
+		ProjectionOperation operation = Aggregation.project(EmptyType.class);
+
+		Document document = operation.toDocument(Aggregation.DEFAULT_CONTEXT);
+		Document projectClause = DocumentTestUtils.getAsDocument(document, PROJECT);
+
+		assertThat(projectClause).isEmpty();
 	}
 
 	private static Document exctractOperation(String field, Document fromProjectClause) {
@@ -2157,6 +2180,14 @@ public class ProjectionOperationUnitTests {
 		String first;
 		String last;
 		String middle;
+	}
+
+	interface ProjectionInterface {
+		String getTitle();
+	}
+
+	static class EmptyType {
+
 	}
 
 }


### PR DESCRIPTION
We now allow to derive field names for a `$project` stage from a given type by including all top level fields.

    // $project : { title : 1, author : 1 }
    Aggregation.project(Book.class)

Requires changes from: #743