### PR TITLE
DATAMONGO-2275 - Fix NPE when mapping MongoJsonSchema used in query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2275-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2275-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2275-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2275-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -297,7 +297,7 @@ public class QueryMapper {
 		}
 
 		if (keyword.isJsonSchema()) {
-			return schemaMapper.mapSchema(new Document(keyword.getKey(), keyword.getValue()), entity.getType());
+			return schemaMapper.mapSchema(new Document(keyword.getKey(), keyword.getValue()), entity != null ? entity.getType() : Object.class);
 		}
 
 		return new Document(keyword.getKey(), convertSimpleOrDocument(keyword.getValue(), entity));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/JsonSchemaQueryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/JsonSchemaQueryTests.java
@@ -21,6 +21,7 @@ import static org.springframework.data.mongodb.core.query.Query.*;
 import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.*;
 
 import lombok.Data;
+import org.bson.Document;
 import reactor.test.StepVerifier;
 
 import org.junit.AfterClass;
@@ -197,6 +198,15 @@ public class JsonSchemaQueryTests {
 
 		assertThat(template.find(query(where("value").type(Type.intType(), Type.stringType())), Person.class))
 				.containsExactlyInAnyOrder(jellyBelly, kazmardBoombub);
+	}
+
+	@Test // DATAMONGO-1835
+	public void findsWithSchemaReturningRawDocument() {
+
+		MongoJsonSchema schema = MongoJsonSchema.builder().required("address").build();
+
+		assertThat(template.find(query(matchingDocumentStructure(schema)), Document.class, template.getCollectionName(Person.class)))
+				.hasSize(2);
 	}
 
 	@Data


### PR DESCRIPTION
We fixed a NPE when reading raw `Document` from a collection using a query matching against a JSON schema.