### PR TITLE
DATAMONGO-2278 - Change querydsl base package names in MongoAnnotatio…

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoAnnotationProcessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoAnnotationProcessor.java
@@ -24,6 +24,7 @@ import javax.lang.model.SourceVersion;
 import javax.tools.Diagnostic;
 
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.lang.Nullable;
 
 import com.querydsl.apt.AbstractQuerydslProcessor;
 import com.querydsl.apt.Configuration;
@@ -33,14 +34,14 @@ import com.querydsl.core.annotations.QueryEmbedded;
 import com.querydsl.core.annotations.QueryEntities;
 import com.querydsl.core.annotations.QuerySupertype;
 import com.querydsl.core.annotations.QueryTransient;
-import org.springframework.lang.Nullable;
 
 /**
  * Annotation processor to create Querydsl query types for QueryDsl annotated classes.
  *
  * @author Oliver Gierke
+ * @author Owen Q
  */
-@SupportedAnnotationTypes({ "com.mysema.query.annotations.*", "org.springframework.data.mongodb.core.mapping.*" })
+@SupportedAnnotationTypes({ "com.querydsl.core.annotations.*", "org.springframework.data.mongodb.core.mapping.*" })
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class MongoAnnotationProcessor extends AbstractQuerydslProcessor {
 


### PR DESCRIPTION
…nProcessor

Current MongoAnnotationProcessor still use 3.x.x querydsl package names.
But current SpringDataMongoDB use querydsl 4.x.x.

Try to use querydsl 4.x.x additional annotations for code-generation, It should changed to 'com.querydsl.core.annotations.*'.

Related tickets: https://jira.spring.io/browse/DATAMONGO-2278