### PR TITLE
DATAMONGO-2288 - Fix wrong indentation on documentation code sample

### DIFF
--- a/src/main/asciidoc/reference/client-session-transactions.adoc
+++ b/src/main/asciidoc/reference/client-session-transactions.adoc
@@ -163,7 +163,7 @@ txTemplate.execute(new TransactionCallbackWithoutResult() {
 
         process(step);
 
-    template.update(Step.class).apply(Update.set("state", // ...
+        template.update(Step.class).apply(Update.set("state", // ...
     };
 });
 ----


### PR DESCRIPTION
Hi, I have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc) but I'm not sure it should be respected here as it's only a small correction in the documentation.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
