### PR TITLE
DATAMONGO-2306 - Add field level encryption to JSON Schema. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2306-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2306-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2306-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2306-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoParsingUtils.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Element;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @SuppressWarnings("deprecation")
 abstract class MongoParsingUtils {
@@ -92,6 +93,7 @@ abstract class MongoParsingUtils {
 		setPropertyValue(clientOptionsDefBuilder, optionsElement, "heartbeat-socket-timeout", "heartbeatSocketTimeout");
 		setPropertyValue(clientOptionsDefBuilder, optionsElement, "ssl", "ssl");
 		setPropertyReference(clientOptionsDefBuilder, optionsElement, "ssl-socket-factory-ref", "sslSocketFactory");
+		setPropertyReference(clientOptionsDefBuilder, optionsElement, "encryption-settings-ref", "autoEncryptionSettings");
 		setPropertyValue(clientOptionsDefBuilder, optionsElement, "server-selection-timeout", "serverSelectionTimeout");
 
 		mongoClientBuilder.addPropertyValue("mongoClientOptions", clientOptionsDefBuilder.getBeanDefinition());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.lang.Nullable;
 
+import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.DBDecoderFactory;
 import com.mongodb.DBEncoderFactory;
 import com.mongodb.MongoClient;
@@ -73,6 +74,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
 	private boolean ssl;
 	private @Nullable SSLSocketFactory sslSocketFactory;
+	private @Nullable AutoEncryptionSettings autoEncryptionSettings;
 
 	/**
 	 * Set the {@link MongoClient} description.
@@ -272,6 +274,16 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 		this.serverSelectionTimeout = serverSelectionTimeout;
 	}
 
+	/**
+	 * Set the {@link AutoEncryptionSettings} to be used.
+	 *
+	 * @param autoEncryptionSettings can be {@literal null}.
+	 * @since 2.2
+	 */
+	public void setAutoEncryptionSettings(@Nullable AutoEncryptionSettings autoEncryptionSettings) {
+		this.autoEncryptionSettings = autoEncryptionSettings;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.config.AbstractFactoryBean#createInstance()
@@ -304,7 +316,8 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 				.requiredReplicaSetName(requiredReplicaSetName) //
 				.serverSelectionTimeout(serverSelectionTimeout) //
 				.sslEnabled(ssl) //
-				.socketFactory(socketFactoryToUse) // TODO: Mongo Driver 4 - remove if not available
+				.autoEncryptionSettings(autoEncryptionSettings) //
+				.socketFactory(socketFactoryToUse) // TODO: Mongo Driver 4 -
 				.socketKeepAlive(socketKeepAlive) // TODO: Mongo Driver 4 - remove if not available
 				.socketTimeout(socketTimeout) //
 				.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier) //

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBean.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.bson.BsonDocument;
+import org.springframework.beans.factory.FactoryBean;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+
+/**
+ * {@link FactoryBean} for creating {@link AutoEncryptionSettings} using the {@link AutoEncryptionSettings.Builder}.
+ *
+ * @author Christoph Strobl
+ * @since 2.2
+ */
+public class MongoEncryptionSettingsFactoryBean implements FactoryBean<AutoEncryptionSettings> {
+
+	private boolean bypassAutoEncryption;
+	private String keyVaultNamespace;
+	private Map<String, Object> extraOptions;
+	private MongoClientSettings keyVaultClientSettings;
+	private Map<String, Map<String, Object>> kmsProviders;
+	private Map<String, BsonDocument> schemaMap;
+
+	/**
+	 * @param bypassAutoEncryption
+	 * @see AutoEncryptionSettings.Builder#bypassAutoEncryption(boolean)
+	 */
+	public void setBypassAutoEncryption(boolean bypassAutoEncryption) {
+		this.bypassAutoEncryption = bypassAutoEncryption;
+	}
+
+	/**
+	 * @param extraOptions
+	 * @see AutoEncryptionSettings.Builder#extraOptions(Map)
+	 */
+	public void setExtraOptions(Map<String, Object> extraOptions) {
+		this.extraOptions = extraOptions;
+	}
+
+	/**
+	 * @param keyVaultNamespace
+	 * @see AutoEncryptionSettings.Builder#keyVaultNamespace(String)
+	 */
+	public void setKeyVaultNamespace(String keyVaultNamespace) {
+		this.keyVaultNamespace = keyVaultNamespace;
+	}
+
+	/**
+	 * @param keyVaultClientSettings
+	 * @see AutoEncryptionSettings.Builder#keyVaultMongoClientSettings(MongoClientSettings)
+	 */
+	public void setKeyVaultClientSettings(MongoClientSettings keyVaultClientSettings) {
+		this.keyVaultClientSettings = keyVaultClientSettings;
+	}
+
+	/**
+	 * @param kmsProviders
+	 * @see AutoEncryptionSettings.Builder#kmsProviders(Map)
+	 */
+	public void setKmsProviders(Map<String, Map<String, Object>> kmsProviders) {
+		this.kmsProviders = kmsProviders;
+	}
+
+	/**
+	 * @param schemaMap
+	 * @see AutoEncryptionSettings.Builder#schemaMap(Map)
+	 */
+	public void setSchemaMap(Map<String, BsonDocument> schemaMap) {
+		this.schemaMap = schemaMap;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see  org.springframework.beans.factory.FactoryBean#getObject()
+	 */
+	@Override
+	public AutoEncryptionSettings getObject() {
+
+		return AutoEncryptionSettings.builder() //
+				.bypassAutoEncryption(bypassAutoEncryption) //
+				.keyVaultNamespace(keyVaultNamespace) //
+				.keyVaultMongoClientSettings(keyVaultClientSettings) //
+				.kmsProviders(orEmpty(kmsProviders)) //
+				.extraOptions(orEmpty(extraOptions)) //
+				.schemaMap(orEmpty(schemaMap)) //
+				.build();
+	}
+
+	private <K, V> Map<K, V> orEmpty(Map<K, V> source) {
+		return source != null ? source : Collections.emptyMap();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see  org.springframework.beans.factory.FactoryBean#getObjectType()
+	 */
+	@Override
+	public Class<?> getObjectType() {
+		return AutoEncryptionSettings.class;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBean.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.bson.BsonDocument;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.lang.Nullable;
 
 import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.MongoClientSettings;
@@ -104,7 +105,7 @@ public class MongoEncryptionSettingsFactoryBean implements FactoryBean<AutoEncry
 				.build();
 	}
 
-	private <K, V> Map<K, V> orEmpty(Map<K, V> source) {
+	private <K, V> Map<K, V> orEmpty(@Nullable Map<K, V> source) {
 		return source != null ? source : Collections.emptyMap();
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
@@ -1057,8 +1057,7 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 
 		private final JsonSchemaProperty targetProperty;
 		private final @Nullable String algorithm;
-		private final @Nullable char[] keyId;
-		private final @Nullable char[] iv;
+		private final @Nullable String keyId;
 
 		/**
 		 * Create new instance of {@link EncryptedJsonSchemaProperty} wrapping the given {@link JsonSchemaProperty target}.
@@ -1066,17 +1065,15 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 		 * @param target must not be {@literal null}.
 		 */
 		public EncryptedJsonSchemaProperty(JsonSchemaProperty target) {
-			this(target, null, null, null);
+			this(target, null, null);
 		}
 
-		private EncryptedJsonSchemaProperty(JsonSchemaProperty target, @Nullable String algorithm, @Nullable char[] keyId,
-				@Nullable char[] iv) {
+		private EncryptedJsonSchemaProperty(JsonSchemaProperty target, @Nullable String algorithm, @Nullable String keyId) {
 
 			Assert.notNull(target, "Target must not be null!");
 			this.targetProperty = target;
 			this.algorithm = algorithm;
 			this.keyId = keyId;
-			this.iv = iv;
 		}
 
 		/**
@@ -1113,19 +1110,15 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 		 * @return new instance of {@link EncryptedJsonSchemaProperty}.
 		 */
 		public EncryptedJsonSchemaProperty algorithm(String algorithm) {
-			return new EncryptedJsonSchemaProperty(targetProperty, algorithm, keyId, iv);
+			return new EncryptedJsonSchemaProperty(targetProperty, algorithm, keyId);
 		}
 
 		/**
 		 * @param key
 		 * @return
 		 */
-		public EncryptedJsonSchemaProperty keyId(char[] key) {
-			return new EncryptedJsonSchemaProperty(targetProperty, algorithm, key, iv);
-		}
-
-		public EncryptedJsonSchemaProperty keyId(String key) {
-			return keyId(key.toCharArray());
+		public EncryptedJsonSchemaProperty keyId(String keyId) {
+			return new EncryptedJsonSchemaProperty(targetProperty, algorithm, keyId);
 		}
 
 		/*
@@ -1141,7 +1134,7 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 			Document enc = new Document();
 
 			if (!ObjectUtils.isEmpty(keyId)) {
-				enc.append("keyId", new String(keyId));
+				enc.append("keyId", keyId);
 			}
 
 			Type type = extractPropertyType(propertySpecification);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaObject.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaObject.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.schema;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
@@ -429,6 +430,23 @@ public interface JsonSchemaObject {
 		}
 
 		/**
+		 * Create a {@link Type} with its default {@link Type#representation() representation} via the name.
+		 * 
+		 * @param name must not be {@literal null}.
+		 * @return the matching type instance.
+		 * @since 2.2
+		 */
+		static Type of(String name) {
+
+			Type type = jsonTypeOf(name);
+			if (jsonTypes().contains(type)) {
+				return type;
+			}
+
+			return bsonTypeOf(name);
+		}
+
+		/**
 		 * @return all known JSON types.
 		 */
 		static Set<Type> jsonTypes() {
@@ -457,10 +475,33 @@ public interface JsonSchemaObject {
 		Object value();
 
 		/**
+		 * Get the {@literal bsonType} representation of the given type.
+		 * 
+		 * @return never {@literal null}.
+		 * @since 2.2
+		 */
+		default Type toBsonType() {
+
+			if (representation().equals("bsonType")) {
+				return this;
+			}
+
+			if (value().equals(Type.booleanType().value())) {
+				return bsonTypeOf("bool");
+			}
+			if (value().equals(Type.numberType().value())) {
+				return bsonTypeOf("long");
+			}
+
+			return bsonTypeOf((String) value());
+		}
+
+		/**
 		 * @author Christpoh Strobl
 		 * @since 2.1
 		 */
 		@RequiredArgsConstructor
+		@EqualsAndHashCode
 		class JsonType implements Type {
 
 			private final String name;
@@ -489,6 +530,7 @@ public interface JsonSchemaObject {
 		 * @since 2.1
 		 */
 		@RequiredArgsConstructor
+		@EqualsAndHashCode
 		class BsonType implements Type {
 
 			private final String name;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaProperty.java
@@ -18,18 +18,9 @@ package org.springframework.data.mongodb.core.schema;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.ArrayJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.BooleanJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.DateJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.NullJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.NumericJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.ObjectJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.RequiredJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.StringJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.TimestampJsonSchemaProperty;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.UntypedJsonSchemaProperty;
 import org.springframework.data.mongodb.core.schema.TypedJsonSchemaObject.NumericJsonSchemaObject;
 import org.springframework.data.mongodb.core.schema.TypedJsonSchemaObject.ObjectJsonSchemaObject;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.*;
 import org.springframework.lang.Nullable;
 
 /**
@@ -66,6 +57,17 @@ public interface JsonSchemaProperty extends JsonSchemaObject {
 	 */
 	static UntypedJsonSchemaProperty untyped(String identifier) {
 		return new UntypedJsonSchemaProperty(identifier, JsonSchemaObject.untyped());
+	}
+
+	/**
+	 * Turns the given target property into an {@link EncryptedJsonSchemaProperty ecrypted} one.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return new instance of {@link EncryptedJsonSchemaProperty}.
+	 * @since 2.2
+	 */
+	static EncryptedJsonSchemaProperty encrypted(JsonSchemaProperty property) {
+		return EncryptedJsonSchemaProperty.encrypted(property);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-2.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-2.2.xsd
@@ -311,6 +311,20 @@ The name of the MongoClient object that determines what server to monitor. (by d
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
 
+	<xsd:simpleType name="encryptionSettingsRef">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+Reference to FactoryBean for com.mongodb.AutoEncryptionSettings - @since 2.2
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation kind="ref">
+					<tool:assignable-to type="org.springframework.data.mongodb.core.MongoEncryptionSettingsFactoryBean" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:union memberTypes="xsd:string"/>
+	</xsd:simpleType>
+
 	<xsd:simpleType name="writeConcernEnumeration">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="NONE" />
@@ -543,6 +557,13 @@ This controls if the driver should us an SSL connection.  Defaults to false.
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="encryption-settings-ref" type="encryptionSettingsRef" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+AutoEncryptionSettings for MongoDB 4.2+ - @since 2.2
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBeanTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoEncryptionSettingsFactoryBeanTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.mongodb.AutoEncryptionSettings;
+
+/**
+ * Integration tests for {@link MongoEncryptionSettingsFactoryBean}.
+ *
+ * @author Christoph Strobl
+ */
+public class MongoEncryptionSettingsFactoryBeanTests {
+
+	@Test // DATAMONGO-2306
+	public void createsAutoEncryptionSettings() {
+
+		RootBeanDefinition definition = new RootBeanDefinition(MongoEncryptionSettingsFactoryBean.class);
+		definition.getPropertyValues().addPropertyValue("bypassAutoEncryption", true);
+		definition.getPropertyValues().addPropertyValue("keyVaultNamespace", "ns");
+
+		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+		factory.registerBeanDefinition("factory", definition);
+
+		MongoEncryptionSettingsFactoryBean bean = factory.getBean("&factory", MongoEncryptionSettingsFactoryBean.class);
+		assertThat(ReflectionTestUtils.getField(bean, "bypassAutoEncryption")).isEqualTo(true);
+
+		AutoEncryptionSettings target = factory.getBean(AutoEncryptionSettings.class);
+		assertThat(target.getKeyVaultNamespace()).isEqualTo("ns");
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/schema/MongoJsonSchemaUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/schema/MongoJsonSchemaUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.schema;
 
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.*;
 import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 import java.util.Arrays;
@@ -69,6 +70,21 @@ public class MongoJsonSchemaUnitTests {
 		assertThat(schema.toDocument()).isEqualTo(new Document("$jsonSchema",
 				new Document("type", "object").append("required", Arrays.asList("firstname", "lastname")).append("properties",
 						new Document("lastname", new Document("type", "string")))));
+	}
+
+	@Test // DATAMONGO-2306
+	public void rendersEncryptedPropertyCorrectly() {
+
+		MongoJsonSchema schema = MongoJsonSchema.builder().properties( //
+				encrypted(string("ssn")) //
+						.aead_aes_256_cbc_hmac_sha_512_deterministic() //
+						.keyId("*key0_id") //
+		).build();
+
+		assertThat(schema.toDocument()).isEqualTo(new Document("$jsonSchema",
+				new Document("type", "object").append("properties",
+						new Document("ssn", new Document("encrypt", new Document("keyId", "*key0_id")
+								.append("algorithm", "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic").append("bsonType", "string"))))));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAMONGO-1835

--- a/src/main/asciidoc/reference/mongo-json-schema.adoc
+++ b/src/main/asciidoc/reference/mongo-json-schema.adoc
@@ -205,6 +205,28 @@ template.find(query(matchingDocumentStructure(schema)), Person.class);
 ----
 ====
 
+[[mongo.jsonSchema.encrypted-fields]]
+==== Encrypted Fields
+
+MongoDB 4.2 https://docs.mongodb.com/master/core/security-client-side-encryption/[Field Level Encryption] allows to directly secure certain properties.
+
+Properties can be wrapped within an encrypted property when setting up the JSON Schema as shown in the example below.
+
+.Client-Side Field Level Encryption via Json Schema
+====
+[source,java]
+----
+MongoJsonSchema schema = MongoJsonSchema.builder()
+    .properties(
+        encrypted(string("ssn"))
+            .algorithm("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
+            .keyId("*key0_id")
+	).build();
+----
+====
+
+NOTE: Make sure to set the drivers `com.mongodb.AutoEncryptionSettings` to use client side encryption.
+
 [[mongo.jsonSchema.types]]
 ==== JSON Schema Types
 

--- a/src/main/asciidoc/reference/mongo-json-schema.adoc
+++ b/src/main/asciidoc/reference/mongo-json-schema.adoc
@@ -208,7 +208,7 @@ template.find(query(matchingDocumentStructure(schema)), Person.class);
 [[mongo.jsonSchema.encrypted-fields]]
 ==== Encrypted Fields
 
-MongoDB 4.2 https://docs.mongodb.com/master/core/security-client-side-encryption/[Field Level Encryption] allows to directly secure certain properties.
+MongoDB 4.2 https://docs.mongodb.com/master/core/security-client-side-encryption/[Field Level Encryption] allows to directly encrypt individual properties.
 
 Properties can be wrapped within an encrypted property when setting up the JSON Schema as shown in the example below.
 
@@ -225,7 +225,7 @@ MongoJsonSchema schema = MongoJsonSchema.builder()
 ----
 ====
 
-NOTE: Make sure to set the drivers `com.mongodb.AutoEncryptionSettings` to use client side encryption.
+NOTE: Make sure to set the drivers `com.mongodb.AutoEncryptionSettings` to use client-side encryption.
 
 [[mongo.jsonSchema.types]]
 ==== JSON Schema Types


### PR DESCRIPTION
We now support encrypted fields via `MongoJsonSchema` and allow XML configuration of `com.mongodb.AutoEncryptionSettings` via a dedicated factory bean.

----

This change builds upon MongoDB Java Driver 3.11.0-beta4 that should come in via #764.