### PR TITLE
DATAMONGO-2328 - Add missing target type conversions for field level type hints. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2328-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2328-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2328-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2328-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverter.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.mongodb.core.convert;
 
-import java.math.BigInteger;
+import static org.springframework.data.convert.ConverterBuilder.*;
 
+import java.math.BigInteger;
+import java.util.Date;
+
+import org.bson.types.Code;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.convert.ConversionService;
@@ -93,6 +97,21 @@ public abstract class AbstractMongoConverter implements MongoConverter, Initiali
 			conversionService.addConverter(BigIntegerToObjectIdConverter.INSTANCE);
 		}
 
+		if (!conversionService.canConvert(Date.class, Long.class)) {
+			conversionService.addConverter(writing(Date.class, Long.class, Date::getTime).getWritingConverter());
+		}
+
+		if (!conversionService.canConvert(Long.class, Date.class)) {
+			conversionService.addConverter(reading(Long.class, Date.class, Date::new).getReadingConverter());
+		}
+
+		if (!conversionService.canConvert(ObjectId.class, Date.class)) {
+
+			conversionService.addConverter(
+					reading(ObjectId.class, Date.class, objectId -> new Date(objectId.getTimestamp())).getReadingConverter());
+		}
+
+		conversionService.addConverter(reading(Code.class, String.class, Code::getCode).getReadingConverter());
 		conversions.registerConvertersIn(conversionService);
 	}
 


### PR DESCRIPTION
We now support `Date -> Long`, `Date -> ObjectId`, `Script -> String` and other conversions for both reading and writing scenarios.