### PR TITLE
DATAMONGO-2327 - Add toJson method to Querydsl query support. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2327-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2327-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2327-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2327-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QuerydslRepositorySupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/QuerydslRepositorySupportTests.java
@@ -25,6 +25,7 @@ import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Id;
@@ -262,17 +263,23 @@ public class QuerydslRepositorySupportTests {
 	public void toStringShouldRenderQuery() {
 
 		QPerson p = QPerson.person;
-		SpringDataMongodbQuery<Person> query = repoSupport.from(p).where(p.lastname.eq("Matthews"));
+		User user = new User();
+		user.setId("id");
+		SpringDataMongodbQuery<Person> query = repoSupport.from(p)
+				.where(p.lastname.eq("Matthews").and(p.coworker.eq(user)));
 
-		assertThat(StringUtils.trimAllWhitespace(query.toString())).isEqualTo("find({\"lastname\":\"Matthews\"})");
+		assertThat(StringUtils.trimAllWhitespace(query.toString()))
+				.isEqualTo("find({\"lastname\":\"Matthews\",\"coworker\":{\"$ref\":\"user\",\"$id\":\"id\"}})");
 
 		query = query.orderBy(p.firstname.asc());
 		assertThat(StringUtils.trimAllWhitespace(query.toString()))
-				.isEqualTo("find({\"lastname\":\"Matthews\"}).sort({\"firstname\":1})");
+				.isEqualTo(
+						"find({\"lastname\":\"Matthews\",\"coworker\":{\"$ref\":\"user\",\"$id\":\"id\"}}).sort({\"firstname\":1})");
 
 		query = query.offset(1).limit(5);
 		assertThat(StringUtils.trimAllWhitespace(query.toString()))
-				.isEqualTo("find({\"lastname\":\"Matthews\"}).sort({\"firstname\":1}).skip(1).limit(5)");
+				.isEqualTo(
+						"find({\"lastname\":\"Matthews\",\"coworker\":{\"$ref\":\"user\",\"$id\":\"id\"}}).sort({\"firstname\":1}).skip(1).limit(5)");
 	}
 
 	@Data


### PR DESCRIPTION
This allows to obtain the raw Json representation of the query for eg. debug usage.
We also updated the `toString` method to return a full Mongo Shell compatible representation of the query including projections, order, skip and limit.

```java
where(p.lastname.eq("Matthews")).orderBy(p.firstname.asc()).offset(1).limit(5);
```
```bash
find({"lastname" : "Matthews"}).sort({"firstname" : 1}).skip(1).limit(5)
```
