### PR TITLE
DATAMONGO-2320 - Fix aggregation field reference for $filter operator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2320-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2320-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2320-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2320-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
@@ -616,7 +616,7 @@ public class ArrayOperators {
 			}
 
 			NestedDelegatingExpressionAggregationOperationContext nea = new NestedDelegatingExpressionAggregationOperationContext(
-					context);
+					context, Collections.singleton(as));
 			return ((AggregationExpression) condition).toDocument(nea);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/VariableOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/VariableOperators.java
@@ -18,7 +18,9 @@ package org.springframework.data.mongodb.core.aggregation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.bson.Document;
 import org.springframework.data.mongodb.core.aggregation.VariableOperators.Let.ExpressionVariable;
@@ -185,7 +187,8 @@ public class VariableOperators {
 			map.putAll(context.getMappedObject(input));
 			map.put("as", itemVariableName);
 			map.put("in",
-					functionToApply.toDocument(new NestedDelegatingExpressionAggregationOperationContext(operationContext)));
+					functionToApply.toDocument(new NestedDelegatingExpressionAggregationOperationContext(operationContext,
+							Collections.singleton(Fields.field(itemVariableName)))));
 
 			return new Document("$map", map);
 		}
@@ -322,12 +325,14 @@ public class VariableOperators {
 
 		private Document getMappedVariable(ExpressionVariable var, AggregationOperationContext context) {
 
-			return new Document(var.variableName, var.expression instanceof AggregationExpression
-					? ((AggregationExpression) var.expression).toDocument(context) : var.expression);
+			return new Document(var.variableName,
+					var.expression instanceof AggregationExpression ? ((AggregationExpression) var.expression).toDocument(context)
+							: var.expression);
 		}
 
 		private Object getMappedIn(AggregationOperationContext context) {
-			return expression.toDocument(new NestedDelegatingExpressionAggregationOperationContext(context));
+			return expression.toDocument(new NestedDelegatingExpressionAggregationOperationContext(context,
+					this.vars.stream().map(var -> Fields.field(var.variableName)).collect(Collectors.toList())));
 		}
 
 		/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/FilterExpressionUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/FilterExpressionUnitTests.java
@@ -61,13 +61,7 @@ public class FilterExpressionUnitTests {
 						.and(filter("items").as("item").by(AggregationFunctionExpressions.GTE.of(Fields.field("item.price"), 100)))
 						.as("items"));
 
-		Document dbo = agg.toDocument("sales", aggregationContext);
-
-		List<Object> pipeline = DocumentTestUtils.getAsDBList(dbo, "pipeline");
-		Document $project = DocumentTestUtils.getAsDocument((Document) pipeline.get(0), "$project");
-		Document items = DocumentTestUtils.getAsDocument($project, "items");
-		Document $filter = DocumentTestUtils.getAsDocument(items, "$filter");
-
+		Document $filter = extractFilterOperatorFromDocument(agg.toDocument("sales", aggregationContext));
 		Document expected = Document.parse("{" + //
 				"input: \"$items\"," + //
 				"as: \"item\"," + //
@@ -83,13 +77,7 @@ public class FilterExpressionUnitTests {
 		TypedAggregation<Sales> agg = Aggregation.newAggregation(Sales.class, Aggregation.project().and("items")
 				.filter("item", AggregationFunctionExpressions.GTE.of(Fields.field("item.price"), 100)).as("items"));
 
-		Document dbo = agg.toDocument("sales", aggregationContext);
-
-		List<Object> pipeline = DocumentTestUtils.getAsDBList(dbo, "pipeline");
-		Document $project = DocumentTestUtils.getAsDocument((Document) pipeline.get(0), "$project");
-		Document items = DocumentTestUtils.getAsDocument($project, "items");
-		Document $filter = DocumentTestUtils.getAsDocument(items, "$filter");
-
+		Document $filter = extractFilterOperatorFromDocument(agg.toDocument("sales", aggregationContext));
 		Document expected = Document.parse("{" + //
 				"input: \"$items\"," + //
 				"as: \"item\"," + //
@@ -106,13 +94,7 @@ public class FilterExpressionUnitTests {
 				Aggregation.project().and(filter(Arrays.<Object> asList(1, "a", 2, null, 3.1D, 4, "5")).as("num")
 						.by(AggregationFunctionExpressions.GTE.of(Fields.field("num"), 3))).as("items"));
 
-		Document dbo = agg.toDocument("sales", aggregationContext);
-
-		List<Object> pipeline = DocumentTestUtils.getAsDBList(dbo, "pipeline");
-		Document $project = DocumentTestUtils.getAsDocument((Document) pipeline.get(0), "$project");
-		Document items = DocumentTestUtils.getAsDocument($project, "items");
-		Document $filter = DocumentTestUtils.getAsDocument(items, "$filter");
-
+		Document $filter = extractFilterOperatorFromDocument(agg.toDocument("sales", aggregationContext));
 		Document expected = Document.parse("{" + //
 				"input: [ 1, \"a\", 2, null, 3.1, 4, \"5\" ]," + //
 				"as: \"num\"," + //
@@ -129,13 +111,7 @@ public class FilterExpressionUnitTests {
 				.and(filter("items").as("item").by(ComparisonOperators.valueOf("item.price").greaterThan("field-1")))
 				.as("items"));
 
-		Document dbo = agg.toDocument("sales", Aggregation.DEFAULT_CONTEXT);
-
-		List<Object> pipeline = DocumentTestUtils.getAsDBList(dbo, "pipeline");
-		Document $project = DocumentTestUtils.getAsDocument((Document) pipeline.get(0), "$project");
-		Document items = DocumentTestUtils.getAsDocument($project, "items");
-		Document $filter = DocumentTestUtils.getAsDocument(items, "$filter");
-
+		Document $filter = extractFilterOperatorFromDocument(agg.toDocument("sales", Aggregation.DEFAULT_CONTEXT));
 		Document expected = Document.parse("{" + //
 				"input: \"$items\"," + //
 				"as: \"item\"," + //
@@ -143,6 +119,14 @@ public class FilterExpressionUnitTests {
 				"}");
 
 		assertThat($filter).isEqualTo(new Document(expected));
+	}
+
+	private Document extractFilterOperatorFromDocument(Document source) {
+
+		List<Object> pipeline = DocumentTestUtils.getAsDBList(source, "pipeline");
+		Document $project = DocumentTestUtils.getAsDocument((Document) pipeline.get(0), "$project");
+		Document items = DocumentTestUtils.getAsDocument($project, "items");
+		return DocumentTestUtils.getAsDocument(items, "$filter");
 	}
 
 	static class Sales {


### PR DESCRIPTION
We now render field and local variable references correctly when using the `$filter` aggregation operator.
Prior to this commit field references had been rendered with an additional `$` prefix.