### PR TITLE
DATAMONGO-2339 - Fix QueryMapper field name resolution for properties containing underscore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2339-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2339-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2339-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2339-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -33,7 +33,6 @@ import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
-
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.domain.Example;
@@ -1099,6 +1098,11 @@ public class QueryMapper {
 		private PropertyPath forName(String path) {
 
 			try {
+
+				if (entity.getPersistentProperty(path) != null) {
+					return PropertyPath.from(Pattern.quote(path), entity.getTypeInformation());
+				}
+
 				return PropertyPath.from(path, entity.getTypeInformation());
 			} catch (PropertyReferenceException | InvalidPersistentPropertyPath e) {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -881,6 +881,15 @@ public class QueryMapperUnitTests {
 		assertThat(document).isEqualTo(new org.bson.Document("scripts", new Code(script)));
 	}
 
+	@Test // DATAMONGO-2339
+	public void findByIdUsesMappedIdFieldNameWithUnderscoreCorrectly() {
+
+		org.bson.Document target = mapper.getMappedObject(new org.bson.Document("with_underscore", "id-1"),
+				context.getPersistentEntity(WithIdPropertyContainingUnderscore.class));
+
+		assertThat(target).isEqualTo(new org.bson.Document("_id", "id-1"));
+	}
+
 	@Document
 	public class Foo {
 		@Id private ObjectId id;
@@ -1012,5 +1021,9 @@ public class QueryMapperUnitTests {
 
 		@Field(targetType = FieldType.SCRIPT) //
 		List<String> scripts;
+	}
+
+	static class WithIdPropertyContainingUnderscore {
+		@Id String with_underscore;
 	}
 }


### PR DESCRIPTION
We now prevent splitting of paths that contain underscores if the entity contains a matching property.