### PR TITLE
DATAMONGO-2344 - Fix slaveOK query option not applied.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2344-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2344-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2344-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2344-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CursorPreparer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CursorPreparer.java
@@ -15,9 +15,15 @@
  */
 package org.springframework.data.mongodb.core;
 
-import org.bson.Document;
+import java.util.function.Function;
 
+import org.bson.Document;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.mongodb.ReadPreference;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
 
 /**
  * Simple callback interface to allow customization of a {@link FindIterable}.
@@ -25,7 +31,14 @@ import com.mongodb.client.FindIterable;
  * @author Oliver Gierke
  * @author Christoph Strobl
  */
-interface CursorPreparer {
+interface CursorPreparer extends ReadPreferenceAware {
+
+	/**
+	 * Default {@link CursorPreparer} just passing on the given {@link FindIterable}.
+	 *
+	 * @since 2.2
+	 */
+	CursorPreparer NO_OP_PREPARER = (iterable -> iterable);
 
 	/**
 	 * Prepare the given cursor (apply limits, skips and so on). Returns the prepared cursor.
@@ -33,4 +46,37 @@ interface CursorPreparer {
 	 * @param cursor
 	 */
 	FindIterable<Document> prepare(FindIterable<Document> cursor);
+
+	/**
+	 * Apply query specific settings to {@link MongoCollection} and initate a find operation returning a
+	 * {@link FindIterable} via the given {@link Function find} function.
+	 * 
+	 * @param collection must not be {@literal null}.
+	 * @param find must not be {@literal null}.
+	 * @return
+	 * @throws IllegalArgumentException if one of the required arguments is {@literal null}.
+	 * @since 2.2
+	 */
+	default FindIterable<Document> initiateFind(MongoCollection<Document> collection,
+			Function<MongoCollection<Document>, FindIterable<Document>> find) {
+
+		Assert.notNull(collection, "Collection must not be null!");
+		Assert.notNull(find, "Find function must not be null!");
+
+		if (hasReadPreferences()) {
+			collection = collection.withReadPreference(getReadPreference());
+		}
+
+		return prepare(find.apply(collection));
+	}
+
+	/**
+	 * @return the {@link ReadPreference} to apply or {@literal null} if none defined.
+	 * @since 2.2
+	 */
+	@Override
+	@Nullable
+	default ReadPreference getReadPreference() {
+		return null;
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupport.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core;
 
+import com.mongodb.ReadPreference;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -266,6 +267,11 @@ class ExecutableFindOperationSupport implements ExecutableFindOperation {
 
 			this.limit = Optional.of(limit);
 			return this;
+		}
+
+		@Override
+		public ReadPreference getReadPreference() {
+			return delegate.getReadPreference();
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -105,6 +105,7 @@ import org.springframework.data.mongodb.core.mapreduce.MapReduceResults;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Meta;
+import org.springframework.data.mongodb.core.query.Meta.CursorOption;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
@@ -447,8 +448,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Document mappedFields = getMappedFieldsObject(query.getFieldsObject(), persistentEntity, returnType);
 			Document mappedQuery = queryMapper.getMappedObject(query.getQueryObject(), persistentEntity);
 
-			FindIterable<Document> cursor = new QueryCursorPreparer(query, entityType)
-					.prepare(collection.find(mappedQuery, Document.class).projection(mappedFields));
+			FindIterable<Document> cursor = new QueryCursorPreparer(query, entityType).initiateFind(collection,
+					col -> col.find(mappedQuery, Document.class).projection(mappedFields));
 
 			return new CloseableIterableCursorAdapter<>(cursor, exceptionTranslator,
 					new ProjectingReadCallback<>(mongoConverter, entityType, returnType, collectionName));
@@ -538,8 +539,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					sortObject, fieldsObject, collectionName);
 		}
 
-		this.executeQueryInternal(new FindCallback(queryObject, fieldsObject, null), preparer, documentCallbackHandler,
-				collectionName);
+		this.executeQueryInternal(new FindCallback(queryObject, fieldsObject, null),
+				preparer != null ? preparer : CursorPreparer.NO_OP_PREPARER, documentCallbackHandler, collectionName);
 	}
 
 	/*
@@ -777,8 +778,9 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Assert.notNull(mode, "BulkMode must not be null!");
 		Assert.hasText(collectionName, "Collection name must not be null or empty!");
 
-		DefaultBulkOperations operations = new DefaultBulkOperations(this, collectionName, new BulkOperationContext(mode,
-				Optional.ofNullable(getPersistentEntity(entityType)), queryMapper, updateMapper, eventPublisher, entityCallbacks));
+		DefaultBulkOperations operations = new DefaultBulkOperations(this, collectionName,
+				new BulkOperationContext(mode, Optional.ofNullable(getPersistentEntity(entityType)), queryMapper, updateMapper,
+						eventPublisher, entityCallbacks));
 
 		operations.setExceptionTranslator(exceptionTranslator);
 		operations.setDefaultWriteConcern(writeConcern);
@@ -814,8 +816,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		if (ObjectUtils.isEmpty(query.getSortObject())) {
 
 			return doFindOne(collectionName, query.getQueryObject(), query.getFieldsObject(),
-					operations.forType(entityClass).getCollation(query).map(Collation::toMongoCollation).orElse(null),
-					entityClass);
+					new QueryCursorPreparer(query, entityClass), entityClass);
 		} else {
 			query.limit(1);
 			List<T> results = find(query, entityClass, collectionName);
@@ -933,6 +934,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 						serializeToJsonSafely(mappedQuery), field, collectionName);
 			}
 
+			QueryCursorPreparer preparer = new QueryCursorPreparer(query, entityClass);
+			if (preparer.hasReadPreferences()) {
+				collection = collection.withReadPreference(preparer.getReadPreference());
+			}
+
 			DistinctIterable<T> iterable = collection.distinct(mappedFieldName, mappedQuery, mongoDriverCompatibleType);
 
 			return operations.forType(entityClass) //
@@ -1007,8 +1013,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Assert.notNull(collectionName, "CollectionName must not be null!");
 		Assert.notNull(returnType, "ReturnType must not be null!");
 
-		String collection = StringUtils.hasText(collectionName) ? collectionName
-				: getCollectionName(domainType);
+		String collection = StringUtils.hasText(collectionName) ? collectionName : getCollectionName(domainType);
 		String distanceField = operations.nearQueryDistanceFieldName(domainType);
 
 		Aggregation $geoNear = TypedAggregation.newAggregation(domainType, Aggregation.geoNear(near, distanceField))
@@ -1039,8 +1044,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	@Nullable
 	@Override
 	public <T> T findAndModify(Query query, Update update, Class<T> entityClass) {
-		return findAndModify(query, update, new FindAndModifyOptions(), entityClass,
-				getCollectionName(entityClass));
+		return findAndModify(query, update, new FindAndModifyOptions(), entityClass, getCollectionName(entityClass));
 	}
 
 	@Nullable
@@ -1296,8 +1300,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Assert.notNull(batchToSave, "BatchToSave must not be null!");
 
-		return (Collection<T>) doInsertBatch(getCollectionName(entityClass), batchToSave,
-				this.mongoConverter);
+		return (Collection<T>) doInsertBatch(getCollectionName(entityClass), batchToSave, this.mongoConverter);
 	}
 
 	@Override
@@ -1791,7 +1794,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		return executeFindMultiInternal(
 				new FindCallback(new Document(), new Document(),
 						operations.forType(entityClass).getCollation().map(Collation::toMongoCollation).orElse(null)),
-				null, new ReadDocumentCallback<>(mongoConverter, entityClass, collectionName), collectionName);
+				CursorPreparer.NO_OP_PREPARER, new ReadDocumentCallback<>(mongoConverter, entityClass, collectionName),
+				collectionName);
 	}
 
 	@Override
@@ -2431,7 +2435,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @return the {@link List} of converted objects.
 	 */
 	protected <T> T doFindOne(String collectionName, Document query, Document fields, Class<T> entityClass) {
-		return doFindOne(collectionName, query, fields, null, entityClass);
+		return doFindOne(collectionName, query, fields, CursorPreparer.NO_OP_PREPARER, entityClass);
 	}
 
 	/**
@@ -2442,12 +2446,13 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @param query the query document that specifies the criteria used to find a record.
 	 * @param fields the document that specifies the fields to be returned.
 	 * @param entityClass the parameterized type of the returned list.
+	 * @param preparer the preparer used to modify the cursor on execution.
 	 * @return the {@link List} of converted objects.
 	 * @since 2.2
 	 */
 	@SuppressWarnings("ConstantConditions")
-	protected <T> T doFindOne(String collectionName, Document query, Document fields,
-			@Nullable com.mongodb.client.model.Collation collation, Class<T> entityClass) {
+	protected <T> T doFindOne(String collectionName, Document query, Document fields, CursorPreparer preparer,
+			Class<T> entityClass) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityClass);
 		Document mappedQuery = queryMapper.getMappedObject(query, entity);
@@ -2458,7 +2463,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					mappedFields, entityClass, collectionName);
 		}
 
-		return executeFindOneInternal(new FindOneCallback(mappedQuery, mappedFields, collation),
+		return executeFindOneInternal(new FindOneCallback(mappedQuery, mappedFields, preparer),
 				new ReadDocumentCallback<>(this.mongoConverter, entityClass, collectionName), collectionName);
 	}
 
@@ -2509,8 +2514,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					serializeToJsonSafely(mappedQuery), mappedFields, entityClass, collectionName);
 		}
 
-		return executeFindMultiInternal(new FindCallback(mappedQuery, mappedFields, null), preparer, objectCallback,
-				collectionName);
+		return executeFindMultiInternal(new FindCallback(mappedQuery, mappedFields, null),
+				preparer != null ? preparer : CursorPreparer.NO_OP_PREPARER, objectCallback, collectionName);
 	}
 
 	/**
@@ -2732,6 +2737,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			DocumentCallback<T> objectCallback, String collectionName) {
 
 		try {
+
 			T result = objectCallback
 					.doWith(collectionCallback.doInCollection(getAndPrepareCollection(doGetDatabase(), collectionName)));
 			return result;
@@ -2759,7 +2765,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @return
 	 */
 	private <T> List<T> executeFindMultiInternal(CollectionCallback<FindIterable<Document>> collectionCallback,
-			@Nullable CursorPreparer preparer, DocumentCallback<T> objectCallback, String collectionName) {
+			CursorPreparer preparer, DocumentCallback<T> objectCallback, String collectionName) {
 
 		try {
 
@@ -2767,14 +2773,9 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 			try {
 
-				FindIterable<Document> iterable = collectionCallback
-						.doInCollection(getAndPrepareCollection(doGetDatabase(), collectionName));
-
-				if (preparer != null) {
-					iterable = preparer.prepare(iterable);
-				}
-
-				cursor = iterable.iterator();
+				cursor = preparer
+						.initiateFind(getAndPrepareCollection(doGetDatabase(), collectionName), collectionCallback::doInCollection)
+						.iterator();
 
 				List<T> result = new ArrayList<>();
 
@@ -2796,21 +2797,17 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	private void executeQueryInternal(CollectionCallback<FindIterable<Document>> collectionCallback,
-			@Nullable CursorPreparer preparer, DocumentCallbackHandler callbackHandler, String collectionName) {
+			CursorPreparer preparer, DocumentCallbackHandler callbackHandler, String collectionName) {
 
 		try {
 
 			MongoCursor<Document> cursor = null;
 
 			try {
-				FindIterable<Document> iterable = collectionCallback
-						.doInCollection(getAndPrepareCollection(doGetDatabase(), collectionName));
 
-				if (preparer != null) {
-					iterable = preparer.prepare(iterable);
-				}
-
-				cursor = iterable.iterator();
+				cursor = preparer
+						.initiateFind(getAndPrepareCollection(doGetDatabase(), collectionName), collectionCallback::doInCollection)
+						.iterator();
 
 				while (cursor.hasNext()) {
 					callbackHandler.processDocument(cursor.next());
@@ -2904,21 +2901,19 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		private final Document query;
 		private final Optional<Document> fields;
-		private final @Nullable com.mongodb.client.model.Collation collation;
+		private final CursorPreparer cursorPreparer;
 
-		public FindOneCallback(Document query, Document fields, @Nullable com.mongodb.client.model.Collation collation) {
+		FindOneCallback(Document query, Document fields, CursorPreparer preparer) {
 
 			this.query = query;
 			this.fields = Optional.of(fields).filter(it -> !ObjectUtils.isEmpty(fields));
-			this.collation = collation;
+			this.cursorPreparer = preparer;
 		}
 
+		@Override
 		public Document doInCollection(MongoCollection<Document> collection) throws MongoException, DataAccessException {
 
-			FindIterable<Document> iterable = collection.find(query, Document.class);
-			if (collation != null) {
-				iterable = iterable.collation(collation);
-			}
+			FindIterable<Document> iterable = cursorPreparer.initiateFind(collection, col -> col.find(query, Document.class));
 
 			if (LOGGER.isDebugEnabled()) {
 
@@ -3314,6 +3309,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 							case PARTIAL:
 								cursorToUse = cursorToUse.partial(true);
 								break;
+							case SLAVE_OK:
+								break;
 							default:
 								throw new IllegalArgumentException(String.format("%s is no supported flag.", option));
 						}
@@ -3325,6 +3322,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			}
 
 			return cursorToUse;
+		}
+
+		@Override
+		public ReadPreference getReadPreference() {
+			return query.getMeta().getFlags().contains(CursorOption.SLAVE_OK) ? ReadPreference.primaryPreferred() : null;
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReadPreferenceAware.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReadPreferenceAware.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.springframework.lang.Nullable;
+
+import com.mongodb.ReadPreference;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.2
+ */
+interface ReadPreferenceAware {
+
+	/**
+	 * @return {@literal true} if a {@link ReadPreference} is set.
+	 */
+	default boolean hasReadPreferences() {
+		return getReadPreference() != null;
+	}
+
+	/**
+	 * @return the {@link ReadPreference} to apply or {@literal null} if none set.
+	 */
+	@Nullable
+	ReadPreference getReadPreference();
+}


### PR DESCRIPTION
Since MongoDB 3.6 the _slaveOk_ option translates to the `ReadPreference.primaryPreferred()` that is now again applied when executing a (reactive)find operation.