### PR TITLE
DATAMONGO-2349 - Fix converter registration for java.time types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2349-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2349-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2349-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2349-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoSimpleTypes.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoSimpleTypes.java
@@ -86,7 +86,18 @@ public abstract class MongoSimpleTypes {
 	}
 
 	private static final Set<Class<?>> MONGO_SIMPLE_TYPES;
-	public static final SimpleTypeHolder HOLDER = new SimpleTypeHolder(MONGO_SIMPLE_TYPES, true);
+	public static final SimpleTypeHolder HOLDER = new SimpleTypeHolder(MONGO_SIMPLE_TYPES, true) {
+
+		@Override
+		public boolean isSimpleType(Class<?> type) {
+
+			if (type.getName().startsWith("java.time")) {
+				return false;
+			}
+
+			return super.isSimpleType(type);
+		}
+	};
 
 	private MongoSimpleTypes() {}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoCustomConversionsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoCustomConversionsUnitTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Test;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * @author Christoph Strobl
+ */
+public class MongoCustomConversionsUnitTests {
+
+	@Test // DATAMONGO-2349
+	public void nonAnnotatedConverterForJavaTimeTypeShouldOnlyBeRegisteredAsReadingConverter() {
+
+		MongoCustomConversions conversions = new MongoCustomConversions(
+				Collections.singletonList(new DateToZonedDateTimeConverter()));
+
+		assertThat(conversions.hasCustomReadTarget(Date.class, ZonedDateTime.class)).isTrue();
+		assertThat(conversions.hasCustomWriteTarget(Date.class)).isFalse();
+	}
+
+	static class DateToZonedDateTimeConverter implements Converter<Date, ZonedDateTime> {
+
+		@Override
+		public ZonedDateTime convert(Date source) {
+			return ZonedDateTime.now();
+		}
+	}
+}


### PR DESCRIPTION
The MongoDB Java Driver does not handle _java.time_ types. Therefore those must not be considered simple types.
The behavior was changed by DATACMNS-1294 forcing usage of `@Reading-` & `@WritingConverter` annotations to disambiguate converter direction.
This PR restores the converter registration to the state before the change in Spring Data Commons.