### PR TITLE
DATAMONGO-2357 - Fix read/write for MongoDB client.model GeoJSON types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2357-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java
@@ -105,6 +105,7 @@ public abstract class AbstractMongoClientConfiguration extends MongoConfiguratio
 		DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDbFactory());
 		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext());
 		converter.setCustomConversions(customConversions());
+		converter.setCodecRegistryProvider(mongoDbFactory());
 
 		return converter;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoConfiguration.java
@@ -111,6 +111,7 @@ public abstract class AbstractMongoConfiguration extends MongoConfigurationSuppo
 		DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDbFactory());
 		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext());
 		converter.setCustomConversions(customConversions());
+		converter.setCodecRegistryProvider(mongoDbFactory());
 
 		return converter;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfiguration.java
@@ -83,6 +83,7 @@ public abstract class AbstractReactiveMongoConfiguration extends MongoConfigurat
 
 		MappingMongoConverter converter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, mongoMappingContext());
 		converter.setCustomConversions(customConversions());
+		converter.setCodecRegistryProvider(reactiveMongoDbFactory());
 
 		return converter;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2846,6 +2846,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mappingContext);
 		converter.setCustomConversions(conversions);
+		converter.setCodecRegistryProvider(factory);
 		converter.afterPropertiesSet();
 
 		return converter;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2774,7 +2774,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		return type == null ? null : mappingContext.getPersistentEntity(type);
 	}
 
-	private static MappingMongoConverter getDefaultMongoConverter() {
+	private MappingMongoConverter getDefaultMongoConverter() {
 
 		MongoCustomConversions conversions = new MongoCustomConversions(Collections.emptyList());
 
@@ -2784,6 +2784,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		MappingMongoConverter converter = new MappingMongoConverter(NO_OP_REF_RESOLVER, context);
 		converter.setCustomConversions(conversions);
+		converter.setCodecRegistryProvider(this.mongoDatabaseFactory);
 		converter.afterPropertiesSet();
 
 		return converter;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoSimpleTypes.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoSimpleTypes.java
@@ -33,6 +33,14 @@ import org.bson.types.Symbol;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 
 import com.mongodb.DBRef;
+import com.mongodb.client.model.geojson.Geometry;
+import com.mongodb.client.model.geojson.GeometryCollection;
+import com.mongodb.client.model.geojson.LineString;
+import com.mongodb.client.model.geojson.MultiLineString;
+import com.mongodb.client.model.geojson.MultiPoint;
+import com.mongodb.client.model.geojson.MultiPolygon;
+import com.mongodb.client.model.geojson.Point;
+import com.mongodb.client.model.geojson.Polygon;
 
 /**
  * Simple constant holder for a {@link SimpleTypeHolder} enriched with Mongo specific simple types.
@@ -79,6 +87,15 @@ public abstract class MongoSimpleTypes {
 		simpleTypes.add(BsonRegularExpression.class);
 		simpleTypes.add(BsonString.class);
 		simpleTypes.add(BsonTimestamp.class);
+
+		simpleTypes.add(Geometry.class);
+		simpleTypes.add(GeometryCollection.class);
+		simpleTypes.add(LineString.class);
+		simpleTypes.add(MultiLineString.class);
+		simpleTypes.add(MultiPoint.class);
+		simpleTypes.add(MultiPolygon.class);
+		simpleTypes.add(Point.class);
+		simpleTypes.add(Polygon.class);
 
 		MONGO_SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateTests.java
@@ -407,6 +407,7 @@ public class SessionBoundMongoTemplateTests {
 
 		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mappingContext);
 		converter.setCustomConversions(conversions);
+		converter.setCodecRegistryProvider(factory);
 		converter.afterPropertiesSet();
 
 		return converter;


### PR DESCRIPTION
We now consider native GeoJSON types of the MongoDB client during conversion passing on the raw values to the driver when writing and using the configured MongoDB codecs on read.