### PR TITLE
DATAMONGO-2366 - Consistently handle exceptions in CursorReadingTask

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2366-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2366-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2366-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2366-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/CursorReadingTask.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/CursorReadingTask.java
@@ -73,9 +73,10 @@ abstract class CursorReadingTask<T, R> implements Task {
 	@Override
 	public void run() {
 
-		start();
-
 		try {
+
+			start();
+
 			while (isRunning()) {
 
 				try {
@@ -263,8 +264,8 @@ abstract class CursorReadingTask<T, R> implements Task {
 
 	/**
 	 * Execute an operation and take care of translating exceptions using the {@link MongoTemplate templates}
-	 * {@link org.springframework.data.mongodb.core.MongoExceptionTranslator} and passing those on to the
-	 * {@link #errorHandler}.
+	 * {@link org.springframework.data.mongodb.core.MongoExceptionTranslator} rethrowing the potentially translated
+	 * exception.
 	 *
 	 * @param callback must not be {@literal null}.
 	 * @param <T>
@@ -279,10 +280,7 @@ abstract class CursorReadingTask<T, R> implements Task {
 		} catch (RuntimeException e) {
 
 			RuntimeException translated = template.getExceptionTranslator().translateExceptionIfPossible(e);
-			RuntimeException toHandle = translated != null ? translated : e;
-
-			errorHandler.handleError(toHandle);
-			throw toHandle;
+			throw translated != null ? translated : e;
 		}
 	}
 }


### PR DESCRIPTION
Exceptions during `CursorReadingTask` startup and during polling are handled now by the same exception handling to handle Exceptions only once and notify `ErrorHandler` exactly once per exception.

Previously, startup exceptions relied on exception handling in the `execute` closure and notified `ErrorHandler` potentially multiple times.

---

Related ticket: [DATAMONGO-2366](https://jira.spring.io/browse/DATAMONGO-2366).