### PR TITLE
DATAMONGO-2388 - Fix CodecConfigurationException when reading index info containing DbRef in partial filter expression.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAMONGO-2388-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2388-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2388-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATAMONGO-2388-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.bson.Document;
+import org.springframework.data.mongodb.util.BsonUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
@@ -117,9 +118,8 @@ public class IndexInfo {
 		boolean sparse = sourceDocument.containsKey("sparse") ? (Boolean) sourceDocument.get("sparse") : false;
 		String language = sourceDocument.containsKey("default_language") ? (String) sourceDocument.get("default_language")
 				: "";
-		String partialFilter = sourceDocument.containsKey("partialFilterExpression")
-				? ((Document) sourceDocument.get("partialFilterExpression")).toJson()
-				: null;
+
+		String partialFilter = extractPartialFilterString(sourceDocument);
 
 		IndexInfo info = new IndexInfo(indexFields, name, unique, sparse, language);
 		info.partialFilterExpression = partialFilter;
@@ -132,6 +132,21 @@ public class IndexInfo {
 		}
 
 		return info;
+	}
+
+	/**
+	 * @param sourceDocument
+	 * @return the {@link String} representation of the partial filter {@link Document}.
+	 * @since 2.1.11
+	 */
+	@Nullable
+	private static String extractPartialFilterString(Document sourceDocument) {
+
+		if (!sourceDocument.containsKey("partialFilterExpression")) {
+			return null;
+		}
+
+		return BsonUtils.toJson(sourceDocument.get("partialFilterExpression", Document.class));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -16,13 +16,18 @@
 package org.springframework.data.mongodb.util;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.bson.json.JsonParseException;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -30,6 +35,7 @@ import org.springframework.util.StringUtils;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
+import com.mongodb.MongoClientSettings;
 
 /**
  * @author Christoph Strobl
@@ -147,4 +153,77 @@ public class BsonUtils {
 		return orElse.apply(source);
 	}
 
+	/**
+	 * Serialize the given {@link Document} as Json applying default codecs if necessary.
+	 * 
+	 * @param source
+	 * @return
+	 * @since 2.1.1
+	 */
+	public static String toJson(Document source) {
+
+		if (source == null) {
+			return null;
+		}
+
+		try {
+			return source.toJson();
+		} catch (Exception e) {
+			return toJson((Object) source);
+		}
+	}
+
+	private static String toJson(Object value) {
+
+		if (value == null) {
+			return null;
+		}
+
+		try {
+			return value instanceof Document
+					? ((Document) value).toJson(MongoClientSettings.getDefaultCodecRegistry().get(Document.class))
+					: serializeValue(value);
+
+		} catch (Exception e) {
+
+			if (value instanceof Collection) {
+				return toString((Collection<?>) value);
+			} else if (value instanceof Map) {
+				return toString((Map<?, ?>) value);
+			} else if (ObjectUtils.isArray(value)) {
+				return toString(Arrays.asList(ObjectUtils.toObjectArray(value)));
+			}
+
+			throw e instanceof JsonParseException ? (JsonParseException) e : new JsonParseException(e);
+		}
+	}
+
+	private static String serializeValue(@Nullable Object value) {
+
+		if (value == null) {
+			return "null";
+		}
+
+		String documentJson = new Document("toBeEncoded", value).toJson();
+		return documentJson.substring(documentJson.indexOf(':') + 1, documentJson.length() - 1).trim();
+	}
+
+	private static String toString(Map<?, ?> source) {
+
+		return iterableToDelimitedString(source.entrySet(), "{ ", " }",
+				entry -> String.format("\"%s\" : %s", entry.getKey(), toJson(entry.getValue())));
+	}
+
+	private static String toString(Collection<?> source) {
+		return iterableToDelimitedString(source, "[ ", " ]", BsonUtils::toJson);
+	}
+
+	private static <T> String iterableToDelimitedString(Iterable<T> source, String prefix, String postfix,
+			Converter<? super T, Object> transformer) {
+
+		return prefix
+				+ StringUtils.collectionToCommaDelimitedString(
+						StreamSupport.stream(source.spliterator(), false).map(transformer::convert).collect(Collectors.toList()))
+				+ postfix;
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateCollationTests.java
@@ -60,6 +60,11 @@ public class MongoTemplateCollationTests {
 		protected String getDatabaseName() {
 			return "collation-tests";
 		}
+
+		@Override
+		protected boolean autoIndexCreation() {
+			return false;
+		}
 	}
 
 	@Autowired MongoTemplate template;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTransactionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTransactionTests.java
@@ -85,6 +85,11 @@ public class MongoTemplateTransactionTests {
 			return DB_NAME;
 		}
 
+		@Override
+		protected boolean autoIndexCreation() {
+			return false;
+		}
+
 		@Bean
 		MongoTransactionManager txManager(MongoDbFactory dbFactory) {
 			return new MongoTransactionManager(dbFactory);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateValidationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateValidationTests.java
@@ -74,6 +74,11 @@ public class MongoTemplateValidationTests {
 		protected String getDatabaseName() {
 			return "validation-tests";
 		}
+
+		@Override
+		protected boolean autoIndexCreation() {
+			return false;
+		}
 	}
 
 	@Autowired MongoTemplate template;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/NoExplicitIdTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/NoExplicitIdTests.java
@@ -59,6 +59,11 @@ public class NoExplicitIdTests {
 		public MongoClient mongoClient() {
 			return MongoTestUtils.client();
 		}
+
+		@Override
+		protected boolean autoIndexCreation() {
+			return false;
+		}
 	}
 
 	@Autowired MongoOperations mongoOps;


### PR DESCRIPTION
Provide the default `CodecRegistry` when converting partial index data to its `String` representation used in `IndexInfo`.

Should be back ported to _2.2.x_ and _2.1.x_.