### PR TITLE
DATAMONGO-765 - Support skip and limit parameters in {Reactive,}Grid…

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.bson.BsonObjectId;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -51,6 +50,7 @@ import com.mongodb.client.gridfs.model.GridFSFile;
  * @author Mark Paluch
  * @author Hartmut Lang
  * @author Niklas Helge Hanft
+ * @author Denis Zavedeev
  */
 public class GridFsTemplate extends GridFsOperationsSupport implements GridFsOperations, ResourcePatternResolver {
 
@@ -166,7 +166,14 @@ public class GridFsTemplate extends GridFsOperationsSupport implements GridFsOpe
 		Document queryObject = getMappedQuery(query.getQueryObject());
 		Document sortObject = getMappedQuery(query.getSortObject());
 
-		return getGridFs().find(queryObject).sort(sortObject);
+		GridFSFindIterable iterable = getGridFs().find(queryObject).sort(sortObject);
+		if (query.getSkip() > 0) {
+			iterable = iterable.skip(Math.toIntExact(query.getSkip()));
+		}
+		if (query.getLimit() > 0) {
+			iterable = iterable.limit(query.getLimit());
+		}
+		return iterable;
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplate.java
@@ -50,6 +50,7 @@ import com.mongodb.reactivestreams.client.gridfs.GridFSFindPublisher;
  *
  * @author Mark Paluch
  * @author Nick Stolwijk
+ * @author Denis Zavedeev
  * @since 2.2
  */
 public class ReactiveGridFsTemplate extends GridFsOperationsSupport implements ReactiveGridFsOperations {
@@ -261,7 +262,12 @@ public class ReactiveGridFsTemplate extends GridFsOperationsSupport implements R
 		Document sortObject = getMappedQuery(query.getSortObject());
 
 		GridFSFindPublisher publisherToUse = getGridFs().find(queryObject).sort(sortObject);
-
+		if (query.getLimit() > 0) {
+			publisherToUse = publisherToUse.limit(query.getLimit());
+		}
+		if (query.getSkip() > 0) {
+			publisherToUse = publisherToUse.skip(Math.toIntExact(query.getSkip()));
+		}
 		Integer cursorBatchSize = query.getMeta().getCursorBatchSize();
 		if (cursorBatchSize != null) {
 			publisherToUse = publisherToUse.batchSize(cursorBatchSize);


### PR DESCRIPTION
…FsTemplate

Leverage `skip` and `limit` methods exposed in `GridFSFindIterable` to support
limiting and skipping results.
In particular these changes allow the `find(Query)` method to correctly
consider parameters of a page request.

Original pull request: #806.
Related tickets: DATAMONGO-765.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
https://jira.spring.io/browse/DATAMONGO-2411
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
