### PR TITLE
DATAMONGO-2414 - Guard drain loop in AsyncInputStreamHandler with state switch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAMONGO-2414-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAMONGO-2414-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAMONGO-2414-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.DATAMONGO-2414-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUpdateTests.java
@@ -22,11 +22,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import com.mongodb.client.MongoClient;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
@@ -37,27 +36,29 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.test.util.EnableIfMongoServerVersion;
+import org.springframework.data.mongodb.test.util.MongoServerCondition;
 import org.springframework.data.mongodb.test.util.MongoTestUtils;
-import org.springframework.data.mongodb.test.util.MongoVersionRule;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 
 /**
  * @author Christoph Strobl
  */
+@ExtendWith(MongoServerCondition.class)
+@EnableIfMongoServerVersion(isGreaterThanEqual = "4.2")
 public class MongoTemplateUpdateTests {
-
-	public static @ClassRule MongoVersionRule REQUIRES_AT_LEAST_4_2 = MongoVersionRule.REQUIRES_4_2;
 
 	static final String DB_NAME = "update-test";
 
 	MongoClient client;
 	MongoTemplate template;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 
-		client = MongoTestUtils.replSetClient();
+		client = MongoTestUtils.client();
 		template = new MongoTemplate(new SimpleMongoClientDbFactory(client, DB_NAME));
 
 		MongoTestUtils.createOrReplaceCollection(DB_NAME, template.getCollectionName(Score.class), client);
@@ -247,7 +248,7 @@ public class MongoTemplateUpdateTests {
 	}
 
 	@Test // DATAMONGO-2331
-	@Ignore("https://jira.mongodb.org/browse/JAVA-3432")
+	@Disabled("https://jira.mongodb.org/browse/JAVA-3432")
 	public void findAndModifyAppliesAggregationUpdateCorrectly() {
 
 		Book one = new Book();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUpdateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUpdateTests.java
@@ -25,10 +25,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
@@ -39,8 +39,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.test.util.EnableIfMongoServerVersion;
+import org.springframework.data.mongodb.test.util.MongoServerCondition;
 import org.springframework.data.mongodb.test.util.MongoTestUtils;
-import org.springframework.data.mongodb.test.util.MongoVersionRule;
 
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoCollection;
@@ -48,19 +49,19 @@ import com.mongodb.reactivestreams.client.MongoCollection;
 /**
  * @author Christoph Strobl
  */
+@ExtendWith(MongoServerCondition.class)
+@EnableIfMongoServerVersion(isGreaterThanEqual = "4.2")
 public class ReactiveMongoTemplateUpdateTests {
-
-	public static @ClassRule MongoVersionRule REQUIRES_AT_LEAST_4_2 = MongoVersionRule.REQUIRES_4_2;
 
 	static final String DB_NAME = "reactive-update-test";
 
 	MongoClient client;
 	ReactiveMongoTemplate template;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void beforeEach() {
 
-		client = MongoTestUtils.reactiveReplSetClient();
+		client = MongoTestUtils.reactiveClient();
 		template = new ReactiveMongoTemplate(new SimpleReactiveMongoDatabaseFactory(client, DB_NAME));
 
 		MongoTestUtils.createOrReplaceCollection(DB_NAME, template.getCollectionName(Score.class), client).then()
@@ -239,7 +240,7 @@ public class ReactiveMongoTemplateUpdateTests {
 	}
 
 	@Test // DATAMONGO-2331
-	@Ignore("https://jira.mongodb.org/browse/JAVA-3432")
+	@Disabled("https://jira.mongodb.org/browse/JAVA-3432")
 	public void findAndModifyAppliesAggregationUpdateCorrectly() {
 
 		Book one = new Book();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/EnableIfMongoServerVersion.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/EnableIfMongoServerVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,36 +21,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.core.annotation.AliasFor;
+import org.junit.jupiter.api.Tag;
 
 /**
- * {@link MongoVersion} allows specifying an version range of mongodb that is applicable for a specific test method. To
- * be used along with {@link MongoVersionRule} or {@link MongoServerCondition}.
- *
  * @author Christoph Strobl
- * @since 2.1
- * @deprecated Use {@link EnableIfMongoServerVersion} instead.
+ * @since 2.3
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Documented
-@EnableIfMongoServerVersion
-@Deprecated
-public @interface MongoVersion {
+@Tag("version-specific")
+public @interface EnableIfMongoServerVersion {
 
 	/**
 	 * Inclusive lower bound of MongoDB server range.
 	 *
 	 * @return {@code 0.0.0} by default.
 	 */
-	@AliasFor(annotation = EnableIfMongoServerVersion.class, attribute = "isGreaterThanEqual")
-	String asOf() default "0.0.0";
+	String isGreaterThanEqual() default "0.0.0";
 
 	/**
 	 * Exclusive upper bound of MongoDB server range.
 	 *
 	 * @return {@code 9999.9999.9999} by default.
 	 */
-	@AliasFor(annotation = EnableIfMongoServerVersion.class, attribute = "isLessThan")
-	String until() default "9999.9999.9999";
+	String isLessThan() default "9999.9999.9999";
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/EnableIfReplicaSetAvailable.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/EnableIfReplicaSetAvailable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.test.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+/**
+ * {@link EnableIfReplicaSetAvailable} marks a specific test class or method to be only executed against a server running in
+ * replicaSet mode. Intended to be used along with {@link MongoServerCondition}.
+ *
+ * @author Christoph Strobl
+ * @since 2.3
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Tag("replSet")
+public @interface EnableIfReplicaSetAvailable {
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoServerCondition.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoServerCondition.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.test.util;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.data.util.Version;
+
+/**
+ * @author Christoph Strobl
+ */
+public class MongoServerCondition implements ExecutionCondition {
+
+	private static final Namespace NAMESPACE = Namespace.create("mongodb", "server");
+
+	private static final Version ANY = new Version(9999, 9999, 9999);
+	private static final Version DEFAULT_HIGH = ANY;
+	private static final Version DEFAULT_LOW = new Version(0, 0, 0);
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+		if (context.getTags().contains("replSet")) {
+			if (!serverIsPartOfReplicaSet(context)) {
+				return ConditionEvaluationResult.disabled("Disabled for servers not running in replicaSet mode.");
+			}
+		}
+
+		if (context.getTags().contains("version-specific") && context.getElement().isPresent()) {
+
+			EnableIfMongoServerVersion version = AnnotatedElementUtils.findMergedAnnotation(context.getElement().get(),
+					EnableIfMongoServerVersion.class);
+
+			Version serverVersion = serverVersion(context);
+
+			if (version != null && !serverVersion.equals(ANY)) {
+
+				Version expectedMinVersion = Version.parse(version.isGreaterThanEqual());
+				if (!expectedMinVersion.equals(ANY) && !expectedMinVersion.equals(DEFAULT_LOW)) {
+					if (serverVersion.isLessThan(expectedMinVersion)) {
+						return ConditionEvaluationResult.disabled(String
+								.format("Disabled for server version %s. Requires at least %s.", serverVersion, expectedMinVersion));
+					}
+				}
+
+				Version expectedMaxVersion = Version.parse(version.isLessThan());
+				if (!expectedMaxVersion.equals(ANY) && !expectedMaxVersion.equals(DEFAULT_HIGH)) {
+					if (serverVersion.isGreaterThanOrEqualTo(expectedMaxVersion)) {
+						return ConditionEvaluationResult.disabled(String
+								.format("Disabled for server version %s. Only supported until %s.", serverVersion, expectedMaxVersion));
+					}
+				}
+			}
+		}
+
+		return ConditionEvaluationResult.enabled("Enabled by default");
+	}
+
+	private boolean serverIsPartOfReplicaSet(ExtensionContext context) {
+
+		return context.getStore(NAMESPACE).getOrComputeIfAbsent("--replSet", (key) -> MongoTestUtils.serverIsReplSet(),
+				Boolean.class);
+	}
+
+	private Version serverVersion(ExtensionContext context) {
+
+		return context.getStore(NAMESPACE).getOrComputeIfAbsent(Version.class, (key) -> MongoTestUtils.serverVersion(),
+				Version.class);
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersionRule.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoVersionRule.java
@@ -38,7 +38,9 @@ import com.mongodb.client.MongoDatabase;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @since 1.6
+ * @deprecated Use {@link MongoServerCondition} instead.
  */
+@Deprecated
 public class MongoVersionRule implements TestRule {
 
 	private static final Version ANY = new Version(9999, 9999, 9999);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/ReplicaSet.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/ReplicaSet.java
@@ -31,7 +31,9 @@ import com.mongodb.client.MongoClient;
  * {@link TestRule} evaluating if MongoDB Server is running with {@code --replSet} flag.
  *
  * @author Christoph Strobl
+ * @deprecated Use {@link MongoServerCondition} with {@link EnableIfReplicaSetAvailable} instead.
  */
+@Deprecated
 public class ReplicaSet implements TestRule {
 
 	boolean required = false;


### PR DESCRIPTION
We now use a non-blocking state switch to determine whether to invoke `drainLoop(…)` from `Subscriber` completion.

Previously, we relied on same thread identification assuming if the subscription thread and the completion thread were the same, that we're already running inside the drain loop.
It turns out that a I/O thread could also run in event-loop mode where subscription and completion happens on the same thread but in between there's some processing and so the the call to completion is a delayed signal and not being called on the same stack as drainLoop(…).
The same-thread assumption was in place to avoid StackOverflow caused by infinite recursions.

We now use a state lock to enter the drain loop. Any concurrent attempts to re-enter the drain loop in Subscriber completion is now prevented to make sure that we continue draining while not causing stack recursions.

---

Related ticket: [DATAMONGO-2414](https://jira.spring.io/browse/DATAMONGO-2414).