### PR TITLE
DATAMONGO-2418 - Obtain EvaluationContextExtensions lazily when parsing Bson queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.3.BUILD-SNAPSHOT</version>
+	<version>2.2.3.DATAMONGO-2418-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.3.BUILD-SNAPSHOT</version>
+		<version>2.2.3.DATAMONGO-2418-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.3.BUILD-SNAPSHOT</version>
+		<version>2.2.3.DATAMONGO-2418-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.3.BUILD-SNAPSHOT</version>
+		<version>2.2.3.DATAMONGO-2418-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
@@ -113,7 +113,7 @@ class AggregationUtils {
 			SpelExpressionParser expressionParser, QueryMethodEvaluationContextProvider evaluationContextProvider) {
 
 		ParameterBindingContext bindingContext = new ParameterBindingContext((accessor::getBindableValue), expressionParser,
-				evaluationContextProvider.getEvaluationContext(method.getParameters(), accessor.getValues()));
+				() -> evaluationContextProvider.getEvaluationContext(method.getParameters(), accessor.getValues()));
 
 		List<AggregationOperation> target = new ArrayList<>(method.getAnnotatedAggregation().length);
 		for (String source : method.getAnnotatedAggregation()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/CollationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/CollationUtils.java
@@ -73,7 +73,7 @@ class CollationUtils {
 		if (StringUtils.trimLeadingWhitespace(collationExpression).startsWith("{")) {
 
 			ParameterBindingContext bindingContext = new ParameterBindingContext((accessor::getBindableValue),
-					expressionParser, evaluationContextProvider.getEvaluationContext(parameters, accessor.getValues()));
+					expressionParser, () -> evaluationContextProvider.getEvaluationContext(parameters, accessor.getValues()));
 
 			return Collation.from(CODEC.decode(collationExpression, bindingContext));
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveStringBasedMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveStringBasedMongoQuery.java
@@ -117,7 +117,7 @@ public class ReactiveStringBasedMongoQuery extends AbstractReactiveMongoQuery {
 	protected Query createQuery(ConvertingParameterAccessor accessor) {
 
 		ParameterBindingContext bindingContext = new ParameterBindingContext((accessor::getBindableValue), expressionParser,
-				evaluationContextProvider.getEvaluationContext(getQueryMethod().getParameters(), accessor.getValues()));
+				() -> evaluationContextProvider.getEvaluationContext(getQueryMethod().getParameters(), accessor.getValues()));
 
 		Document queryObject = CODEC.decode(this.query, bindingContext);
 		Document fieldsObject = CODEC.decode(this.fieldSpec, bindingContext);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedMongoQuery.java
@@ -116,7 +116,7 @@ public class StringBasedMongoQuery extends AbstractMongoQuery {
 	protected Query createQuery(ConvertingParameterAccessor accessor) {
 
 		ParameterBindingContext bindingContext = new ParameterBindingContext((accessor::getBindableValue), expressionParser,
-				evaluationContextProvider.getEvaluationContext(getQueryMethod().getParameters(), accessor.getValues()));
+				() -> evaluationContextProvider.getEvaluationContext(getQueryMethod().getParameters(), accessor.getValues()));
 
 		Document queryObject = CODEC.decode(this.query, bindingContext);
 		Document fieldsObject = CODEC.decode(this.fieldSpec, bindingContext);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingDocumentCodec.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingDocumentCodec.java
@@ -162,7 +162,7 @@ public class ParameterBindingDocumentCodec implements CollectibleCodec<Document>
 	public Document decode(@Nullable String json, Object[] values) {
 
 		return decode(json, new ParameterBindingContext((index) -> values[index], new SpelExpressionParser(),
-				EvaluationContextProvider.DEFAULT.getEvaluationContext(values)));
+				() -> EvaluationContextProvider.DEFAULT.getEvaluationContext(values)));
 	}
 
 	public Document decode(@Nullable String json, ParameterBindingContext bindingContext) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
@@ -26,6 +26,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -95,6 +96,15 @@ public class ParameterBindingJsonReader extends AbstractBsonReader {
 
 	public ParameterBindingJsonReader(String json, ValueProvider accessor, SpelExpressionParser spelExpressionParser,
 			EvaluationContext evaluationContext) {
+
+		this(json, accessor, spelExpressionParser, () -> evaluationContext);
+	}
+
+	/**
+	 * 	@since 2.2.3
+	 */
+	public ParameterBindingJsonReader(String json, ValueProvider accessor, SpelExpressionParser spelExpressionParser,
+			Supplier<EvaluationContext> evaluationContext) {
 
 		this.scanner = new JsonScanner(json);
 		setContext(new Context(null, BsonContextType.TOP_LEVEL));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -26,6 +26,10 @@ import java.util.List;
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
 import org.junit.Test;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
  * Unit tests for {@link ParameterBindingJsonReader}.
@@ -195,6 +199,25 @@ public class ParameterBindingJsonReaderUnitTests {
 		Document target = parse("{ 'end_date' : { $gte : { $date : ?0 } } }", time);
 
 		assertThat(target).isEqualTo(Document.parse("{ 'end_date' : { $gte : { $date : " + time + " } } } "));
+	}
+
+	@Test // DATAMONGO-2418
+	public void shouldNotAccessSpElEveluationContextWhenNoSpelPresentInBindableTarget() {
+
+		Object[] args = new Object[] { "value" };
+		EvaluationContext evaluationContext = new StandardEvaluationContext() {
+
+			@Override
+			public TypedValue getRootObject() {
+				throw new RuntimeException("o_O");
+			}
+		};
+
+		ParameterBindingJsonReader reader = new ParameterBindingJsonReader("{ 'name':'?0' }",
+				new ParameterBindingContext((index) -> args[index], new SpelExpressionParser(), evaluationContext));
+		Document target = new ParameterBindingDocumentCodec().decode(reader, DecoderContext.builder().build());
+
+		assertThat(target).isEqualTo(new Document("name", "value"));
 	}
 
 	private static Document parse(String json, Object... args) {


### PR DESCRIPTION
This fix puts a patch on the issue when an annotated query does not require a SpEL context. However it does not solve the eager resolution of potential root objects in `ExtensionAwareEvaluationContextProvider` (see: [DATACMNS-1625](https://jira.spring.io/browse/DATACMNS-1625)) and therefore is likely to fail if the actual query uses an expression.

Should be forward ported to 2.3 / 3.0