### PR TITLE
DATAMONGO-2451 - Fix value conversion for id properties used in sort expression.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2451-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2451-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperations.java
@@ -127,7 +127,7 @@ public class DefaultIndexOperations implements IndexOperations {
 			indexOptions = addPartialFilterIfPresent(indexOptions, indexDefinition.getIndexOptions(), entity);
 			indexOptions = addDefaultCollationIfRequired(indexOptions, entity);
 
-			Document mappedKeys = mapper.getMappedObject(indexDefinition.getIndexKeys(), entity);
+			Document mappedKeys = mapper.getMappedSort(indexDefinition.getIndexKeys(), entity);
 			return collection.createIndex(mappedKeys, indexOptions);
 		});
 	}
@@ -223,7 +223,7 @@ public class DefaultIndexOperations implements IndexOperations {
 
 		Assert.isInstanceOf(Document.class, sourceOptions.get(PARTIAL_FILTER_EXPRESSION_KEY));
 		return ops.partialFilterExpression(
-				mapper.getMappedObject((Document) sourceOptions.get(PARTIAL_FILTER_EXPRESSION_KEY), entity));
+				mapper.getMappedSort((Document) sourceOptions.get(PARTIAL_FILTER_EXPRESSION_KEY), entity));
 	}
 
 	private static IndexOptions addDefaultCollationIfRequired(IndexOptions ops, MongoPersistentEntity<?> entity) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -174,7 +174,13 @@ public class QueryMapper {
 			return new Document();
 		}
 
-		Document mappedSort = getMappedObject(sortObject, entity);
+		Document mappedSort = new Document();
+		for(Map.Entry<String,Object> entry : BsonUtils.asMap(sortObject).entrySet()) {
+
+			Field field = createPropertyField(entity, entry.getKey(), mappingContext);
+			mappedSort.put(field.getMappedKey(), entry.getValue());
+		}
+
 		mapMetaAttributes(mappedSort, entity, MetaMapping.WHEN_PRESENT);
 		return mappedSort;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -44,7 +44,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.convert.converter.Converter;
@@ -3711,6 +3710,20 @@ public class MongoTemplateTests {
 		assertThat(target.inner.id).isEqualTo(innerId);
 	}
 
+	@Test // DATAMONGO-2451
+	public void sortOnIdFieldWithExplicitTypeShouldWork() {
+
+		template.dropCollection(WithIdAndFieldAnnotation.class);
+
+		WithIdAndFieldAnnotation f = new WithIdAndFieldAnnotation();
+		f.id = new ObjectId().toHexString();
+		f.value = "value";
+
+		template.save(f);
+
+		assertThat(template.find(new BasicQuery("{}").with(Sort.by("id")), WithIdAndFieldAnnotation.class)).isNotEmpty();
+	}
+
 	private AtomicReference<ImmutableVersioned> createAfterSaveReference() {
 
 		AtomicReference<ImmutableVersioned> saved = new AtomicReference<>();
@@ -4244,5 +4257,15 @@ public class MongoTemplateTests {
 
 		@Field("id") String id;
 		String value;
+	}
+
+	@Data
+	static class WithIdAndFieldAnnotation {
+
+		@Id //
+		@Field(name = "_id") //
+		String id;
+		String value;
+
 	}
 }


### PR DESCRIPTION
Previously we falsely converted the sort value (1/-1) into the id types target value when a `@Field` annotation had been present.