### PR TITLE
DATAMONGO-2406 - Derived reactive deleteBy query execution should allow Mono<Void> result.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2406-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2406-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveMongoQueryExecution.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveMongoQueryExecution.java
@@ -19,6 +19,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 
+import org.reactivestreams.Publisher;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.domain.Pageable;
@@ -168,6 +169,10 @@ interface ReactiveMongoQueryExecution {
 
 			ReturnedType returnedType = processor.getReturnedType();
 
+			if (returnsMonoVoid(returnedType)) {
+				return Flux.from((Publisher) source).then();
+			}
+
 			if (ClassUtils.isPrimitiveOrWrapper(returnedType.getReturnedType())) {
 				return source;
 			}
@@ -181,5 +186,9 @@ interface ReactiveMongoQueryExecution {
 
 			return processor.processResult(source, converter);
 		}
+	}
+
+	static boolean returnsMonoVoid(ReturnedType returnedType) {
+		return returnedType.getReturnedType() == Void.class;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/ReactiveMongoRepositoryTests.java
@@ -17,6 +17,8 @@ package org.springframework.data.mongodb.repository;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.domain.Sort.Direction.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
 import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
 
 import lombok.Data;
@@ -575,6 +577,18 @@ public class ReactiveMongoRepositoryTests {
 				.expectNext("lastname").verifyComplete();
 	}
 
+	@Test // DATAMONGO-2406
+	public void deleteByShouldHandleVoidResultTypeCorrectly() {
+
+		repository.deleteByLastname(dave.getLastname()) //
+				.as(StepVerifier::create) //
+				.verifyComplete();
+
+		template.find(query(where("lastname").is(dave.getLastname())), Person.class) //
+				.as(StepVerifier::create) //
+				.verifyComplete();
+	}
+
 	interface ReactivePersonRepository
 			extends ReactiveMongoRepository<Person, String>, ReactiveQuerydslPredicateExecutor<Person> {
 
@@ -645,6 +659,8 @@ public class ReactiveMongoRepositoryTests {
 
 		@Query(value = "{_id:?0}")
 		Mono<org.bson.Document> findDocumentById(String id);
+
+		Mono<Void> deleteByLastname(String lastname);
 	}
 
 	interface ReactiveContactRepository extends ReactiveMongoRepository<Contact, String> {}


### PR DESCRIPTION
`Mono<Void>` is now a supported return type of derived reactive _deleteBy_ queries like:

```java
Mono<Void> deleteByLastname(String lastname);
```