### PR TITLE
DATAMONGO-2449 - Evaluate allowDiskUse added to Meta annotation when executing derived Aggregation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2449-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2449-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2449-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2449-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -52,6 +52,7 @@ public class Meta {
 	private final Map<String, Object> values = new LinkedHashMap<>(2);
 	private final Set<CursorOption> flags = new LinkedHashSet<>();
 	private Integer cursorBatchSize;
+	private Boolean allowDiskUse;
 
 	public Meta() {}
 
@@ -65,6 +66,7 @@ public class Meta {
 		this.values.putAll(source.values);
 		this.flags.addAll(source.flags);
 		this.cursorBatchSize = source.cursorBatchSize;
+		this.allowDiskUse = source.allowDiskUse;
 	}
 
 	/**
@@ -282,6 +284,27 @@ public class Meta {
 			return false;
 		}
 		return ObjectUtils.nullSafeEquals(this.flags, other.flags);
+	}
+
+	/**
+	 * When set to true, aggregation stages can write data to disk.
+	 *
+	 * @return {@literal null} if not set.
+	 * @since 3.0
+	 */
+	@Nullable
+	public Boolean getAllowDiskUse() {
+		return allowDiskUse;
+	}
+
+	/**
+	 * Set to true, to allow aggregation stages to write data to disk.
+	 *
+	 * @param allowDiskUse use {@literal null} for server defaults.
+	 * @since 3.0
+	 */
+	public void setAllowDiskUse(@Nullable Boolean allowDiskUse) {
+		this.allowDiskUse = allowDiskUse;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Meta.java
@@ -83,4 +83,13 @@ public @interface Meta {
 	 */
 	org.springframework.data.mongodb.core.query.Meta.CursorOption[] flags() default {};
 
+	/**
+	 * When set to true, aggregation stages can write data to disk.
+	 *
+	 * @return {@literal false} by default.
+	 * @since 3.0
+	 * @see Aggregation
+	 */
+	boolean allowDiskUse() default false;
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.repository.query;
 
 import lombok.experimental.UtilityClass;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -91,6 +92,14 @@ class AggregationUtils {
 
 		if (meta.getCursorBatchSize() != null) {
 			builder.cursorBatchSize(meta.getCursorBatchSize());
+		}
+
+		if(meta.getMaxTimeMsec() != null && meta.getMaxTimeMsec() > 0) {
+			builder.maxTime(Duration.ofMillis(meta.getMaxTimeMsec()));
+		}
+
+		if (meta.getAllowDiskUse() != null) {
+			builder.allowDiskUse(meta.getAllowDiskUse());
 		}
 
 		return builder;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -304,6 +304,10 @@ public class MongoQueryMethod extends QueryMethod {
 			}
 		}
 
+		if(meta.allowDiskUse()) {
+			metaAttributes.setAllowDiskUse(meta.allowDiskUse());
+		}
+
 		return metaAttributes;
 	}
 

--- a/src/main/asciidoc/reference/mongo-repositories-aggregation.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories-aggregation.adoc
@@ -11,7 +11,6 @@ The definition may contain simple placeholders like `?0` as well as https://docs
 ----
 public interface PersonRepository extends CrudReppsitory<Person, String> {
 
-
   @Aggregation("{ $group: { _id : $lastname, names : { $addToSet : $firstname } } }")
   List<PersonAggregate> groupByLastnameAndFirstnames();                            <1>
 
@@ -73,6 +72,36 @@ To gain more control, you might consider `AggregationResult` as method return ty
 <7> Obtain the raw `AggregationResults` mapped to the generic target wrapper type `SumValue` or `org.bson.Document`.
 <8> Like in <6>, a single value can be directly obtained from multiple result ``Document``s.
 ====
+
+In some scenarios aggregations might require additional options like a maximum execution time, additional log comments or the permission to temporarily write data to disk.
+Use the `@Meta` annotation to set those options via `maxExecutionTimeMs`, `comment` or `allowDiskUse`.
+
+[source,java]
+----
+public interface PersonRepository extends CrudReppsitory<Person, String> {
+
+  @Meta(allowDiskUse = true)
+  @Aggregation("{ $group: { _id : $lastname, names : { $addToSet : $firstname } } }")
+  List<PersonAggregate> groupByLastnameAndFirstnames();
+}
+----
+
+Or use `@Meta` to create your own annotation as shown in the sample below.
+
+[source,java]
+----
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+@Meta(allowDiskUse = true)
+@interface AllowDiskUse { }
+
+public interface PersonRepository extends CrudReppsitory<Person, String> {
+
+  @AllowDiskUse
+  @Aggregation("{ $group: { _id : $lastname, names : { $addToSet : $firstname } } }")
+  List<PersonAggregate> groupByLastnameAndFirstnames();
+}
+----
 
 TIP: You can use `@Aggregation` also with <<mongo.reactive.repositories, Reactive Repositories>>.
 


### PR DESCRIPTION
In some scenarios aggregations might require additional options like a maximum execution time, additional log comments or the permission to temporarily write data to disk.
Use the `@Meta` annotation to set those options via `maxExecutionTimeMs`, `comment` or `allowDiskUse`.

```java
public interface PersonRepository extends CrudReppsitory<Person, String> {

  @Meta(allowDiskUse = true)
  @Aggregation("{ $group: { _id : $lastname, names : { $addToSet : $firstname } } }")
  List<PersonAggregate> groupByLastnameAndFirstnames();
}
```