### PR TITLE
DATAMONGO-2460 - Fix target type computation for complex id properties with @Field annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2460-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2460-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2460-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2460-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
@@ -79,8 +79,14 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 		this.fieldNamingStrategy = fieldNamingStrategy == null ? PropertyNameFieldNamingStrategy.INSTANCE
 				: fieldNamingStrategy;
 
-		if (isIdProperty() && getFieldName() != ID_FIELD_NAME) {
-			LOG.warn("Customizing field name for id property not allowed! Custom name will not be considered!");
+		if (isIdProperty() && hasExplicitFieldName()) {
+
+			String annotatedName = getAnnotatedFieldName();
+			if (!ID_FIELD_NAME.equals(annotatedName)) {
+				LOG.warn(
+						"Customizing field name for id property '{}.{}' is not allowed! Custom name ('{}') will not be considered!",
+						owner.getName(), getName(), annotatedName);
+			}
 		}
 	}
 
@@ -167,6 +173,11 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 
 		FieldType fieldType = fieldAnnotation.targetType();
 		if (fieldType == FieldType.IMPLICIT) {
+
+			if (isEntity()) {
+				return org.bson.Document.class;
+			}
+
 			return getType();
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -223,6 +224,13 @@ public class BasicMongoPersistentPropertyUnitTests {
 		assertThat(property.getFieldType()).isEqualTo(ObjectId.class);
 	}
 
+	@Test // DATAMONGO-2460
+	public void fieldTypeShouldBeDocumentForPropertiesAnnotatedIdWhenAComplexTypeAndFieldTypeImplicit() {
+
+		MongoPersistentProperty property = getPropertyFor(WithComplexId.class, "id");
+		assertThat(property.getFieldType()).isEqualTo(Document.class);
+	}
+
 	private MongoPersistentProperty getPropertyFor(Field field) {
 		return getPropertyFor(entity, field);
 	}
@@ -328,5 +336,17 @@ public class BasicMongoPersistentPropertyUnitTests {
 	static class WithStringMongoIdMappedToObjectId {
 
 		@MongoId(FieldType.OBJECT_ID) String id;
+	}
+
+	static class ComplexId {
+
+		String value;
+	}
+
+	static class WithComplexId {
+
+		@Id
+		@org.springframework.data.mongodb.core.mapping.Field
+		ComplexId id;
 	}
 }


### PR DESCRIPTION
We now set the target type to `org.bson.Document` for _id_ properties annotated with `@Field` having the implicit target type derived from the annotation. 
Along the lines we fixed warning when an _id_ property with explicit (unsupported) field name is detected.