### PR TITLE
DATAMONGO-2479 - Add AfterConvertCallback and ReactiveAfterConvertCal…

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertCallback.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.springframework.data.mapping.callback.EntityCallback;
+
+/**
+ * Callback being invoked after a domain object is converted from a Document (when reading from the DB).
+ *
+ * @author Mark Paluch
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface AfterConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is converted from a Document. Can return either the same
+	 * or a modified instance of the domain object.
+	 *
+	 * @param entity the domain object (the result of the conversion).
+	 * @param document must not be {@literal null}.
+	 * @param collection name of the collection.
+	 * @return the domain object that is the result of the conversion from the Document.
+	 */
+	T onAfterConvert(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterConvertCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Callback being invoked after a domain object is converted from a Document (when reading from the DB).
+ *
+ * @author Mark Paluch
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ * @see ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface ReactiveAfterConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is converted from a Document. Can return either the same
+	 * or a modified instance of the domain object.
+	 *
+	 * @param entity the domain object (the result of the conversion).
+	 * @param document must not be {@literal null}.
+	 * @param collection name of the collection.
+	 * @return a {@link Publisher} emitting the domain object that is the result of the conversion from the Document.
+	 */
+	Publisher<T> onAfterConvert(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UncustomizableFindPublisher.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UncustomizableFindPublisher.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import com.mongodb.CursorType;
+import com.mongodb.reactivestreams.client.FindPublisher;
+import lombok.RequiredArgsConstructor;
+import org.bson.conversions.Bson;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link FindPublisher} implementation which does nothing in all FindPublisher's eigen methods, but delegates
+ * {@link #subscribe(Subscriber)} call to a {@link Publisher} passed in the constructor.
+ *
+ * @author Roman Puchkovskiy
+ */
+@RequiredArgsConstructor
+class UncustomizableFindPublisher<T> implements FindPublisher<T> {
+	private final Publisher<T> realPublisher;
+
+	@Override
+	public Publisher<T> first() {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> filter(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> limit(int i) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> skip(int i) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> maxTime(long l, TimeUnit timeUnit) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> maxAwaitTime(long l, TimeUnit timeUnit) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> projection(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> sort(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> noCursorTimeout(boolean b) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> oplogReplay(boolean b) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> partial(boolean b) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> cursorType(CursorType cursorType) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> collation(com.mongodb.client.model.Collation collation) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> comment(String s) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> hint(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> hintString(String s) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> max(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> min(Bson bson) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> returnKey(boolean b) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> showRecordId(boolean b) {
+		return this;
+	}
+
+	@Override
+	public FindPublisher<T> batchSize(int i) {
+		return this;
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> subscriber) {
+		realPublisher.subscribe(subscriber);
+	}
+}


### PR DESCRIPTION
…lback.

Currently, only BeforeConvertCallback and BeforeSaveCallback are supported (and their reactive counterparts). This PR adds support for 'after-convert' event using entity callbacks feature.

Please note that I changed ReactiveMongoTemplate.DocumentCallback interface making its only method reactive. It seems ok because it is only used inside reactive contexts (actually, it was only called when doing a `map()` on a `Flux`/`Mono`, so now it is used in `concatMap()`/`flatMap()`).

I've only implemented one callback type ('after-convert') for now because I'd like to get an opinion from project member(s) on this issue: am I on the right track, or maybe it should not be implemented at all. After all, the original authors only implemented 2 callbacks for some reason.

What do you think?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
