### PR TITLE
DATAMONGO-2479 - Add AfterConvertCallback and AfterSaveCallback (and …

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -74,16 +74,7 @@ import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
 import org.springframework.data.mongodb.core.aggregation.PrefixingDelegatingAggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.TypeBasedAggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
-import org.springframework.data.mongodb.core.convert.DbRefResolver;
-import org.springframework.data.mongodb.core.convert.JsonSchemaMapper;
-import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import org.springframework.data.mongodb.core.convert.MongoJsonSchemaMapper;
-import org.springframework.data.mongodb.core.convert.MongoWriter;
-import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
-import org.springframework.data.mongodb.core.convert.QueryMapper;
-import org.springframework.data.mongodb.core.convert.UpdateMapper;
+import org.springframework.data.mongodb.core.convert.*;
 import org.springframework.data.mongodb.core.index.MongoMappingEventPublisher;
 import org.springframework.data.mongodb.core.index.ReactiveIndexOperations;
 import org.springframework.data.mongodb.core.index.ReactiveMongoPersistentEntityIndexCreator;
@@ -91,16 +82,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.mapping.MongoSimpleTypes;
-import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
-import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
-import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent;
-import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
-import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
-import org.springframework.data.mongodb.core.mapping.event.BeforeSaveEvent;
-import org.springframework.data.mongodb.core.mapping.event.MongoMappingEvent;
-import org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeConvertCallback;
-import org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeSaveCallback;
+import org.springframework.data.mongodb.core.mapping.event.*;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Meta;
@@ -127,16 +109,7 @@ import com.mongodb.CursorType;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
-import com.mongodb.client.model.CountOptions;
-import com.mongodb.client.model.CreateCollectionOptions;
-import com.mongodb.client.model.DeleteOptions;
-import com.mongodb.client.model.FindOneAndDeleteOptions;
-import com.mongodb.client.model.FindOneAndReplaceOptions;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.ReplaceOptions;
-import com.mongodb.client.model.ReturnDocument;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.ValidationOptions;
+import com.mongodb.client.model.*;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
@@ -163,6 +136,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Roman Puchkovskiy
  * @since 2.0
  */
 public class ReactiveMongoTemplate implements ReactiveMongoOperations, ApplicationContextAware {
@@ -1050,7 +1024,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			cursor = cursor.maxTime(options.getMaxTime().toMillis(), TimeUnit.MILLISECONDS);
 		}
 
-		return Flux.from(cursor).map(readCallback::doWith);
+		return Flux.from(cursor).concatMap(readCallback::doWith);
 	}
 
 	/*
@@ -1093,7 +1067,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 				.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
 
 		return aggregate($geoNear, collection, Document.class) //
-				.map(callback::doWith);
+				.concatMap(callback::doWith);
 	}
 
 	/*
@@ -1186,9 +1160,13 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 				}).flatMap(it -> {
 
 					PersistableEntityModel<S> flowObject = (PersistableEntityModel<S>) it;
-					return doFindAndReplace(flowObject.getCollection(), mappedQuery, mappedFields, mappedSort,
-							queryContext.getCollation(entityType).orElse(null), entityType, flowObject.getTarget(), options,
-							resultType);
+					Mono<T> afterFindAndReplace = doFindAndReplace(flowObject.getCollection(), mappedQuery,
+							mappedFields, mappedSort, queryContext.getCollation(entityType).orElse(null),
+							entityType, flowObject.getTarget(), options, resultType);
+					return afterFindAndReplace.flatMap(saved -> {
+						maybeEmitEvent(new AfterSaveEvent<>(saved, flowObject.getTarget(), flowObject.getCollection()));
+						return maybeCallAfterSave(saved, flowObject.getTarget(), flowObject.getCollection());
+					});
 				});
 	}
 
@@ -1345,12 +1323,12 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 				}).flatMap(it -> {
 
-					return insertDocument(it.getCollection(), it.getTarget(), it.getSource().getClass()).map(id -> {
+					return insertDocument(it.getCollection(), it.getTarget(), it.getSource().getClass()).flatMap(id -> {
 
 						T saved = operations.forEntity(it.getSource(), mongoConverter.getConversionService())
 								.populateIdIfNecessary(id);
 						maybeEmitEvent(new AfterSaveEvent<>(saved, it.getTarget(), collectionName));
-						return saved;
+						return maybeCallAfterSave(saved, it.getTarget(), collectionName);
 					});
 				});
 	}
@@ -1436,13 +1414,14 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			return insertDocumentList(collectionName, documents).thenMany(Flux.fromIterable(tuples));
 		});
 
-		return insertDocuments.map(tuple -> {
+		return insertDocuments.flatMap(tuple -> {
 
-			Object id = MappedDocument.of(tuple.getT2()).getId();
+			Document document = tuple.getT2();
+			Object id = MappedDocument.of(document).getId();
 
 			T saved = tuple.getT1().populateIdIfNecessary(id);
-			maybeEmitEvent(new AfterSaveEvent<>(saved, tuple.getT2(), collectionName));
-			return saved;
+			maybeEmitEvent(new AfterSaveEvent<>(saved, document, collectionName));
+			return maybeCallAfterSave(saved, document, collectionName);
 		});
 	}
 
@@ -1522,9 +1501,11 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 				maybeEmitEvent(new BeforeSaveEvent<>(toConvert, document, collectionName));
 				return maybeCallBeforeSave(toConvert, document, collectionName).flatMap(it -> {
 
-					return doUpdate(collectionName, query, mapped.updateWithoutId(), it.getClass(), false, false).map(result -> {
-						return maybeEmitEvent(new AfterSaveEvent<T>(it, document, collectionName)).getSource();
-					});
+					return doUpdate(collectionName, query, mapped.updateWithoutId(), it.getClass(), false, false)
+							.flatMap(result -> {
+								maybeEmitEvent(new AfterSaveEvent<T>(it, document, collectionName));
+								return maybeCallAfterSave(it, document, collectionName);
+							});
 				});
 			});
 		});
@@ -1546,10 +1527,11 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 				return maybeCallBeforeSave(toConvert, dbDoc, collectionName).flatMap(it -> {
 
-					return saveDocument(collectionName, dbDoc, it.getClass()).map(id -> {
+					return saveDocument(collectionName, dbDoc, it.getClass()).flatMap(id -> {
 
 						T saved = entity.populateIdIfNecessary(id);
-						return maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName)).getSource();
+						maybeEmitEvent(new AfterSaveEvent<>(saved, dbDoc, collectionName));
+						return maybeCallAfterSave(saved, dbDoc, collectionName);
 					});
 				});
 			});
@@ -2213,7 +2195,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			publisher = collation.map(Collation::toMongoCollation).map(publisher::collation).orElse(publisher);
 
 			return Flux.from(publisher)
-					.map(new ReadDocumentCallback<>(mongoConverter, resultType, inputCollectionName)::doWith);
+					.concatMap(new ReadDocumentCallback<>(mongoConverter, resultType, inputCollectionName)::doWith);
 		});
 	}
 
@@ -2613,7 +2595,6 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		return event;
 	}
 
-	@SuppressWarnings("unchecked")
 	protected <T> Mono<T> maybeCallBeforeConvert(T object, String collection) {
 
 		if (null != entityCallbacks) {
@@ -2623,11 +2604,28 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		return Mono.just(object);
 	}
 
-	@SuppressWarnings("unchecked")
 	protected <T> Mono<T> maybeCallBeforeSave(T object, Document document, String collection) {
 
 		if (null != entityCallbacks) {
 			return entityCallbacks.callback(ReactiveBeforeSaveCallback.class, object, document, collection);
+		}
+
+		return Mono.just(object);
+	}
+
+	protected <T> Mono<T> maybeCallAfterSave(T object, Document document, String collection) {
+
+		if (null != entityCallbacks) {
+			return entityCallbacks.callback(ReactiveAfterSaveCallback.class, object, document, collection);
+		}
+
+		return Mono.just(object);
+	}
+
+	protected <T> Mono<T> maybeCallAfterConvert(T object, Document document, String collection) {
+
+		if (null != entityCallbacks) {
+			return entityCallbacks.callback(ReactiveAfterConvertCallback.class, object, document, collection);
 		}
 
 		return Mono.just(object);
@@ -2720,7 +2718,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			DocumentCallback<T> objectCallback, String collectionName) {
 
 		return createMono(collectionName,
-				collection -> Mono.from(collectionCallback.doInCollection(collection)).map(objectCallback::doWith));
+				collection -> Mono.from(collectionCallback.doInCollection(collection)).flatMap(objectCallback::doWith));
 	}
 
 	/**
@@ -2746,7 +2744,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		return createFlux(collectionName, collection -> {
 			return Flux.from(preparer.initiateFind(collection, collectionCallback::doInCollection))
-					.map(objectCallback::doWith);
+					.concatMap(objectCallback::doWith);
 		});
 	}
 
@@ -3042,7 +3040,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 	interface DocumentCallback<T> {
 
-		T doWith(Document object);
+		Mono<T> doWith(Document object);
 	}
 
 	/**
@@ -3071,6 +3069,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 * {@link EntityReader}.
 	 *
 	 * @author Mark Paluch
+	 * @author Roman Puchkovskiy
 	 */
 	class ReadDocumentCallback<T> implements DocumentCallback<T> {
 
@@ -3088,27 +3087,33 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			this.collectionName = collectionName;
 		}
 
-		public T doWith(@Nullable Document object) {
+		public Mono<T> doWith(Document document) {
 
-			if (null != object) {
-				maybeEmitEvent(new AfterLoadEvent<>(object, type, collectionName));
-			}
-			T source = reader.read(type, object);
+			maybeEmitEvent(new AfterLoadEvent<>(document, type, collectionName));
+
+			T source = reader.read(type, document);
 			if (null != source) {
-				maybeEmitEvent(new AfterConvertEvent<>(object, source, collectionName));
+				maybeEmitEvent(new AfterConvertEvent<>(document, source, collectionName));
 			}
-			return source;
+			return Mono.defer(() -> {
+				if (null != source) {
+					return maybeCallAfterConvert(source, document, collectionName);
+				} else {
+					return Mono.empty();
+				}
+			});
 		}
 	}
 
 	/**
-	 * {@link MongoTemplate.DocumentCallback} transforming {@link Document} into the given {@code targetType} or
+	 * {@link DocumentCallback} transforming {@link Document} into the given {@code targetType} or
 	 * decorating the {@code sourceType} with a {@literal projection} in case the {@code targetType} is an
-	 * {@litera interface}.
+	 * {@literal interface}.
 	 *
 	 * @param <S>
 	 * @param <T>
 	 * @author Christoph Strobl
+	 * @author Roman Puchkovskiy
 	 * @since 2.0
 	 */
 	@RequiredArgsConstructor
@@ -3119,29 +3124,30 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		private final @NonNull Class<T> targetType;
 		private final @NonNull String collectionName;
 
-		@Nullable
 		@SuppressWarnings("unchecked")
-		public T doWith(@Nullable Document object) {
-
-			if (object == null) {
-				return null;
-			}
+		public Mono<T> doWith(Document document) {
 
 			Class<?> typeToRead = targetType.isInterface() || targetType.isAssignableFrom(entityType) //
 					? entityType //
 					: targetType;
 
-			if (null != object) {
-				maybeEmitEvent(new AfterLoadEvent<>(object, typeToRead, collectionName));
-			}
+			maybeEmitEvent(new AfterLoadEvent<>(document, typeToRead, collectionName));
 
-			Object source = reader.read(typeToRead, object);
+			Object source = reader.read(typeToRead, document);
 			Object result = targetType.isInterface() ? projectionFactory.createProjection(targetType, source) : source;
 
-			if (null != source) {
-				maybeEmitEvent(new AfterConvertEvent<>(object, result, collectionName));
+			T castEntity = (T) result;
+			if (null != castEntity) {
+				maybeEmitEvent(new AfterConvertEvent<>(document, castEntity, collectionName));
 			}
-			return (T) result;
+
+			return Mono.defer(() -> {
+				if (null != castEntity) {
+					return maybeCallAfterConvert(castEntity, document, collectionName);
+				} else {
+					return Mono.empty();
+				}
+			});
 		}
 	}
 
@@ -3151,6 +3157,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 *
 	 * @author Mark Paluch
 	 * @author Chrstoph Strobl
+	 * @author Roman Puchkovskiy
 	 */
 	static class GeoNearResultDocumentCallback<T> implements DocumentCallback<GeoResult<T>> {
 
@@ -3175,16 +3182,17 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			this.metric = metric;
 		}
 
-		public GeoResult<T> doWith(Document object) {
+		public Mono<GeoResult<T>> doWith(Document object) {
 
-			double distance = Double.NaN;
+			final double distance;
 			if (object.containsKey(distanceField)) {
 				distance = NumberUtils.convertNumberToTargetClass(object.get(distanceField, Number.class), Double.class);
+			} else {
+				distance = Double.NaN;
 			}
-
-			T doWith = delegate.doWith(object);
-
-			return new GeoResult<>(doWith, new Distance(distance, metric));
+			
+			return delegate.doWith(object)
+					.map(doWith -> new GeoResult<>(doWith, new Distance(distance, metric)));
 		}
 	}
 
@@ -3202,7 +3210,6 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			this.type = type;
 		}
 
-		@SuppressWarnings("deprecation")
 		public FindPublisher<Document> prepare(FindPublisher<Document> findPublisher) {
 
 			FindPublisher<Document> findPublisherToUse = operations.forType(type) //

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterConvertCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.springframework.data.mapping.callback.EntityCallback;
+
+/**
+ * Callback being invoked after a domain object is converted from a Document (when reading from the DB).
+ *
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface AfterConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is converted from a Document. Can return either the same
+	 * or a modified instance of the domain object.
+	 *
+	 * @param entity the domain object (the result of the conversion).
+	 * @param document must not be {@literal null}.
+	 * @param collection name of the collection.
+	 * @return the domain object that is the result of the conversion from the Document.
+	 */
+	T onAfterConvert(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/AfterSaveCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.springframework.data.mapping.callback.EntityCallback;
+
+/**
+ * Entity callback triggered after save of a document.
+ *
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface AfterSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is saved. Can return either the same or a modified instance
+	 * of the domain object.
+	 *
+	 * @param entity the domain object that was saved.
+	 * @param document {@link Document} representing the {@code entity}.
+	 * @param collection name of the collection.
+	 * @return the domain object that was persisted.
+	 */
+	T onAfterSave(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterConvertCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterConvertCallback.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Callback being invoked after a domain object is converted from a Document (when reading from the DB).
+ *
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ * @see ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface ReactiveAfterConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is converted from a Document. Can return either the same
+	 * or a modified instance of the domain object.
+	 *
+	 * @param entity the domain object (the result of the conversion).
+	 * @param document must not be {@literal null}.
+	 * @param collection name of the collection.
+	 * @return a {@link Publisher} emitting the domain object that is the result of the conversion from the Document.
+	 */
+	Publisher<T> onAfterConvert(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterSaveCallback.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/event/ReactiveAfterSaveCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping.event;
+
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Entity callback triggered after save of a document.
+ *
+ * @author Roman Puchkovskiy
+ * @since 3.0
+ * @see ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface ReactiveAfterSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is saved. Can return either the same or a modified instance
+	 * of the domain object.
+	 *
+	 * @param entity the domain object that was saved.
+	 * @param document {@link Document} representing the {@code entity}.
+	 * @param collection name of the collection.
+	 * @return a {@link Publisher} emitting the domain object to be returned to the caller.
+	 */
+	Publisher<T> onAfterSave(T entity, Document document, String collection);
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultBulkOperationsUnitTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.convert.UpdateMapper;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveCallback;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
@@ -83,6 +84,7 @@ import com.mongodb.client.model.WriteModel;
  * @author Mark Paluch
  * @author Minsu Kim
  * @author Jens Schauder
+ * @author Roman Puchkovskiy
  */
 @ExtendWith(MockitoExtension.class)
 class DefaultBulkOperationsUnitTests {
@@ -207,16 +209,17 @@ class DefaultBulkOperationsUnitTests {
 		assertThat(updateModel.getReplacement().getString("lastName")).isEqualTo("Kim");
 	}
 
-	@Test // DATAMONGO-2261
+	@Test // DATAMONGO-2261, DATAMONGO-2479
 	void bulkInsertInvokesEntityCallbacks() {
 
 		BeforeConvertPersonCallback beforeConvertCallback = spy(new BeforeConvertPersonCallback());
 		BeforeSavePersonCallback beforeSaveCallback = spy(new BeforeSavePersonCallback());
+		AfterSavePersonCallback afterSaveCallback = spy(new AfterSavePersonCallback());
 
 		ops = new DefaultBulkOperations(template, "collection-1",
 				new BulkOperationContext(BulkMode.ORDERED, Optional.of(mappingContext.getPersistentEntity(Person.class)),
 						new QueryMapper(converter), new UpdateMapper(converter), null,
-						EntityCallbacks.create(beforeConvertCallback, beforeSaveCallback)));
+						EntityCallbacks.create(beforeConvertCallback, beforeSaveCallback, afterSaveCallback)));
 
 		Person entity = new Person("init");
 		ops.insert(entity);
@@ -228,11 +231,13 @@ class DefaultBulkOperationsUnitTests {
 		ops.execute();
 
 		verify(beforeSaveCallback).onBeforeSave(personArgumentCaptor.capture(), any(), eq("collection-1"));
-		assertThat(personArgumentCaptor.getAllValues()).extracting("firstName").containsExactly("init", "before-convert");
+		verify(afterSaveCallback).onAfterSave(personArgumentCaptor.capture(), any(), eq("collection-1"));
+		assertThat(personArgumentCaptor.getAllValues()).extracting("firstName")
+				.containsExactly("init", "before-convert", "before-convert");
 		verify(collection).bulkWrite(captor.capture(), any());
 
 		InsertOneModel<Document> updateModel = (InsertOneModel<Document>) captor.getValue().get(0);
-		assertThat(updateModel.getDocument()).containsEntry("firstName", "before-save");
+		assertThat(updateModel.getDocument()).containsEntry("firstName", "after-save");
 	}
 
 	@Test // DATAMONGO-2290
@@ -361,6 +366,16 @@ class DefaultBulkOperationsUnitTests {
 
 			document.put("firstName", "before-save");
 			return new Person("before-save");
+		}
+	}
+
+	static class AfterSavePersonCallback implements AfterSaveCallback<Person> {
+
+		@Override
+		public Person onAfterSave(Person entity, Document document, String collection) {
+
+			document.put("firstName", "after-save");
+			return new Person("after-save");
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
+import org.assertj.core.api.Assertions;
 import org.bson.types.Code;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
@@ -46,6 +47,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
@@ -62,6 +64,7 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 import org.springframework.data.geo.Shape;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.mapping.model.MappingInstantiationException;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
 import org.springframework.data.mongodb.core.convert.DocumentAccessorUnitTests.NestedType;
@@ -75,6 +78,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.mapping.PersonPojoStringId;
 import org.springframework.data.mongodb.core.mapping.TextScore;
+import org.springframework.data.mongodb.core.mapping.event.AfterConvertCallback;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -90,6 +94,7 @@ import com.mongodb.DBRef;
  * @author Patrik Wasik
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Roman Puchkovskiy
  */
 @ExtendWith(MockitoExtension.class)
 public class MappingMongoConverterUnitTests {
@@ -2103,6 +2108,62 @@ public class MappingMongoConverterUnitTests {
 				.isEqualTo(new BasicDBObject("property", "value"));
 	}
 
+	@Test // DATAMONGO-2479
+	public void entityCallbacksAreNotSetByDefault() {
+		Assertions.assertThat(ReflectionTestUtils.getField(converter, "entityCallbacks")).isNull();
+	}
+
+	@Test // DATAMONGO-2479
+	public void entityCallbacksShouldBeInitiatedOnSettingApplicationContext() {
+
+		ApplicationContext ctx = new StaticApplicationContext();
+		converter.setApplicationContext(ctx);
+
+		Assertions.assertThat(ReflectionTestUtils.getField(converter, "entityCallbacks")).isNotNull();
+	}
+
+	@Test // DATAMONGO-2479
+	public void setterForEntityCallbackOverridesContextInitializedOnes() {
+
+		ApplicationContext ctx = new StaticApplicationContext();
+		converter.setApplicationContext(ctx);
+
+		EntityCallbacks callbacks = EntityCallbacks.create();
+		converter.setEntityCallbacks(callbacks);
+
+		Assertions.assertThat(ReflectionTestUtils.getField(converter, "entityCallbacks")).isSameAs(callbacks);
+	}
+
+	@Test // DATAMONGO-2479
+	public void setterForApplicationContextShouldNotOverrideAlreadySetEntityCallbacks() {
+
+		EntityCallbacks callbacks = EntityCallbacks.create();
+		ApplicationContext ctx = new StaticApplicationContext();
+
+		converter.setEntityCallbacks(callbacks);
+		converter.setApplicationContext(ctx);
+
+		Assertions.assertThat(ReflectionTestUtils.getField(converter, "entityCallbacks")).isSameAs(callbacks);
+	}
+
+	@Test // DATAMONGO-2479
+	public void resolveDBRefMapValueShouldInvokeCallbacks() {
+
+		AfterConvertCallback<Person> afterConvertCallback = spy(new ReturningAfterConvertCallback());
+		converter.setEntityCallbacks(EntityCallbacks.create(afterConvertCallback));
+
+		when(resolver.fetch(Mockito.any(DBRef.class))).thenReturn(new org.bson.Document());
+		DBRef dbRef = mock(DBRef.class);
+
+		org.bson.Document refMap = new org.bson.Document("foo", dbRef);
+		org.bson.Document document = new org.bson.Document("personMap", refMap);
+
+		DBRefWrapper result = converter.read(DBRefWrapper.class, document);
+		
+		verify(afterConvertCallback).onAfterConvert(eq(result.personMap.get("foo")),
+				eq(new org.bson.Document()), any());
+	}
+
 	static class GenericType<T> {
 		T content;
 	}
@@ -2565,4 +2626,12 @@ public class MappingMongoConverterUnitTests {
 		Date dateAsObjectId;
 	}
 
+	static class ReturningAfterConvertCallback implements AfterConvertCallback<Person> {
+
+		@Override
+		public Person onAfterConvert(Person entity, org.bson.Document document, String collection) {
+
+			return entity;
+		}
+	}
 }


### PR DESCRIPTION
…their reactive versions).

Previously, only BeforeConvertCallback and BeforeSaveCallback were supported (and their reactive counterparts). This commit adds support for 'after-convert' and 'after-save' events using entity callbacks feature.

Please note that I changed `ReactiveMongoTemplate.DocumentCallback` interface making its only method reactive. It seems ok because it is only used inside reactive contexts (actually, it was only called when doing a `map()` on a `Flux`/`Mono`, so now it is used in `concatMap()`/`flatMap()`).

This supersedes https://github.com/spring-projects/spring-data-mongodb/pull/837 , so I am closing that.

What do you think?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
