### PR TITLE
DATAMONGO-2416 - Add convenience methods accepting CriteriaDefinition on Fluent API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2416-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2416-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.geo.GeoResults;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.lang.Nullable;
@@ -169,6 +170,18 @@ public interface ExecutableFindOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingFind<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingFind}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingFind<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 
 		/**
 		 * Set the filter query for the geoNear execution.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperation.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.ExecutableFindOperation.ExecutableFind;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 
 /**
@@ -30,7 +31,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * The collection to operate on is by default derived from the initial {@literal domainType} and can be defined there
  * via {@link org.springframework.data.mongodb.core.mapping.Document}. Using {@code inCollection} allows to override the
  * collection name for the execution.
- * 
+ *
  * <pre>
  *     <code>
  *         mapReduce(Human.class)
@@ -44,6 +45,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * </pre>
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.1
  */
 public interface ExecutableMapReduceOperation {
@@ -146,6 +148,18 @@ public interface ExecutableMapReduceOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingMapReduce<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingMapReduce}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingMapReduce<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.core;
 
 import java.util.List;
 
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 
 import com.mongodb.client.result.DeleteResult;
@@ -119,6 +120,18 @@ public interface ExecutableRemoveOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingRemove<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingRemove}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingRemove<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableUpdateOperation.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
@@ -210,6 +211,18 @@ public interface ExecutableUpdateOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		UpdateWithUpdate<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithUpdate}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default UpdateWithUpdate<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
@@ -19,6 +19,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.data.geo.GeoResult;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -143,6 +144,18 @@ public interface ReactiveFindOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingFind<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingFind}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingFind<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 
 		/**
 		 * Set the filter query for the geoNear execution.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMapReduceOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMapReduceOperation.java
@@ -19,6 +19,7 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.data.mongodb.core.ExecutableFindOperation.ExecutableFind;
 import org.springframework.data.mongodb.core.mapreduce.MapReduceOptions;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 
 /**
@@ -30,7 +31,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * The collection to operate on is by default derived from the initial {@literal domainType} and can be defined there
  * via {@link org.springframework.data.mongodb.core.mapping.Document}. Using {@code inCollection} allows to override the
  * collection name for the execution.
- * 
+ *
  * <pre>
  *     <code>
  *         mapReduce(Human.class)
@@ -146,6 +147,18 @@ public interface ReactiveMapReduceOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingMapReduce<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingMapReduce}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingMapReduce<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveRemoveOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveRemoveOperation.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 
 import com.mongodb.client.result.DeleteResult;
@@ -106,6 +107,18 @@ public interface ReactiveRemoveOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		TerminatingRemove<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingRemove}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingRemove<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	interface ReactiveRemove<T> extends RemoveWithCollection<T> {}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveUpdateOperation.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.data.mongodb.core;
 
-import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
-import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import reactor.core.publisher.Mono;
 
+import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 
 import com.mongodb.client.result.UpdateResult;
 
@@ -171,6 +172,18 @@ public interface ReactiveUpdateOperation {
 		 * @throws IllegalArgumentException if query is {@literal null}.
 		 */
 		UpdateWithUpdate<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithUpdate}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default UpdateWithUpdate<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -95,6 +95,8 @@ public class Query {
 	 */
 	public Query addCriteria(CriteriaDefinition criteriaDefinition) {
 
+		Assert.notNull(criteriaDefinition, "CriteriaDefinition must not be null!");
+
 		CriteriaDefinition existing = this.criteria.get(criteriaDefinition.getKey());
 		String key = criteriaDefinition.getKey();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -55,22 +55,22 @@ import org.springframework.data.mongodb.test.util.Template;
  * @author Mark Paluch
  */
 @ExtendWith(MongoTemplateExtension.class)
-public class ExecutableFindOperationSupportTests {
+class ExecutableFindOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
 	private static final String STAR_WARS_PLANETS = "star-wars-universe";
 
 	@Template(database = "executable-find-operation-support-tests", initialEntitySet = { Person.class, Planet.class }) //
-	static MongoTestTemplate template;
+	private static MongoTestTemplate template;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
-	Planet alderan;
-	Planet dantooine;
+	private Planet alderan;
+	private Planet dantooine;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		template.flush();
 
@@ -82,37 +82,37 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void domainTypeIsRequired() {
+	void domainTypeIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void returnTypeIsRequiredOnSet() {
+	void returnTypeIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(Person.class).as(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void collectionIsRequiredOnSet() {
+	void collectionIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(Person.class).inCollection(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAll() {
+	void findAll() {
 		assertThat(template.query(Person.class).all()).containsExactlyInAnyOrder(han, luke);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllWithCollection() {
+	void findAllWithCollection() {
 		assertThat(template.query(Human.class).inCollection(STAR_WARS).all()).hasSize(2);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllWithProjection() {
+	void findAllWithProjection() {
 		assertThat(template.query(Person.class).as(Jedi.class).all()).hasOnlyElementsOfType(Jedi.class).hasSize(2);
 	}
 
 	@Test // DATAMONGO-2041
-	public void findAllWithProjectionOnEmbeddedType() {
+	void findAllWithProjectionOnEmbeddedType() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -124,94 +124,94 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void findByReturningAllValuesAsClosedInterfaceProjection() {
+	void findByReturningAllValuesAsClosedInterfaceProjection() {
 
 		assertThat(template.query(Person.class).as(PersonProjection.class).all())
 				.hasOnlyElementsOfTypes(PersonProjection.class);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllBy() {
+	void findAllBy() {
 
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).all())
 				.containsExactlyInAnyOrder(luke);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllByWithCollectionUsingMappingInformation() {
+	void findAllByWithCollectionUsingMappingInformation() {
 
 		assertThat(template.query(Jedi.class).inCollection(STAR_WARS).matching(query(where("name").is("luke"))).all())
 				.hasSize(1).hasOnlyElementsOfType(Jedi.class);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllByWithCollection() {
+	void findAllByWithCollection() {
 		assertThat(template.query(Human.class).inCollection(STAR_WARS).matching(query(where("firstname").is("luke"))).all())
 				.hasSize(1);
 	}
 
 	@Test // DATAMONGO-2323
-	public void findAllAsDocument() {
+	void findAllAsDocument() {
 		assertThat(
 				template.query(Document.class).inCollection(STAR_WARS).matching(query(where("firstname").is("luke"))).all())
 						.hasSize(1);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllByWithProjection() {
+	void findAllByWithProjection() {
 
 		assertThat(template.query(Person.class).as(Jedi.class).matching(query(where("firstname").is("luke"))).all())
 				.hasOnlyElementsOfType(Jedi.class).hasSize(1);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findBy() {
+	void findBy() {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).one()).contains(luke);
 	}
 
 	@Test // DATAMONGO-2416
-	public void findByCriteria() {
+	void findByCriteria() {
 		assertThat(template.query(Person.class).matching(where("firstname").is("luke")).one()).contains(luke);
 	}
 
 	@Test // DATAMONGO-1563
-	public void findByNoMatch() {
+	void findByNoMatch() {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("spock"))).one()).isEmpty();
 	}
 
 	@Test // DATAMONGO-1563
-	public void findByTooManyResults() {
+	void findByTooManyResults() {
 		assertThatExceptionOfType(IncorrectResultSizeDataAccessException.class)
 				.isThrownBy(() -> template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).one());
 	}
 
 	@Test // DATAMONGO-1726
-	public void findByReturningOneValue() {
+	void findByReturningOneValue() {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).oneValue()).isEqualTo(luke);
 	}
 
 	@Test // DATAMONGO-1726
-	public void findByReturningOneValueButTooManyResults() {
+	void findByReturningOneValueButTooManyResults() {
 		assertThatExceptionOfType(IncorrectResultSizeDataAccessException.class).isThrownBy(
 				() -> template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).oneValue());
 	}
 
 	@Test // DATAMONGO-1726
-	public void findByReturningFirstValue() {
+	void findByReturningFirstValue() {
 
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).firstValue())
 				.isEqualTo(luke);
 	}
 
 	@Test // DATAMONGO-1726
-	public void findByReturningFirstValueForManyResults() {
+	void findByReturningFirstValueForManyResults() {
 
 		assertThat(template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).firstValue())
 				.isIn(han, luke);
 	}
 
 	@Test // DATAMONGO-1733
-	public void findByReturningFirstValueAsClosedInterfaceProjection() {
+	void findByReturningFirstValueAsClosedInterfaceProjection() {
 
 		PersonProjection result = template.query(Person.class).as(PersonProjection.class)
 				.matching(query(where("firstname").is("han"))).firstValue();
@@ -221,7 +221,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void findByReturningFirstValueAsOpenInterfaceProjection() {
+	void findByReturningFirstValueAsOpenInterfaceProjection() {
 
 		PersonSpELProjection result = template.query(Person.class).as(PersonSpELProjection.class)
 				.matching(query(where("firstname").is("han"))).firstValue();
@@ -231,7 +231,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void streamAll() {
+	void streamAll() {
 
 		try (Stream<Person> stream = template.query(Person.class).stream()) {
 			assertThat(stream).containsExactlyInAnyOrder(han, luke);
@@ -239,7 +239,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void streamAllWithCollection() {
+	void streamAllWithCollection() {
 
 		try (Stream<Human> stream = template.query(Human.class).inCollection(STAR_WARS).stream()) {
 			assertThat(stream).hasSize(2);
@@ -247,7 +247,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void streamAllWithProjection() {
+	void streamAllWithProjection() {
 
 		try (Stream<Jedi> stream = template.query(Person.class).as(Jedi.class).stream()) {
 			assertThat(stream).hasOnlyElementsOfType(Jedi.class).hasSize(2);
@@ -255,7 +255,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void streamAllReturningResultsAsClosedInterfaceProjection() {
+	void streamAllReturningResultsAsClosedInterfaceProjection() {
 
 		TerminatingFind<PersonProjection> operation = template.query(Person.class).as(PersonProjection.class);
 
@@ -268,7 +268,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void streamAllReturningResultsAsOpenInterfaceProjection() {
+	void streamAllReturningResultsAsOpenInterfaceProjection() {
 
 		TerminatingFind<PersonSpELProjection> operation = template.query(Person.class).as(PersonSpELProjection.class);
 
@@ -281,7 +281,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void streamAllBy() {
+	void streamAllBy() {
 
 		try (Stream<Person> stream = template.query(Person.class).matching(query(where("firstname").is("luke"))).stream()) {
 			assertThat(stream).containsExactlyInAnyOrder(luke);
@@ -289,7 +289,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllNearBy() {
+	void findAllNearBy() {
 
 		GeoResults<Planet> results = template.query(Planet.class).near(NearQuery.near(-73.9667, 40.78).spherical(true))
 				.all();
@@ -298,7 +298,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAllNearByWithCollectionAndProjection() {
+	void findAllNearByWithCollectionAndProjection() {
 
 		GeoResults<Human> results = template.query(Object.class).inCollection(STAR_WARS_PLANETS).as(Human.class)
 				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
@@ -310,7 +310,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void findAllNearByReturningGeoResultContentAsClosedInterfaceProjection() {
+	void findAllNearByReturningGeoResultContentAsClosedInterfaceProjection() {
 
 		GeoResults<PlanetProjection> results = template.query(Planet.class).as(PlanetProjection.class)
 				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
@@ -323,7 +323,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1733
-	public void findAllNearByReturningGeoResultContentAsOpenInterfaceProjection() {
+	void findAllNearByReturningGeoResultContentAsOpenInterfaceProjection() {
 
 		GeoResults<PlanetSpELProjection> results = template.query(Planet.class).as(PlanetSpELProjection.class)
 				.near(NearQuery.near(-73.9667, 40.78).spherical(true)).all();
@@ -336,29 +336,29 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1728
-	public void firstShouldReturnFirstEntryInCollection() {
+	void firstShouldReturnFirstEntryInCollection() {
 		assertThat(template.query(Person.class).first()).isNotEmpty();
 	}
 
 	@Test // DATAMONGO-1734
-	public void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
+	void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
 		assertThat(template.query(Person.class).count()).isEqualTo(2);
 	}
 
 	@Test // DATAMONGO-1734
-	public void countShouldReturnNrOfElementsMatchingQuery() {
+	void countShouldReturnNrOfElementsMatchingQuery() {
 
 		assertThat(template.query(Person.class).matching(query(where("firstname").is(luke.getFirstname()))).count())
 				.isEqualTo(1);
 	}
 
 	@Test // DATAMONGO-1734
-	public void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
+	void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
 		assertThat(template.query(Person.class).exists()).isTrue();
 	}
 
 	@Test // DATAMONGO-1734
-	public void existsShouldReturnFalseIfNoElementExistsInCollection() {
+	void existsShouldReturnFalseIfNoElementExistsInCollection() {
 
 		template.remove(new BasicQuery("{}"), STAR_WARS);
 
@@ -366,29 +366,29 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1734
-	public void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
+	void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
 
 		assertThat(template.query(Person.class).matching(query(where("firstname").is(luke.getFirstname()))).exists())
 				.isTrue();
 	}
 
 	@Test // DATAMONGO-1734
-	public void existsShouldReturnFalseWhenNoElementMatchesQuery() {
+	void existsShouldReturnFalseWhenNoElementMatchesQuery() {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("spock"))).exists()).isFalse();
 	}
 
 	@Test // DATAMONGO-1734
-	public void returnsTargetObjectDirectlyIfProjectionInterfaceIsImplemented() {
+	void returnsTargetObjectDirectlyIfProjectionInterfaceIsImplemented() {
 		assertThat(template.query(Person.class).as(Contact.class).all()).allMatch(it -> it instanceof Person);
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsEmptyListIfNoMatchFound() {
+	void distinctReturnsEmptyListIfNoMatchFound() {
 		assertThat(template.query(Person.class).distinct("actually-not-property-in-use").as(String.class).all()).isEmpty();
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsSimpleFieldValuesCorrectlyForCollectionHavingReturnTypeSpecifiedThatCanBeConvertedDirectlyByACodec() {
+	void distinctReturnsSimpleFieldValuesCorrectlyForCollectionHavingReturnTypeSpecifiedThatCanBeConvertedDirectlyByACodec() {
 
 		Person anakin = new Person();
 		anakin.firstname = "anakin";
@@ -401,7 +401,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsSimpleFieldValuesCorrectly() {
+	void distinctReturnsSimpleFieldValuesCorrectly() {
 
 		Person anakin = new Person();
 		anakin.firstname = "anakin";
@@ -424,7 +424,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectly() {
+	void distinctReturnsComplexValuesCorrectly() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -439,7 +439,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectlyHavingReturnTypeSpecified() {
+	void distinctReturnsComplexValuesCorrectlyHavingReturnTypeSpecified() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -455,7 +455,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectlyHavingReturnTypeDocumentSpecified() {
+	void distinctReturnsComplexValuesCorrectlyHavingReturnTypeDocumentSpecified() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -471,21 +471,21 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctMapsFieldNameCorrectly() {
+	void distinctMapsFieldNameCorrectly() {
 
 		assertThat(template.query(Jedi.class).inCollection(STAR_WARS).distinct("name").as(String.class).all())
 				.containsExactlyInAnyOrder("han", "luke");
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsRawValuesIfReturnTypeIsBsonValue() {
+	void distinctReturnsRawValuesIfReturnTypeIsBsonValue() {
 
 		assertThat(template.query(Person.class).distinct("lastname").as(BsonValue.class).all())
 				.containsExactlyInAnyOrder(new BsonString("solo"), new BsonString("skywalker"));
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsValuesMappedToTheirJavaTypeEvenWhenNotExplicitlyDefinedByTheDomainType() {
+	void distinctReturnsValuesMappedToTheirJavaTypeEvenWhenNotExplicitlyDefinedByTheDomainType() {
 
 		template.save(new Document("darth", "vader"), STAR_WARS);
 
@@ -493,7 +493,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsMappedDomainTypeForProjections() {
+	void distinctReturnsMappedDomainTypeForProjections() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -505,7 +505,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctAlllowsQueryUsingObjectSourceType() {
+	void distinctAlllowsQueryUsingObjectSourceType() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -517,7 +517,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsMappedDomainTypeExtractedFromPropertyWhenNoExplicitTypePresent() {
+	void distinctReturnsMappedDomainTypeExtractedFromPropertyWhenNoExplicitTypePresent() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -531,7 +531,7 @@ public class ExecutableFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctThrowsExceptionWhenExplicitMappingTypeCannotBeApplied() {
+	void distinctThrowsExceptionWhenExplicitMappingTypeCannotBeApplied() {
 		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
 				.isThrownBy(() -> template.query(Person.class).distinct("firstname").as(Long.class).all());
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -169,6 +169,11 @@ public class ExecutableFindOperationSupportTests {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("luke"))).one()).contains(luke);
 	}
 
+	@Test // DATAMONGO-2416
+	public void findByCriteria() {
+		assertThat(template.query(Person.class).matching(where("firstname").is("luke")).one()).contains(luke);
+	}
+
 	@Test // DATAMONGO-1563
 	public void findByNoMatch() {
 		assertThat(template.query(Person.class).matching(query(where("firstname").is("spock"))).one()).isEmpty();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperationSupportUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperationSupportUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -39,6 +40,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * Unit tests for {@link ExecutableMapReduceOperationSupport}.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @currentRead Beyond the Shadows - Brent Weeks
  */
 @ExtendWith(MockitoExtension.class)
@@ -104,6 +106,18 @@ public class ExecutableMapReduceOperationSupportUnitTests {
 		when(template.getCollectionName(eq(Person.class))).thenReturn(STAR_WARS);
 		Query query = new BasicQuery("{ 'lastname' : 'skywalker' }");
 		mapReduceOpsSupport.mapReduce(Person.class).map(MAP_FUNCTION).reduce(REDUCE_FUNCTION).matching(query).all();
+
+		verify(template).mapReduce(eq(query), eq(Person.class), eq(STAR_WARS), eq(MAP_FUNCTION), eq(REDUCE_FUNCTION),
+				isNull(), eq(Person.class));
+	}
+
+	@Test // DATAMONGO-2416
+	void usesCriteriaWhenPresent() {
+
+		when(template.getCollectionName(eq(Person.class))).thenReturn(STAR_WARS);
+		Query query = Query.query(where("lastname").is("skywalker"));
+		mapReduceOpsSupport.mapReduce(Person.class).map(MAP_FUNCTION).reduce(REDUCE_FUNCTION)
+				.matching(where("lastname").is("skywalker")).all();
 
 		verify(template).mapReduce(eq(query), eq(Person.class), eq(STAR_WARS), eq(MAP_FUNCTION), eq(REDUCE_FUNCTION),
 				isNull(), eq(Person.class));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperationSupportUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableMapReduceOperationSupportUnitTests.java
@@ -44,7 +44,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * @currentRead Beyond the Shadows - Brent Weeks
  */
 @ExtendWith(MockitoExtension.class)
-public class ExecutableMapReduceOperationSupportUnitTests {
+class ExecutableMapReduceOperationSupportUnitTests {
 
 	private static final String STAR_WARS = "star-wars";
 	private static final String MAP_FUNCTION = "function() { emit(this.id, this.firstname) }";

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableRemoveOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableRemoveOperationSupportTests.java
@@ -84,6 +84,14 @@ public class ExecutableRemoveOperationSupportTests {
 		assertThat(result.getDeletedCount()).isEqualTo(1L);
 	}
 
+	@Test // DATAMONGO-2416
+	public void removeAllMatchingCriteria() {
+
+		DeleteResult result = template.remove(Person.class).matching(where("firstname").is("han")).all();
+
+		assertThat(result.getDeletedCount()).isEqualTo(1L);
+	}
+
 	@Test // DATAMONGO-1563
 	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableRemoveOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableRemoveOperationSupportTests.java
@@ -41,18 +41,18 @@ import com.mongodb.client.result.DeleteResult;
  * @author Mark Paluch
  */
 @ExtendWith(MongoTemplateExtension.class)
-public class ExecutableRemoveOperationSupportTests {
+class ExecutableRemoveOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
 
 	@Template(initialEntitySet = Person.class) //
-	static MongoTestTemplate template;
+	private static MongoTestTemplate template;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		template.flush();
 
@@ -69,7 +69,7 @@ public class ExecutableRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void removeAll() {
+	void removeAll() {
 
 		DeleteResult result = template.remove(Person.class).all();
 
@@ -77,7 +77,7 @@ public class ExecutableRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void removeAllMatching() {
+	void removeAllMatching() {
 
 		DeleteResult result = template.remove(Person.class).matching(query(where("firstname").is("han"))).all();
 
@@ -85,7 +85,7 @@ public class ExecutableRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2416
-	public void removeAllMatchingCriteria() {
+	void removeAllMatchingCriteria() {
 
 		DeleteResult result = template.remove(Person.class).matching(where("firstname").is("han")).all();
 
@@ -93,7 +93,7 @@ public class ExecutableRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
+	void removeAllMatchingWithAlternateDomainTypeAndCollection() {
 
 		DeleteResult result = template.remove(Jedi.class).inCollection(STAR_WARS).matching(query(where("name").is("luke")))
 				.all();
@@ -102,7 +102,7 @@ public class ExecutableRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void removeAndReturnAllMatching() {
+	void removeAndReturnAllMatching() {
 
 		List<Person> result = template.remove(Person.class).matching(query(where("firstname").is("han"))).findAndRemove();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -120,6 +120,17 @@ public class ExecutableUpdateOperationSupportTests {
 		assertThat(result.getUpsertedId()).isNull();
 	}
 
+	@Test // DATAMONGO-2416
+	public void updateAllMatchingCriteria() {
+
+		UpdateResult result = template.update(Person.class).matching(where("id").is(han.getId()))
+				.apply(new Update().set("firstname", "Han"))
+				.all();
+
+		assertThat(result.getModifiedCount()).isEqualTo(1L);
+		assertThat(result.getUpsertedId()).isNull();
+	}
+
 	@Test // DATAMONGO-1563
 	public void updateWithDifferentDomainClassAndCollection() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -44,18 +44,18 @@ import com.mongodb.client.result.UpdateResult;
  * @author Mark Paluch
  */
 @ExtendWith(MongoTemplateExtension.class)
-public class ExecutableUpdateOperationSupportTests {
+class ExecutableUpdateOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
 
 	@Template(initialEntitySet = { Human.class, Jedi.class, Person.class }) //
-	static MongoTestTemplate template;
+	private static MongoTestTemplate template;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		template.flush();
 
@@ -72,28 +72,28 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void domainTypeIsRequired() {
+	void domainTypeIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void updateIsRequired() {
+	void updateIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(Person.class).apply(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void collectionIsRequiredOnSet() {
+	void collectionIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(Person.class).inCollection(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAndModifyOptionsAreRequiredOnSet() {
+	void findAndModifyOptionsAreRequiredOnSet() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> template.update(Person.class).apply(new Update()).withOptions(null));
 	}
 
 	@Test // DATAMONGO-1563
-	public void updateFirst() {
+	void updateFirst() {
 
 		UpdateResult result = template.update(Person.class).apply(new Update().set("firstname", "Han")).first();
 
@@ -102,7 +102,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void updateAll() {
+	void updateAll() {
 
 		UpdateResult result = template.update(Person.class).apply(new Update().set("firstname", "Han")).all();
 
@@ -111,7 +111,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void updateAllMatching() {
+	void updateAllMatching() {
 
 		UpdateResult result = template.update(Person.class).matching(queryHan()).apply(new Update().set("firstname", "Han"))
 				.all();
@@ -121,7 +121,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2416
-	public void updateAllMatchingCriteria() {
+	void updateAllMatchingCriteria() {
 
 		UpdateResult result = template.update(Person.class).matching(where("id").is(han.getId()))
 				.apply(new Update().set("firstname", "Han"))
@@ -132,7 +132,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void updateWithDifferentDomainClassAndCollection() {
+	void updateWithDifferentDomainClassAndCollection() {
 
 		UpdateResult result = template.update(Jedi.class).inCollection(STAR_WARS)
 				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).all();
@@ -144,7 +144,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAndModifyValue() {
+	void findAndModifyValue() {
 
 		Person result = template.update(Person.class).matching(queryHan()).apply(new Update().set("firstname", "Han"))
 				.findAndModifyValue();
@@ -155,7 +155,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAndModify() {
+	void findAndModify() {
 
 		Optional<Person> result = template.update(Person.class).matching(queryHan())
 				.apply(new Update().set("firstname", "Han")).findAndModify();
@@ -166,7 +166,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAndModifyWithDifferentDomainTypeAndCollection() {
+	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		Optional<Jedi> result = template.update(Jedi.class).inCollection(STAR_WARS)
 				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).findAndModify();
@@ -177,7 +177,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void findAndModifyWithOptions() {
+	void findAndModifyWithOptions() {
 
 		Optional<Person> result = template.update(Person.class).matching(queryHan())
 				.apply(new Update().set("firstname", "Han")).withOptions(FindAndModifyOptions.options().returnNew(true))
@@ -187,7 +187,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	public void upsert() {
+	void upsert() {
 
 		UpdateResult result = template.update(Person.class).matching(query(where("id").is("id-3")))
 				.apply(new Update().set("firstname", "Chewbacca")).upsert();
@@ -197,7 +197,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceValue() {
+	void findAndReplaceValue() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -210,7 +210,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplace() {
+	void findAndReplace() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -223,7 +223,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithCollection() {
+	void findAndReplaceWithCollection() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -237,7 +237,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithOptions() {
+	void findAndReplaceWithOptions() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -249,7 +249,7 @@ public class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithProjection() {
+	void findAndReplaceWithProjection() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
@@ -61,20 +61,20 @@ import com.mongodb.client.MongoClient;
  * @author Christoph Strobl
  */
 @ExtendWith(MongoClientExtension.class)
-public class ReactiveFindOperationSupportTests {
+class ReactiveFindOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
-	MongoTemplate blocking;
-	ReactiveMongoTemplate template;
+	private MongoTemplate blocking;
+	private ReactiveMongoTemplate template;
 
-	static @Client MongoClient client;
-	static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
+	private static @Client MongoClient client;
+	private static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		blocking = new MongoTemplate(new SimpleMongoClientDatabaseFactory(client, "ExecutableFindOperationSupportTests"));
 		recreateCollection(STAR_WARS, false);
@@ -113,22 +113,22 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void domainTypeIsRequired() {
+	void domainTypeIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void returnTypeIsRequiredOnSet() {
+	void returnTypeIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(Person.class).as(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void collectionIsRequiredOnSet() {
+	void collectionIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.query(Person.class).inCollection(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAll() {
+	void findAll() {
 
 		template.query(Person.class).all().collectList().as(StepVerifier::create).consumeNextWith(actual -> {
 			assertThat(actual).containsExactlyInAnyOrder(han, luke);
@@ -136,19 +136,19 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllWithCollection() {
+	void findAllWithCollection() {
 		template.query(Human.class).inCollection(STAR_WARS).all().as(StepVerifier::create).expectNextCount(2)
 				.verifyComplete();
 	}
 
 	@Test // DATAMONGO-2323
-	public void findAllAsDocumentDocument() {
+	void findAllAsDocumentDocument() {
 		template.query(Document.class).inCollection(STAR_WARS).all().as(StepVerifier::create).expectNextCount(2)
 				.verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllWithProjection() {
+	void findAllWithProjection() {
 
 		template.query(Person.class).as(Jedi.class).all().map(it -> it.getClass().getName()).as(StepVerifier::create) //
 				.expectNext(Jedi.class.getName(), Jedi.class.getName()) //
@@ -156,7 +156,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllBy() {
+	void findAllBy() {
 
 		template.query(Person.class).matching(query(where("firstname").is("luke"))).all().as(StepVerifier::create) //
 				.expectNext(luke) //
@@ -164,7 +164,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2416
-	public void findAllByCriteria() {
+	void findAllByCriteria() {
 
 		template.query(Person.class).matching(where("firstname").is("luke")).all().as(StepVerifier::create) //
 				.expectNext(luke) //
@@ -172,7 +172,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllByWithCollectionUsingMappingInformation() {
+	void findAllByWithCollectionUsingMappingInformation() {
 
 		template.query(Jedi.class).inCollection(STAR_WARS).matching(query(where("name").is("luke"))).all()
 				.as(StepVerifier::create).consumeNextWith(it -> assertThat(it).isInstanceOf(Jedi.class)) //
@@ -180,7 +180,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllByWithCollection() {
+	void findAllByWithCollection() {
 
 		template.query(Human.class).inCollection(STAR_WARS).matching(query(where("firstname").is("luke"))).all()
 				.as(StepVerifier::create).expectNextCount(1) //
@@ -188,7 +188,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllByWithProjection() {
+	void findAllByWithProjection() {
 
 		template.query(Person.class).as(Jedi.class).matching(query(where("firstname").is("luke"))).all()
 				.as(StepVerifier::create).consumeNextWith(it -> assertThat(it).isInstanceOf(Jedi.class)) //
@@ -196,7 +196,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllByWithClosedInterfaceProjection() {
+	void findAllByWithClosedInterfaceProjection() {
 
 		template.query(Person.class).as(PersonProjection.class).matching(query(where("firstname").is("luke"))).all()
 				.as(StepVerifier::create).consumeNextWith(it -> {
@@ -208,7 +208,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllByWithOpenInterfaceProjection() {
+	void findAllByWithOpenInterfaceProjection() {
 
 		template.query(Person.class).as(PersonSpELProjection.class).matching(query(where("firstname").is("luke"))).all()
 				.as(StepVerifier::create).consumeNextWith(it -> {
@@ -220,7 +220,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findBy() {
+	void findBy() {
 
 		template.query(Person.class).matching(query(where("firstname").is("luke"))).one().as(StepVerifier::create)
 				.expectNext(luke) //
@@ -228,14 +228,14 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findByNoMatch() {
+	void findByNoMatch() {
 
 		template.query(Person.class).matching(query(where("firstname").is("spock"))).one().as(StepVerifier::create)
 				.verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void findByTooManyResults() {
+	void findByTooManyResults() {
 
 		template.query(Person.class).matching(query(where("firstname").in("han", "luke"))).one().as(StepVerifier::create)
 				.expectError(IncorrectResultSizeDataAccessException.class) //
@@ -243,7 +243,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllNearBy() {
+	void findAllNearBy() {
 
 		blocking.indexOps(Planet.class).ensureIndex(
 				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
@@ -263,7 +263,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllNearByWithCollectionAndProjection() {
+	void findAllNearByWithCollectionAndProjection() {
 
 		blocking.indexOps(Planet.class).ensureIndex(
 				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
@@ -286,7 +286,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllNearByReturningGeoResultContentAsClosedInterfaceProjection() {
+	void findAllNearByReturningGeoResultContentAsClosedInterfaceProjection() {
 
 		blocking.indexOps(Planet.class).ensureIndex(
 				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
@@ -309,7 +309,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAllNearByReturningGeoResultContentAsOpenInterfaceProjection() {
+	void findAllNearByReturningGeoResultContentAsOpenInterfaceProjection() {
 
 		blocking.indexOps(Planet.class).ensureIndex(
 				new GeospatialIndex("coordinates").typed(GeoSpatialIndexType.GEO_2DSPHERE).named("planet-coordinate-idx"));
@@ -332,7 +332,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2080
-	public void tail() throws InterruptedException {
+	void tail() throws InterruptedException {
 
 		recreateCollection(STAR_WARS, true);
 		insertObjects();
@@ -360,7 +360,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2080
-	public void tailWithProjection() {
+	void tailWithProjection() {
 
 		recreateCollection(STAR_WARS, true);
 		insertObjects();
@@ -373,7 +373,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2080
-	public void tailWithClosedInterfaceProjection() {
+	void tailWithClosedInterfaceProjection() {
 
 		recreateCollection(STAR_WARS, true);
 		insertObjects();
@@ -390,7 +390,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2080
-	public void tailWithOpenInterfaceProjection() {
+	void tailWithOpenInterfaceProjection() {
 
 		recreateCollection(STAR_WARS, true);
 		insertObjects();
@@ -407,17 +407,17 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void firstShouldReturnFirstEntryInCollection() {
+	void firstShouldReturnFirstEntryInCollection() {
 		template.query(Person.class).first().as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
+	void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
 		template.query(Person.class).count().as(StepVerifier::create).expectNext(2L).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void countShouldReturnNrOfElementsMatchingQuery() {
+	void countShouldReturnNrOfElementsMatchingQuery() {
 
 		template.query(Person.class).matching(query(where("firstname").is(luke.getFirstname()))).count()
 				.as(StepVerifier::create).expectNext(1L) //
@@ -425,12 +425,12 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
+	void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
 		template.query(Person.class).exists().as(StepVerifier::create).expectNext(true).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void existsShouldReturnFalseIfNoElementExistsInCollection() {
+	void existsShouldReturnFalseIfNoElementExistsInCollection() {
 
 		blocking.remove(new BasicQuery("{}"), STAR_WARS);
 
@@ -438,7 +438,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
+	void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
 
 		template.query(Person.class).matching(query(where("firstname").is(luke.getFirstname()))).exists()
 				.as(StepVerifier::create).expectNext(true) //
@@ -446,7 +446,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void existsShouldReturnFalseWhenNoElementMatchesQuery() {
+	void existsShouldReturnFalseWhenNoElementMatchesQuery() {
 
 		template.query(Person.class).matching(query(where("firstname").is("spock"))).exists().as(StepVerifier::create)
 				.expectNext(false) //
@@ -454,14 +454,14 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsEmptyListIfNoMatchFound() {
+	void distinctReturnsEmptyListIfNoMatchFound() {
 
 		template.query(Person.class).distinct("actually-not-property-in-use").as(String.class).all()
 				.as(StepVerifier::create).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsSimpleFieldValuesCorrectlyForCollectionHavingReturnTypeSpecifiedThatCanBeConvertedDirectlyByACodec() {
+	void distinctReturnsSimpleFieldValuesCorrectlyForCollectionHavingReturnTypeSpecifiedThatCanBeConvertedDirectlyByACodec() {
 
 		Person anakin = new Person();
 		anakin.firstname = "anakin";
@@ -475,7 +475,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsSimpleFieldValuesCorrectly() {
+	void distinctReturnsSimpleFieldValuesCorrectly() {
 
 		Person anakin = new Person();
 		anakin.firstname = "anakin";
@@ -503,7 +503,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectly() {
+	void distinctReturnsComplexValuesCorrectly() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -520,7 +520,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectlyHavingReturnTypeSpecified() {
+	void distinctReturnsComplexValuesCorrectlyHavingReturnTypeSpecified() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -537,7 +537,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsComplexValuesCorrectlyReturnTypeDocumentSpecified() {
+	void distinctReturnsComplexValuesCorrectlyReturnTypeDocumentSpecified() {
 
 		Sith sith = new Sith();
 		sith.rank = "lord";
@@ -554,7 +554,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctMapsFieldNameCorrectly() {
+	void distinctMapsFieldNameCorrectly() {
 
 		template.query(Jedi.class).inCollection(STAR_WARS).distinct("name").as(String.class).all().as(StepVerifier::create)
 				.assertNext(in("han", "luke")).assertNext(in("han", "luke")) //
@@ -562,7 +562,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsRawValuesIfReturnTypeIsBsonValue() {
+	void distinctReturnsRawValuesIfReturnTypeIsBsonValue() {
 
 		Consumer<BsonValue> inValues = in(new BsonString("solo"), new BsonString("skywalker"));
 		template.query(Person.class).distinct("lastname").as(BsonValue.class).all().as(StepVerifier::create)
@@ -572,7 +572,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsValuesMappedToTheirJavaTypeEvenWhenNotExplicitlyDefinedByTheDomainType() {
+	void distinctReturnsValuesMappedToTheirJavaTypeEvenWhenNotExplicitlyDefinedByTheDomainType() {
 
 		blocking.save(new Document("darth", "vader"), STAR_WARS);
 
@@ -582,7 +582,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsMappedDomainTypeForProjections() {
+	void distinctReturnsMappedDomainTypeForProjections() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -595,7 +595,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctAlllowsQueryUsingObjectSourceType() {
+	void distinctAlllowsQueryUsingObjectSourceType() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -608,7 +608,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctReturnsMappedDomainTypeExtractedFromPropertyWhenNoExplicitTypePresent() {
+	void distinctReturnsMappedDomainTypeExtractedFromPropertyWhenNoExplicitTypePresent() {
 
 		luke.father = new Person();
 		luke.father.firstname = "anakin";
@@ -624,7 +624,7 @@ public class ReactiveFindOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1761
-	public void distinctThrowsExceptionWhenExplicitMappingTypeCannotBeApplied() {
+	void distinctThrowsExceptionWhenExplicitMappingTypeCannotBeApplied() {
 
 		template.query(Person.class).distinct("firstname").as(Long.class).all().as(StepVerifier::create)
 				.expectError(InvalidDataAccessApiUsageException.class) //

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
@@ -163,6 +163,14 @@ public class ReactiveFindOperationSupportTests {
 				.verifyComplete();
 	}
 
+	@Test // DATAMONGO-2416
+	public void findAllByCriteria() {
+
+		template.query(Person.class).matching(where("firstname").is("luke")).all().as(StepVerifier::create) //
+				.expectNext(luke) //
+				.verifyComplete();
+	}
+
 	@Test // DATAMONGO-1719
 	public void findAllByWithCollectionUsingMappingInformation() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMapReduceOperationSupportUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMapReduceOperationSupportUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -39,6 +40,7 @@ import org.springframework.data.mongodb.core.query.Query;
  * Unit tests for {@link ReactiveMapReduceOperationSupport}.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @currentRead Beyond the Shadows - Brent Weeks
  */
 @ExtendWith(MockitoExtension.class)
@@ -107,6 +109,19 @@ public class ReactiveMapReduceOperationSupportUnitTests {
 
 		Query query = new BasicQuery("{ 'lastname' : 'skywalker' }");
 		mapReduceOpsSupport.mapReduce(Person.class).map(MAP_FUNCTION).reduce(REDUCE_FUNCTION).matching(query).all();
+
+		verify(template).mapReduce(eq(query), eq(Person.class), eq(STAR_WARS), eq(Person.class), eq(MAP_FUNCTION),
+				eq(REDUCE_FUNCTION), isNull());
+	}
+
+	@Test // DATAMONGO-2416
+	void usesCriteriaWhenPresent() {
+
+		when(template.getCollectionName(eq(Person.class))).thenReturn(STAR_WARS);
+
+		Query query = Query.query(where("lastname").is("skywalker"));
+		mapReduceOpsSupport.mapReduce(Person.class).map(MAP_FUNCTION).reduce(REDUCE_FUNCTION)
+				.matching(where("lastname").is("skywalker")).all();
 
 		verify(template).mapReduce(eq(query), eq(Person.class), eq(STAR_WARS), eq(Person.class), eq(MAP_FUNCTION),
 				eq(REDUCE_FUNCTION), isNull());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveRemoveOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveRemoveOperationSupportTests.java
@@ -38,20 +38,20 @@ import com.mongodb.client.MongoClient;
  * @author Mark Paluch
  */
 @ExtendWith(MongoClientExtension.class)
-public class ReactiveRemoveOperationSupportTests {
+class ReactiveRemoveOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
-	static @Client MongoClient client;
-	static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
+	private static @Client MongoClient client;
+	private static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
 
-	MongoTemplate blocking;
-	ReactiveMongoTemplate template;
+	private MongoTemplate blocking;
+	private ReactiveMongoTemplate template;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		blocking = new MongoTemplate(new SimpleMongoClientDatabaseFactory(client, "ExecutableRemoveOperationSupportTests"));
 		blocking.dropCollection(STAR_WARS);
@@ -71,7 +71,7 @@ public class ReactiveRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void removeAll() {
+	void removeAll() {
 
 		template.remove(Person.class).all().as(StepVerifier::create).consumeNextWith(actual -> {
 			assertThat(actual.getDeletedCount()).isEqualTo(2L);
@@ -79,21 +79,21 @@ public class ReactiveRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void removeAllMatching() {
+	void removeAllMatching() {
 
 		template.remove(Person.class).matching(query(where("firstname").is("han"))).all().as(StepVerifier::create)
 				.consumeNextWith(actual -> assertThat(actual.getDeletedCount()).isEqualTo(1L)).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void removeAllMatchingCriteria() {
+	void removeAllMatchingCriteria() {
 
 		template.remove(Person.class).matching(where("firstname").is("han")).all().as(StepVerifier::create)
 				.consumeNextWith(actual -> assertThat(actual.getDeletedCount()).isEqualTo(1L)).verifyComplete();
 	}
 
 	@Test // DATAMONGO-1719
-	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
+	void removeAllMatchingWithAlternateDomainTypeAndCollection() {
 
 		template.remove(Jedi.class).inCollection(STAR_WARS).matching(query(where("name").is("luke"))).all()
 				.as(StepVerifier::create).consumeNextWith(actual -> assertThat(actual.getDeletedCount()).isEqualTo(1L))
@@ -101,7 +101,7 @@ public class ReactiveRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void removeAndReturnAllMatching() {
+	void removeAndReturnAllMatching() {
 
 		template.remove(Person.class).matching(query(where("firstname").is("han"))).findAndRemove().as(StepVerifier::create)
 				.expectNext(han).verifyComplete();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveRemoveOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveRemoveOperationSupportTests.java
@@ -86,6 +86,13 @@ public class ReactiveRemoveOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
+	public void removeAllMatchingCriteria() {
+
+		template.remove(Person.class).matching(where("firstname").is("han")).all().as(StepVerifier::create)
+				.consumeNextWith(actual -> assertThat(actual.getDeletedCount()).isEqualTo(1L)).verifyComplete();
+	}
+
+	@Test // DATAMONGO-1719
 	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
 
 		template.remove(Jedi.class).inCollection(STAR_WARS).matching(query(where("name").is("luke"))).all()

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -128,6 +128,17 @@ public class ReactiveUpdateOperationSupportTests {
 				}).verifyComplete();
 	}
 
+	@Test // DATAMONGO-2416
+	public void updateAllMatchingCriteria() {
+
+		template.update(Person.class).matching(where("id").is(han.getId())).apply(new Update().set("firstname", "Han"))
+				.all().as(StepVerifier::create).consumeNextWith(actual -> {
+
+					assertThat(actual.getModifiedCount()).isEqualTo(1L);
+					assertThat(actual.getUpsertedId()).isNull();
+				}).verifyComplete();
+	}
+
 	@Test // DATAMONGO-1719
 	public void updateWithDifferentDomainClassAndCollection() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -41,20 +41,20 @@ import com.mongodb.client.MongoClient;
  * @author Mark Paluch
  */
 @ExtendWith(MongoClientExtension.class)
-public class ReactiveUpdateOperationSupportTests {
+class ReactiveUpdateOperationSupportTests {
 
 	private static final String STAR_WARS = "star-wars";
-	static @Client MongoClient client;
-	static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
+	private static @Client MongoClient client;
+	private static @Client com.mongodb.reactivestreams.client.MongoClient reactiveClient;
 
-	MongoTemplate blocking;
-	ReactiveMongoTemplate template;
+	private MongoTemplate blocking;
+	private ReactiveMongoTemplate template;
 
-	Person han;
-	Person luke;
+	private Person han;
+	private Person luke;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		blocking = new MongoTemplate(new SimpleMongoClientDatabaseFactory(client, "ExecutableUpdateOperationSupportTests"));
 		blocking.dropCollection(STAR_WARS);
@@ -74,28 +74,28 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void domainTypeIsRequired() {
+	void domainTypeIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void updateIsRequired() {
+	void updateIsRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(Person.class).apply(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void collectionIsRequiredOnSet() {
+	void collectionIsRequiredOnSet() {
 		assertThatIllegalArgumentException().isThrownBy(() -> template.update(Person.class).inCollection(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAndModifyOptionsAreRequiredOnSet() {
+	void findAndModifyOptionsAreRequiredOnSet() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> template.update(Person.class).apply(new Update()).withOptions(null));
 	}
 
 	@Test // DATAMONGO-1719
-	public void updateFirst() {
+	void updateFirst() {
 
 		template.update(Person.class).apply(new Update().set("firstname", "Han")).first().as(StepVerifier::create)
 				.consumeNextWith(actual -> {
@@ -107,7 +107,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void updateAll() {
+	void updateAll() {
 
 		template.update(Person.class).apply(new Update().set("firstname", "Han")).all().as(StepVerifier::create)
 				.consumeNextWith(actual -> {
@@ -118,7 +118,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void updateAllMatching() {
+	void updateAllMatching() {
 
 		template.update(Person.class).matching(queryHan()).apply(new Update().set("firstname", "Han")).all()
 				.as(StepVerifier::create).consumeNextWith(actual -> {
@@ -129,7 +129,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-2416
-	public void updateAllMatchingCriteria() {
+	void updateAllMatchingCriteria() {
 
 		template.update(Person.class).matching(where("id").is(han.getId())).apply(new Update().set("firstname", "Han"))
 				.all().as(StepVerifier::create).consumeNextWith(actual -> {
@@ -140,7 +140,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void updateWithDifferentDomainClassAndCollection() {
+	void updateWithDifferentDomainClassAndCollection() {
 
 		template.update(Jedi.class).inCollection(STAR_WARS).matching(query(where("_id").is(han.getId())))
 				.apply(new Update().set("name", "Han")).all().as(StepVerifier::create).consumeNextWith(actual -> {
@@ -154,7 +154,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAndModify() {
+	void findAndModify() {
 
 		template.update(Person.class).matching(queryHan()).apply(new Update().set("firstname", "Han")).findAndModify()
 				.as(StepVerifier::create).expectNext(han).verifyComplete();
@@ -164,7 +164,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAndModifyWithDifferentDomainTypeAndCollection() {
+	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		template.update(Jedi.class).inCollection(STAR_WARS).matching(query(where("_id").is(han.getId())))
 				.apply(new Update().set("name", "Han")).findAndModify().as(StepVerifier::create)
@@ -175,7 +175,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void findAndModifyWithOptions() {
+	void findAndModifyWithOptions() {
 
 		template.update(Person.class).matching(queryHan()).apply(new Update().set("firstname", "Han"))
 				.withOptions(FindAndModifyOptions.options().returnNew(true)).findAndModify().as(StepVerifier::create)
@@ -186,7 +186,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	public void upsert() {
+	void upsert() {
 
 		template.update(Person.class).matching(query(where("id").is("id-3")))
 				.apply(new Update().set("firstname", "Chewbacca")).upsert().as(StepVerifier::create).consumeNextWith(actual -> {
@@ -197,7 +197,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplace() {
+	void findAndReplace() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -213,7 +213,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithProjection() {
+	void findAndReplaceWithProjection() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -225,7 +225,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithCollection() {
+	void findAndReplaceWithCollection() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";
@@ -241,7 +241,7 @@ public class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1827
-	public void findAndReplaceWithOptions() {
+	void findAndReplaceWithOptions() {
 
 		Person luke = new Person();
 		luke.firstname = "Luke";

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractMongoQueryUnitTests.java
@@ -100,7 +100,7 @@ class AbstractMongoQueryUnitTests {
 		doReturn(converter).when(mongoOperationsMock).getConverter();
 		doReturn(executableFind).when(mongoOperationsMock).query(any());
 		doReturn(withQueryMock).when(executableFind).as(any());
-		doReturn(withQueryMock).when(withQueryMock).matching(any());
+		doReturn(withQueryMock).when(withQueryMock).matching(any(Query.class));
 
 		when(mongoOperationsMock.remove(any(), any(), anyString())).thenReturn(deleteResultMock);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQueryUnitTests.java
@@ -52,7 +52,10 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
+ * Unit tests for {@link AbstractReactiveMongoQuery}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @currentRead Way of Kings - Brandon Sanderson
  */
 @ExtendWith(MockitoExtension.class)
@@ -81,7 +84,7 @@ class AbstractReactiveMongoQueryUnitTests {
 
 		doReturn(executableFind).when(mongoOperationsMock).query(any());
 		doReturn(withQueryMock).when(executableFind).as(any());
-		doReturn(withQueryMock).when(withQueryMock).matching(any());
+		doReturn(withQueryMock).when(withQueryMock).matching(any(Query.class));
 	}
 
 	@Test // DATAMONGO-1854


### PR DESCRIPTION
The fluent API now exposes default interface methods accepting CriteriaDefinition for a more concise expression of queries that do not require a Query object.

`template.query(Person.class).matching(where("firstname").is("luke")).all()`

instead of

`template.query(Person.class).matching(query(where("firstname").is("luke"))).all()`

---

Related ticket: [DATAMONGO-2416](https://jira.spring.io/browse/DATAMONGO-2416).