### PR TITLE
DATAMONGO-625 - Add support for GridFS with predefined id.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-625-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-625-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-625-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-625-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsObject.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsObject.java
@@ -21,7 +21,7 @@ import org.springframework.lang.Nullable;
 import com.mongodb.client.gridfs.model.GridFSFile;
 
 /**
- * A common interface when dealing with GridFs items using Spring Data.o
+ * A common interface when dealing with GridFs items using Spring Data.
  *
  * @author Christoph Strobl
  * @since 3.0
@@ -31,7 +31,7 @@ public interface GridFsObject<ID, CONTENT> {
 	/**
 	 * The {@link GridFSFile#getId()} value converted into its simple java type. <br />
 	 * A {@link org.bson.BsonString} will be converted to plain {@link String}.
-	 * 
+	 *
 	 * @return can be {@literal null} depending on the implementation.
 	 */
 	@Nullable
@@ -39,34 +39,35 @@ public interface GridFsObject<ID, CONTENT> {
 
 	/**
 	 * The filename.
-	 * 
+	 *
 	 * @return
 	 */
 	String getFilename();
 
 	/**
 	 * The actual file content.
-	 * 
+	 *
 	 * @return
+	 * @throws IllegalStateException if the content cannot be obtained.
 	 */
 	CONTENT getContent();
 
 	/**
 	 * Additional information like file metadata (eg. contentType).
-	 * 
+	 *
 	 * @return never {@literal null}.
 	 */
 	Options getOptions();
 
 	/**
 	 * Additional, context relevant information.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 */
 	class Options {
 
-		private Document metadata = new Document();
-		private int chunkSize = -1;
+		private final Document metadata;
+		private final int chunkSize;
 
 		private Options(Document metadata, int chunkSize) {
 
@@ -81,16 +82,6 @@ public interface GridFsObject<ID, CONTENT> {
 		 */
 		public static Options none() {
 			return new Options(new Document(), -1);
-		}
-
-		/**
-		 * Static factory method to create {@link Options} with given chunk size.
-		 *
-		 * @param chunkSize
-		 * @return new instance of {@link Options}.
-		 */
-		public static Options chunked(int chunkSize) {
-			return new Options(new Document(), chunkSize);
 		}
 
 		/**
@@ -115,7 +106,7 @@ public interface GridFsObject<ID, CONTENT> {
 
 		/**
 		 * Set the associated content type.
-		 * 
+		 *
 		 * @param contentType must not be {@literal null}.
 		 * @return new instance of {@link Options}.
 		 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsObject.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsObject.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import org.bson.Document;
+import org.springframework.lang.Nullable;
+
+import com.mongodb.client.gridfs.model.GridFSFile;
+
+/**
+ * A common interface when dealing with GridFs items using Spring Data.o
+ *
+ * @author Christoph Strobl
+ * @since 3.0
+ */
+public interface GridFsObject<ID, CONTENT> {
+
+	/**
+	 * The {@link GridFSFile#getId()} value converted into its simple java type. <br />
+	 * A {@link org.bson.BsonString} will be converted to plain {@link String}.
+	 * 
+	 * @return can be {@literal null} depending on the implementation.
+	 */
+	@Nullable
+	ID getFileId();
+
+	/**
+	 * The filename.
+	 * 
+	 * @return
+	 */
+	String getFilename();
+
+	/**
+	 * The actual file content.
+	 * 
+	 * @return
+	 */
+	CONTENT getContent();
+
+	/**
+	 * Additional information like file metadata (eg. contentType).
+	 * 
+	 * @return never {@literal null}.
+	 */
+	Options getOptions();
+
+	/**
+	 * Additional, context relevant information.
+	 * 
+	 * @author Christoph Strobl
+	 */
+	class Options {
+
+		private Document metadata = new Document();
+		private int chunkSize = -1;
+
+		private Options(Document metadata, int chunkSize) {
+
+			this.metadata = metadata;
+			this.chunkSize = chunkSize;
+		}
+
+		/**
+		 * Static factory to create empty options.
+		 *
+		 * @return new instance of {@link Options}.
+		 */
+		public static Options none() {
+			return new Options(new Document(), -1);
+		}
+
+		/**
+		 * Static factory method to create {@link Options} with given chunk size.
+		 *
+		 * @param chunkSize
+		 * @return new instance of {@link Options}.
+		 */
+		public static Options chunked(int chunkSize) {
+			return new Options(new Document(), chunkSize);
+		}
+
+		/**
+		 * Static factory method to create {@link Options} with given content type.
+		 *
+		 * @param contentType
+		 * @return new instance of {@link Options}.
+		 */
+		public static Options typed(String contentType) {
+			return new Options(new Document("_contentType", contentType), -1);
+		}
+
+		/**
+		 * Static factory method to create {@link Options} by extracting information from the given {@link GridFSFile}.
+		 *
+		 * @param gridFSFile can be {@literal null}, returns {@link #none()} in that case.
+		 * @return new instance of {@link Options}.
+		 */
+		public static Options from(@Nullable GridFSFile gridFSFile) {
+			return gridFSFile != null ? new Options(gridFSFile.getMetadata(), gridFSFile.getChunkSize()) : none();
+		}
+
+		/**
+		 * Set the associated content type.
+		 * 
+		 * @param contentType must not be {@literal null}.
+		 * @return new instance of {@link Options}.
+		 */
+		public Options contentType(String contentType) {
+
+			Options target = new Options(new Document(metadata), chunkSize);
+			target.metadata.put("_contentType", contentType);
+			return target;
+		}
+
+		/**
+		 * @param metadata
+		 * @return new instance of {@link Options}.
+		 */
+		public Options metadata(Document metadata) {
+			return new Options(metadata, chunkSize);
+		}
+
+		/**
+		 * @param chunkSize the file chunk size to use.
+		 * @return new instance of {@link Options}.
+		 */
+		public Options chunkSize(int chunkSize) {
+			return new Options(metadata, chunkSize);
+		}
+
+		/**
+		 * @return never {@literal null}.
+		 */
+		public Document getMetadata() {
+			return metadata;
+		}
+
+		/**
+		 * @return the chunk size to use.
+		 */
+		public int getChunkSize() {
+			return chunkSize;
+		}
+
+		/**
+		 * @return {@literal null} if not set.
+		 */
+		@Nullable
+		String getContentType() {
+			return (String) metadata.get("_contentType");
+		}
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
@@ -59,7 +59,9 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	 * @param metadata can be {@literal null}.
 	 * @return the {@link ObjectId} of the {@link com.mongodb.client.gridfs.model.GridFSFile} just created.
 	 */
-	ObjectId store(InputStream content, @Nullable Object metadata);
+	default ObjectId store(InputStream content, @Nullable Object metadata) {
+		return store(content, null, metadata);
+	}
 
 	/**
 	 * Stores the given content into a file with the given name.
@@ -80,7 +82,9 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	 * @param contentType can be {@literal null}.
 	 * @return the {@link ObjectId} of the {@link com.mongodb.client.gridfs.model.GridFSFile} just created.
 	 */
-	ObjectId store(InputStream content, @Nullable String filename, @Nullable String contentType);
+	default ObjectId store(InputStream content, @Nullable String filename, @Nullable String contentType) {
+		return store(content, filename, contentType, null);
+	}
 
 	/**
 	 * Stores the given content into a file with the given name using the given metadata. The metadata object will be
@@ -91,7 +95,9 @@ public interface GridFsOperations extends ResourcePatternResolver {
 	 * @param metadata can be {@literal null}.
 	 * @return the {@link ObjectId} of the {@link com.mongodb.client.gridfs.model.GridFSFile} just created.
 	 */
-	ObjectId store(InputStream content, @Nullable String filename, @Nullable Object metadata);
+	default ObjectId store(InputStream content, @Nullable String filename, @Nullable Object metadata) {
+		return store(content, filename, null, metadata);
+	}
 
 	/**
 	 * Stores the given content into a file with the given name and content type using the given metadata. The metadata
@@ -141,21 +147,21 @@ public interface GridFsOperations extends ResourcePatternResolver {
 			uploadBuilder.metadata(metadata);
 		}
 
-		return save(uploadBuilder.build());
+		return store(uploadBuilder.build());
 	}
 
 	/**
 	 * Stores the given {@link GridFsObject}, likely a {@link GridFsUpload}, into into a file with given
 	 * {@link GridFsObject#getFilename() name}. If the {@link GridFsObject#getFileId()} is set, the file will be stored
 	 * with that id, otherwise the server auto creates a new id. <br />
-	 * 
+	 *
 	 * @param upload the {@link GridFsObject} (most likely a {@link GridFsUpload}) to be stored.
 	 * @param <T> id type of the underlying {@link com.mongodb.client.gridfs.model.GridFSFile}
 	 * @return the id of the stored file. Either an auto created value or {@link GridFsObject#getFileId()}, but never
 	 *         {@literal null}.
 	 * @since 3.0
 	 */
-	<T> T save(GridFsObject<T, InputStream> upload);
+	<T> T store(GridFsObject<T, InputStream> upload);
 
 	/**
 	 * Returns all files matching the given query. Note, that currently {@link Sort} criterias defined at the

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsTemplate.java
@@ -89,31 +89,6 @@ public class GridFsTemplate extends GridFsOperationsSupport implements GridFsOpe
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#store(java.io.InputStream, java.lang.Object)
-	 */
-	@Override
-	public ObjectId store(InputStream content, @Nullable Object metadata) {
-		return store(content, null, metadata);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#store(java.io.InputStream, java.lang.String, java.lang.String)
-	 */
-	public ObjectId store(InputStream content, @Nullable String filename, @Nullable String contentType) {
-		return store(content, filename, contentType, (Object) null);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#store(java.io.InputStream, java.lang.String, java.lang.Object)
-	 */
-	public ObjectId store(InputStream content, @Nullable String filename, @Nullable Object metadata) {
-		return store(content, filename, null, metadata);
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#store(java.io.InputStream, java.lang.String, java.lang.String, java.lang.Object)
 	 */
 	public ObjectId store(InputStream content, @Nullable String filename, @Nullable String contentType,
@@ -125,7 +100,7 @@ public class GridFsTemplate extends GridFsOperationsSupport implements GridFsOpe
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.gridfs.GridFsOperations#save(org.springframework.data.mongodb.gridfs.GridFsObject)
 	 */
-	public <T> T save(GridFsObject<T, InputStream> upload) {
+	public <T> T store(GridFsObject<T, InputStream> upload) {
 
 		GridFSUploadOptions uploadOptions = computeUploadOptionsFor(upload.getOptions().getContentType(),
 				upload.getOptions().getMetadata());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsUpload.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsUpload.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.springframework.data.util.Lazy;
+import org.springframework.lang.Nullable;
+
+import com.mongodb.client.gridfs.model.GridFSFile;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.0
+ */
+public class GridFsUpload<ID> implements GridFsObject<ID, InputStream> {
+
+	private static final InputStream EMPTY_STREAM = new InputStream() {
+		@Override
+		public int read() throws IOException {
+			return -1;
+		}
+	};
+
+	private ID id;
+	private Lazy<InputStream> dataStream;
+	private String filename;
+	private Options options;
+
+	/**
+	 * The {@link GridFSFile#getId()} value converted into its simple java type. <br />
+	 * A {@link org.bson.BsonString} will be converted to plain {@link String}.
+	 * 
+	 * @return can be {@literal null}.
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getFileId()
+	 */
+	@Override
+	public ID getFileId() {
+		return id;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getFielname()
+	 */
+	@Override
+	public String getFilename() {
+		return filename;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getContent()
+	 */
+	@Override
+	public InputStream getContent() {
+		return dataStream.orElse(EMPTY_STREAM);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getOptions()
+	 */
+	@Override
+	public Options getOptions() {
+		return options;
+	}
+
+	/**
+	 * Create a new instance of {@link GridFsUpload} for the given {@link InputStream}.
+	 *
+	 * @param stream must not be {@literal null}.
+	 * @return new instance of {@link GridFsUpload}.
+	 */
+	public static GridFsUploadBuilder<ObjectId> fromStream(InputStream stream) {
+		return new GridFsUploadBuilder().content(stream);
+	}
+
+	/**
+	 * Builder to create {@link GridFsUpload} in a fluent way.
+	 * 
+	 * @param <T> the target id type.
+	 */
+	public static class GridFsUploadBuilder<T> {
+
+		private GridFsUpload upload;
+
+		public GridFsUploadBuilder() {
+			this.upload = new GridFsUpload();
+			this.upload.options = Options.none();
+		}
+
+		/**
+		 * Define the content of the file to upload.
+		 *
+		 * @param stream the upload content.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> content(InputStream stream) {
+
+			upload.dataStream = Lazy.of(() -> stream);
+			return this;
+		}
+
+		/**
+		 * Set the id to use.
+		 *
+		 * @param id the id to save the content to.
+		 * @param <T1>
+		 * @return this.
+		 */
+		public <T1> GridFsUploadBuilder<T1> id(T1 id) {
+
+			upload.id = id;
+			return (GridFsUploadBuilder<T1>) this;
+		}
+
+		/**
+		 * Set the filename.
+		 *
+		 * @param filename the filename to use.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> filename(String filename) {
+
+			upload.filename = filename;
+			return this;
+		}
+
+		/**
+		 * Set additional file information.
+		 *
+		 * @param options must not be {@literal null}.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> options(Options options) {
+
+			upload.options = options;
+			return this;
+		}
+
+		/**
+		 * Set the file metadata.
+		 *
+		 * @param metadata must not be {@literal null}.
+		 * @return
+		 */
+		public GridFsUploadBuilder<T> metadata(Document metadata) {
+
+			upload.options = upload.options.metadata(metadata);
+			return this;
+		}
+
+		/**
+		 * Set the upload chunk size in bytes.
+		 *
+		 * @param chunkSize use negative number for default.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> chunkSize(int chunkSize) {
+
+			upload.options = upload.options.chunkSize(chunkSize);
+			return this;
+		}
+
+		/**
+		 * Set id, filename, metadata and chunk size from given file.
+		 * 
+		 * @param gridFSFile must not be {@literal null}.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> gridFsFile(GridFSFile gridFSFile) {
+
+			upload.id = gridFSFile.getId();
+			upload.filename = gridFSFile.getFilename();
+			upload.options = upload.options.metadata(gridFSFile.getMetadata());
+			upload.options = upload.options.chunkSize(gridFSFile.getChunkSize());
+
+			return this;
+		}
+
+		/**
+		 * Set the content type.
+		 * 
+		 * @param contentType must not be {@literal null}.
+		 * @return this.
+		 */
+		public GridFsUploadBuilder<T> contentType(String contentType) {
+
+			upload.options = upload.options.contentType(contentType);
+			return this;
+		}
+
+		public GridFsUpload<T> build() {
+			return (GridFsUpload<T>) upload;
+		}
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
@@ -155,7 +155,7 @@ public interface ReactiveGridFsOperations {
 			uploadBuilder.metadata(metadata);
 		}
 
-		return save(uploadBuilder.build());
+		return store(uploadBuilder.build());
 	}
 
 	/**
@@ -169,7 +169,7 @@ public interface ReactiveGridFsOperations {
 	 *         {@link GridFsObject#getFileId()}.
 	 * @since 3.0
 	 */
-	<T> Mono<T> save(GridFsObject<T, Publisher<DataBuffer>> upload);
+	<T> Mono<T> store(GridFsObject<T, Publisher<DataBuffer>> upload);
 
 	/**
 	 * Returns a {@link Flux} emitting all files matching the given query. <br />

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplate.java
@@ -121,7 +121,7 @@ public class ReactiveGridFsTemplate extends GridFsOperationsSupport implements R
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.gridfs.ReactiveGridFsOperations#save(org.springframework.data.mongodb.gridfs.GridFsObject)
 	 */
-	public <T> Mono<T> save(GridFsObject<T, Publisher<DataBuffer>> upload) {
+	public <T> Mono<T> store(GridFsObject<T, Publisher<DataBuffer>> upload) {
 
 		GridFSUploadOptions uploadOptions = computeUploadOptionsFor(upload.getOptions().getContentType(),
 				upload.getOptions().getMetadata());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsUpload.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsUpload.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.gridfs;
+
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.lang.Nullable;
+
+import com.mongodb.client.gridfs.model.GridFSFile;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.0
+ */
+public class ReactiveGridFsUpload<ID> implements GridFsObject<ID, Publisher<DataBuffer>> {
+
+	private ID id;
+	private Publisher<DataBuffer> dataStream;
+	private String filename;
+	private Options options;
+
+	/**
+	 * The {@link GridFSFile#getId()} value converted into its simple java type. <br />
+	 * A {@link org.bson.BsonString} will be converted to plain {@link String}.
+	 *
+	 * @return can be {@literal null}.
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getFileId()
+	 */
+	@Override
+	public ID getFileId() {
+		return id;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getFielname()
+	 */
+	@Override
+	public String getFilename() {
+		return filename;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getContent()
+	 */
+	@Override
+	public Publisher<DataBuffer> getContent() {
+		return dataStream;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.gridfs.GridFsObject#getOptions()
+	 */
+	@Override
+	public Options getOptions() {
+		return options;
+	}
+
+	/**
+	 * Create a new instance of {@link ReactiveGridFsUpload} for the given {@link Publisher}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return new instance of {@link GridFsUpload}.
+	 */
+	public static ReactiveGridFsUploadBuilder<ObjectId> fromPublisher(Publisher<DataBuffer> source) {
+		return new ReactiveGridFsUploadBuilder().content(source);
+	}
+
+	/**
+	 * Builder to create {@link ReactiveGridFsUpload} in a fluent way.
+	 *
+	 * @param <T> the target id type.
+	 */
+	public static class ReactiveGridFsUploadBuilder<T> {
+
+		ReactiveGridFsUpload upload;
+
+		public ReactiveGridFsUploadBuilder() {
+
+			this.upload = new ReactiveGridFsUpload();
+			this.upload.options = Options.none();
+		}
+
+		/**
+		 * Define the content of the file to upload.
+		 *
+		 * @param source the upload content.
+		 * @return this.
+		 */
+		public ReactiveGridFsUploadBuilder<T> content(Publisher<DataBuffer> source) {
+			upload.dataStream = source;
+			return this;
+		}
+
+		/**
+		 * Set the id to use.
+		 *
+		 * @param id the id to save the content to.
+		 * @param <T1>
+		 * @return this.
+		 */
+		public <T1> ReactiveGridFsUploadBuilder<T1> id(T1 id) {
+
+			upload.id = id;
+			return (ReactiveGridFsUploadBuilder<T1>) this;
+		}
+
+		/**
+		 * Set the filename.
+		 *
+		 * @param filename the filename to use.
+		 * @return this.
+		 */
+		public ReactiveGridFsUploadBuilder<T> filename(String filename) {
+
+			upload.filename = filename;
+			return this;
+		}
+
+		/**
+		 * Set additional file information.
+		 *
+		 * @param options must not be {@literal null}.
+		 * @return this.
+		 */
+		public ReactiveGridFsUploadBuilder<T> options(Options options) {
+
+			upload.options = options;
+			return this;
+		}
+
+		/**
+		 * Set the file metadata.
+		 *
+		 * @param metadata must not be {@literal null}.
+		 * @return
+		 */
+		public ReactiveGridFsUploadBuilder<T> metadata(Document metadata) {
+
+			upload.options = upload.options.metadata(metadata);
+			return this;
+		}
+
+		/**
+		 * Set the upload chunk size in bytes.
+		 *
+		 * @param chunkSize use negative number for default.
+		 * @return
+		 */
+		public ReactiveGridFsUploadBuilder<T> chunkSize(int chunkSize) {
+
+			upload.options = upload.options.chunkSize(chunkSize);
+			return this;
+		}
+
+		/**
+		 * Set id, filename, metadata and chunk size from given file.
+		 *
+		 * @param gridFSFile must not be {@literal null}.
+		 * @return this.
+		 */
+		public ReactiveGridFsUploadBuilder<T> gridFsFile(GridFSFile gridFSFile) {
+
+			upload.id = gridFSFile.getId();
+			upload.filename = gridFSFile.getFilename();
+			upload.options = upload.options.metadata(gridFSFile.getMetadata());
+			upload.options = upload.options.chunkSize(gridFSFile.getChunkSize());
+
+			return this;
+		}
+
+		/**
+		 * Set the content type.
+		 *
+		 * @param contentType must not be {@literal null}.
+		 * @return this.
+		 */
+		public ReactiveGridFsUploadBuilder<T> contentType(String contentType) {
+
+			upload.options = upload.options.contentType(contentType);
+			return this;
+		}
+
+		public ReactiveGridFsUpload<T> build() {
+			return (ReactiveGridFsUpload<T>) upload;
+		}
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -36,11 +36,11 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonParseException;
 import org.bson.types.ObjectId;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mongodb.CodecRegistryProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.NumberUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -171,16 +171,12 @@ public class BsonUtils {
 			return new BsonBoolean((Boolean) source);
 		}
 
-		if(source instanceof Float) {
+		if (source instanceof Float) {
 			return new BsonDouble((Float) source);
 		}
 
-		if (source instanceof Double) {
-			return new BsonDouble((Double) source);
-		}
-
-		throw new IllegalArgumentException(
-				String.format("Unable to convert % (%s) to BsonValue.", source, source != null ? source.getClass() : "null"));
+		throw new IllegalArgumentException(String.format("Unable to convert %s (%s) to BsonValue.", source,
+				source != null ? source.getClass().getName() : "null"));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -23,15 +23,24 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonParseException;
+import org.bson.types.ObjectId;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mongodb.CodecRegistryProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.NumberUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -118,6 +127,60 @@ public class BsonUtils {
 			default:
 				return value;
 		}
+	}
+
+	/**
+	 * Convert a given simple value (eg. {@link String}, {@link Long}) to its corresponding {@link BsonValue}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return the corresponding {@link BsonValue} representation.
+	 * @throws IllegalArgumentException if {@literal source} does not correspond to a {@link BsonValue} type.
+	 * @since 3.0
+	 */
+	public static BsonValue simpleToBsonValue(Object source) {
+
+		if (source instanceof BsonValue) {
+			return (BsonValue) source;
+		}
+
+		if (source instanceof ObjectId) {
+			return new BsonObjectId((ObjectId) source);
+		}
+
+		if (source instanceof String) {
+			return new BsonString((String) source);
+		}
+
+		if (source instanceof Double) {
+			return new BsonDouble((Double) source);
+		}
+
+		if (source instanceof Integer) {
+			return new BsonInt32((Integer) source);
+		}
+
+		if (source instanceof Long) {
+			return new BsonInt64((Long) source);
+		}
+
+		if (source instanceof byte[]) {
+			return new BsonBinary((byte[]) source);
+		}
+
+		if (source instanceof Boolean) {
+			return new BsonBoolean((Boolean) source);
+		}
+
+		if(source instanceof Float) {
+			return new BsonDouble((Float) source);
+		}
+
+		if (source instanceof Double) {
+			return new BsonDouble((Double) source);
+		}
+
+		throw new IllegalArgumentException(
+				String.format("Unable to convert % (%s) to BsonValue.", source, source != null ? source.getClass() : "null"));
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIntegrationTests.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import org.bson.BsonObjectId;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.Before;
@@ -287,6 +288,29 @@ public class GridFsTemplateIntegrationTests {
 
 			assertThat(content).isEqualTo(StreamUtils.copyToByteArray(entry.getValue().getInputStream()));
 		}
+	}
+
+	@Test // DATAMONGO-625
+	public void storeSavesGridFsUploadWithGivenIdCorrectly() throws IOException {
+
+		String id = "id-1";
+
+		GridFsUpload<String> upload = GridFsUpload.fromStream(resource.getInputStream()) //
+				.id(id) //
+				.filename("gridFsUpload.xml") //
+				.contentType("xml") //
+				.build();
+
+		assertThat(operations.save(upload)).isEqualTo(id);
+
+		GridFsResource fsFile = operations.getResource(operations.findOne(query(where("_id").is(id))));
+		byte[] content = StreamUtils.copyToByteArray(fsFile.getInputStream());
+
+		assertThat(content).isEqualTo(StreamUtils.copyToByteArray(resource.getInputStream()));
+		assertThat(fsFile.getFilename()).isEqualTo("gridFsUpload.xml");
+		assertThat(fsFile.getId()).isEqualTo(new BsonString(id));
+		assertThat(fsFile.getFileId()).isEqualTo(id);
+		assertThat(fsFile.getContentType()).isEqualTo("xml");
 	}
 
 	@Test // DATAMONGO-765

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/GridFsTemplateIntegrationTests.java
@@ -301,7 +301,7 @@ public class GridFsTemplateIntegrationTests {
 				.contentType("xml") //
 				.build();
 
-		assertThat(operations.save(upload)).isEqualTo(id);
+		assertThat(operations.store(upload)).isEqualTo(id);
 
 		GridFsResource fsFile = operations.getResource(operations.findOne(query(where("_id").is(id))));
 		byte[] content = StreamUtils.copyToByteArray(fsFile.getInputStream());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplateTests.java
@@ -278,7 +278,7 @@ public class ReactiveGridFsTemplateTests {
 				.contentType("xml") //
 				.build();
 
-		operations.save(upload).as(StepVerifier::create).expectNext(id).verifyComplete();
+		operations.store(upload).as(StepVerifier::create).expectNext(id).verifyComplete();
 
 		operations.findOne(query(where("_id").is(id))).flatMap(operations::getResource)
 				.flatMapMany(ReactiveGridFsResource::getDownloadStream) //

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/BsonUtilsTest.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/BsonUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.util.json;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.util.BsonUtils;
+
+/**
+ * @author Christoph Strobl
+ */
+class BsonUtilsTest {
+
+	@Test // DATAMONGO-625
+	void simpleToBsonValue() {
+
+		assertThat(BsonUtils.simpleToBsonValue(Long.valueOf(10))).isEqualTo(new BsonInt64(10));
+		assertThat(BsonUtils.simpleToBsonValue(new Integer(10))).isEqualTo(new BsonInt32(10));
+		assertThat(BsonUtils.simpleToBsonValue(Double.valueOf(0.1D))).isEqualTo(new BsonDouble(0.1D));
+		assertThat(BsonUtils.simpleToBsonValue("value")).isEqualTo(new BsonString("value"));
+	}
+
+	@Test // DATAMONGO-625
+	void primitiveToBsonValue() {
+		assertThat(BsonUtils.simpleToBsonValue(10L)).isEqualTo(new BsonInt64(10));
+	}
+
+	@Test // DATAMONGO-625
+	void objectIdToBsonValue() {
+
+		ObjectId source = new ObjectId();
+		assertThat(BsonUtils.simpleToBsonValue(source)).isEqualTo(new BsonObjectId(source));
+	}
+
+	@Test // DATAMONGO-625
+	void bsonValueToBsonValue() {
+
+		BsonObjectId source = new BsonObjectId(new ObjectId());
+		assertThat(BsonUtils.simpleToBsonValue(source)).isSameAs(source);
+	}
+
+	@Test // DATAMONGO-625
+	void unsupportedToBsonValue() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> BsonUtils.simpleToBsonValue(new Object()));
+	}
+}


### PR DESCRIPTION
We now support storing GridFS content with predefined `_id`, which allows to replace an existing resource instead of having to delete and reupload it.

```java
GridFsUpload<String> upload = GridFsUpload.fromStream(resource.getInputStream())
	.id(id)
	.filename("upload.xml")
	.contentType("sync")
	.build();

gridFsTemplate.save(upload);
```

```java
ReactiveGridFsUpload<String> upload = ReactiveGridFsUpload.fromPublisher(data)
	.id(id)
	.filename("upload.xml")
	.contentType("reactive")
	.build();

reactiveGridFsTemplate.save(upload).subscribe();
```