### PR TITLE
DATAMONGO-2445 - Deprecate ReactiveGridFsOperations using AsyncInputStream.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.6.BUILD-SNAPSHOT</version>
+	<version>2.2.6.DATAMONGO-2445-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.6.BUILD-SNAPSHOT</version>
+		<version>2.2.6.DATAMONGO-2445-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.6.BUILD-SNAPSHOT</version>
+		<version>2.2.6.DATAMONGO-2445-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.6.BUILD-SNAPSHOT</version>
+		<version>2.2.6.DATAMONGO-2445-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
@@ -111,7 +111,10 @@ public interface ReactiveGridFsOperations {
 	 * @param metadata can be {@literal null}
 	 * @return a {@link Mono} emitting the {@link ObjectId} of the {@link com.mongodb.client.gridfs.model.GridFSFile} just
 	 *         created.
+	 * @deprecated since 2.2.6. Will be removed in 3.0. Please use {@link #store(Publisher, String, String, Object)}
+	 *             instead.
 	 */
+	@Deprecated
 	Mono<ObjectId> store(AsyncInputStream content, @Nullable String filename, @Nullable String contentType,
 			@Nullable Object metadata);
 
@@ -151,7 +154,10 @@ public interface ReactiveGridFsOperations {
 	 * @param metadata can be {@literal null}.
 	 * @return a {@link Mono} emitting the {@link ObjectId} of the {@link com.mongodb.client.gridfs.model.GridFSFile} just
 	 *         created.
+	 * @deprecated since 2.2.6. Will be removed in 3.0. Please use {@link #store(Publisher, String, String, Document)}
+	 *             instead.
 	 */
+	@Deprecated
 	Mono<ObjectId> store(AsyncInputStream content, @Nullable String filename, @Nullable String contentType,
 			@Nullable Document metadata);
 


### PR DESCRIPTION
Methods using `AsyncInputStream` will be removed in _3.0_. Please use the once accepting a `Publisher`.