### PR TITLE
DATAMONGO-2502 - Fix regression in field name mapping for nested array paths.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2502-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2502-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2502-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2502-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -272,6 +272,7 @@ public class UpdateMapper extends QueryMapper {
 	 *
 	 * @author Thomas Darimont
 	 * @author Oliver Gierke
+	 * @author Christoph Strobl
 	 */
 	private static class MetadataBackedUpdateField extends MetadataBackedField {
 
@@ -289,7 +290,7 @@ public class UpdateMapper extends QueryMapper {
 		public MetadataBackedUpdateField(MongoPersistentEntity<?> entity, String key,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
-			super(key.replaceAll("\\.\\$(\\[.*\\])?", ""), entity, mappingContext);
+			super(key, entity, mappingContext);
 			this.key = key;
 		}
 
@@ -338,7 +339,7 @@ public class UpdateMapper extends QueryMapper {
 					MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext,
 					Association<MongoPersistentProperty> association, String key) {
 
-				super(association);
+				super(key, association);
 				this.mapper = new KeyMapper(key, mappingContext);
 			}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -966,6 +966,32 @@ public class QueryMapperUnitTests {
 		assertThat(target).isEqualTo(new org.bson.Document("arrayCustomName.$[some_item].nes-ted.$[other_item]", "value"));
 	}
 
+	@Test // DATAMONGO-2502
+	void shouldAllowDeeplyNestedPlaceholders() {
+
+		org.bson.Document target = mapper.getMappedObject(
+				query(where("level0.$[some_item].arrayObj.$[other_item].nested").is("value")).getQueryObject(),
+				context.getPersistentEntity(WithDeepArrayNesting.class));
+
+		assertThat(target).isEqualTo(new org.bson.Document("level0.$[some_item].arrayObj.$[other_item].nested", "value"));
+	}
+
+	@Test // DATAMONGO-2502
+	void shouldAllowDeeplyNestedPlaceholdersWithCustomName() {
+
+		org.bson.Document target = mapper.getMappedObject(
+				query(where("level0.$[some_item].arrayCustomName.$[other_item].nested").is("value")).getQueryObject(),
+				context.getPersistentEntity(WithDeepArrayNesting.class));
+
+		assertThat(target)
+				.isEqualTo(new org.bson.Document("level0.$[some_item].arrayCustomName.$[other_item].nes-ted", "value"));
+	}
+
+	class WithDeepArrayNesting {
+
+		List<WithNestedArray> level0;
+	}
+
 	class WithNestedArray {
 
 		List<NestedArrayOfObj> arrayObj;


### PR DESCRIPTION
We now remove placeholders correctly which allows to traverse the path based on actual properties. This enables a correct mapping of the individual parts.

Related to [DATAMONGO-2488](https://jira.spring.io/browse/DATAMONGO-2488) (#841).