### PR TITLE
DATAMONGO-2507 - Default method ReactiveFindOperation.DistinctWithQuery.matching(CriteriaDefinition).

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
@@ -46,6 +46,7 @@ import org.springframework.data.mongodb.core.query.Query;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Juergen Zimmermann
  * @since 2.0
  */
 public interface ReactiveFindOperation {
@@ -275,6 +276,18 @@ public interface ReactiveFindOperation {
 		 * @throws IllegalArgumentException if resultType is {@literal null}.
 		 */
 		TerminatingDistinct<T> matching(Query query);
+
+		/**
+		 * Set the filter {@link CriteriaDefinition criteria} to be used.
+		 *
+		 * @param criteriaDefinition must not be {@literal null}.
+		 * @return new instance of {@link TerminatingFind}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 * @since 3.0
+		 */
+		default TerminatingDistinct<T> matching(CriteriaDefinition criteriaDefinition) {
+			return matching(Query.query(criteriaDefinition));
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveFindOperationSupportTests.java
@@ -59,6 +59,7 @@ import com.mongodb.client.MongoClient;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Juergen Zimmermann
  */
 @ExtendWith(MongoClientExtension.class)
 class ReactiveFindOperationSupportTests {
@@ -168,6 +169,14 @@ class ReactiveFindOperationSupportTests {
 
 		template.query(Person.class).matching(where("firstname").is("luke")).all().as(StepVerifier::create) //
 				.expectNext(luke) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-2507
+	void findAllWithProjectionByCriteria() {
+
+		template.query(Person.class).as(Jedi.class).matching(where("firstname").is("luke")).all()
+				.as(StepVerifier::create).consumeNextWith(it -> assertThat(it).isInstanceOf(Jedi.class)) //
 				.verifyComplete();
 	}
 


### PR DESCRIPTION
A PR for https://jira.spring.io/browse/DATAMONGO-2507 to add a default method accepting a `CriteriaDefinition` on `ReactiveFindOperation.DistinctWithQuery`.

- [ x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ x] You submit test cases (unit or integration tests) that back your changes.
- [ x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
