### PR TITLE
DATAMONGO-2516 - Assert compatibility with MongoDB 4.4-rc0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2516-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2516-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2516-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2516-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateIndexTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateIndexTests.java
@@ -208,8 +208,9 @@ public class ReactiveMongoTemplateIndexTests {
 		StepVerifier.create(template.getCollection("indexedSample").listIndexes(Document.class)).expectNextCount(0)
 				.verifyComplete();
 
-		template.findAll(IndexedSample.class) //
-				.delayElements(Duration.ofMillis(200)) // TODO: check if 4.2.0 server GA still requires this timeout
+		template.findAll(IndexedSample.class).defaultIfEmpty(new IndexedSample()) //
+				.delayElements(Duration.ofMillis(500)) // TODO: check if 4.2.0 server GA still requires this timeout
+				.then()
 				.as(StepVerifier::create) //
 				.verifyComplete();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
@@ -49,8 +49,9 @@ class UpdateOperationsUnitTests {
 	QueryMapper queryMapper = new QueryMapper(mongoConverter);
 	UpdateMapper updateMapper = new UpdateMapper(mongoConverter);
 	EntityOperations entityOperations = new EntityOperations(mappingContext);
+	PropertyOperations propertyOperations = new PropertyOperations(mappingContext);
 
-	ExtendedQueryOperations queryOperations = new ExtendedQueryOperations(queryMapper, updateMapper, entityOperations,
+	ExtendedQueryOperations queryOperations = new ExtendedQueryOperations(queryMapper, updateMapper, entityOperations, propertyOperations,
 			MongoClientSettings::getDefaultCodecRegistry);
 
 	@Test // DATAMONGO-2341
@@ -123,9 +124,9 @@ class UpdateOperationsUnitTests {
 
 	class ExtendedQueryOperations extends QueryOperations {
 
-		ExtendedQueryOperations(QueryMapper queryMapper, UpdateMapper updateMapper, EntityOperations entityOperations,
+		ExtendedQueryOperations(QueryMapper queryMapper, UpdateMapper updateMapper, EntityOperations entityOperations, PropertyOperations propertyOperations,
 				CodecRegistryProvider codecRegistryProvider) {
-			super(queryMapper, updateMapper, entityOperations, codecRegistryProvider);
+			super(queryMapper, updateMapper, entityOperations, propertyOperations, codecRegistryProvider);
 		}
 
 		@NonNull

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/MongoRepositoryTextSearchIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/MongoRepositoryTextSearchIntegrationTests.java
@@ -169,13 +169,13 @@ public class MongoRepositoryTextSearchIntegrationTests {
 		assertThat(result.get(0)).isEqualTo(snipes);
 	}
 
-	@Test // DATAMONGO-973
+	@Test // DATAMONGO-973, DATAMONGO-2516
 	public void derivedFinderMethodWithoutFullTextShouldNoCauseTroubleWhenHavingEntityWithTextScoreProperty() {
 
 		initRepoWithDefaultDocuments();
 		List<FullTextDocument> result = repo.findByTitle(DROP_ZONE.getTitle());
 		assertThat(result.get(0)).isEqualTo(DROP_ZONE);
-		assertThat(result.get(0).score).isEqualTo(0.0F);
+		assertThat(result.get(0).score).isNull();
 	}
 
 	private void initRepoWithDefaultDocuments() {


### PR DESCRIPTION
Fixes:
- Fields list must not contain text search score property when no `$text` criteria present.
- Sort must not be an empty document when running map reduce.
- Timeout in tests creating indexes.

Changes:
- score property might now be `null` (was `zero` before) when not having a `$text` criteria present. 