### PR TITLE
DATAMONGO-2517 - Fix invalid entity creation for text queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.7.BUILD-SNAPSHOT</version>
+	<version>2.2.x.DATAMONGO-2517-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.7.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2517-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.7.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2517-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.7.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2517-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -1263,9 +1263,12 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		}
 
 		if (conversions.isSimpleType(obj.getClass())) {
-			// Doesn't need conversion
-			return getPotentiallyConvertedSimpleWrite(obj,
-					typeInformation != null ? typeInformation.getType() : Object.class);
+
+			Class<?> conversionTargetType = Object.class;
+			if(typeInformation != null && conversions.isSimpleType(typeInformation.getType())) {
+				conversionTargetType = typeInformation.getType();
+			}
+			return getPotentiallyConvertedSimpleWrite(obj, conversionTargetType);
 		}
 
 		if (obj instanceof List) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -55,6 +55,7 @@ import org.springframework.data.mongodb.core.mapping.TextScore;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.TextQuery;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
@@ -988,6 +989,16 @@ public class QueryMapperUnitTests {
 				.isEqualTo(new org.bson.Document("level0.$[some_item].arrayCustomName.$[other_item].nes-ted", "value"));
 	}
 
+	@Test // DATAMONGO-2517
+	public void shouldParseNestedKeywordWithArgumentMatchingTheSourceEntitiesConstructorCorrectly() {
+
+		TextQuery source = new TextQuery("test");
+
+		org.bson.Document target = mapper.getMappedObject(source.getQueryObject(),
+				context.getPersistentEntity(WithSingleStringArgConstructor.class));
+		assertThat(target).isEqualTo(org.bson.Document.parse("{\"$text\" : { \"$search\" : \"test\" }}"));
+	}
+
 	class WithDeepArrayNesting {
 
 		List<WithNestedArray> level0;
@@ -1158,5 +1169,17 @@ public class QueryMapperUnitTests {
 
 		String id;
 		@Field(targetType = FieldType.OBJECT_ID) String stringAsOid;
+	}
+
+	@Document
+	static class WithSingleStringArgConstructor {
+
+		String value;
+
+		public WithSingleStringArgConstructor() {}
+
+		public WithSingleStringArgConstructor(String value) {
+			this.value = value;
+		}
 	}
 }


### PR DESCRIPTION
Fix a glitch in the `MappingMongoConverter` that uses the single argument constructor (since it matches in type and parameter count to the given input string) to falsely instantiate an Entity when it should not.