### PR TITLE
DATAMONGO-2519 - Default methods on ReactiveGridFsOperations to accept CriteriaDefinition.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
@@ -25,6 +25,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.gridfs.ReactiveGridFsUpload.ReactiveGridFsUploadBuilder;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -36,6 +37,7 @@ import com.mongodb.client.gridfs.model.GridFSFile;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Juergen Zimmermann
  * @since 2.2
  */
 public interface ReactiveGridFsOperations {
@@ -183,6 +185,18 @@ public interface ReactiveGridFsOperations {
 	Flux<GridFSFile> find(Query query);
 
 	/**
+	 * Returns a {@link Flux} emitting all files matching the given {@link CriteriaDefinition criteria}. <br />
+	 * <strong>Note:</strong> Currently {@link Sort} criteria defined at the {@link Query} will not be regarded as MongoDB
+	 * does not support ordering for GridFS file access.
+	 *
+	 * @param criteria must not be {@literal null}.
+	 * @return {@link Flux#empty()} if no mach found.
+	 */
+	default Flux<GridFSFile> find(CriteriaDefinition criteria) {
+		return find(Query.query(criteria));
+	}
+
+	/**
 	 * Returns a {@link Mono} emitting a single {@link com.mongodb.client.gridfs.model.GridFSFile} matching the given
 	 * query or {@link Mono#empty()} in case no file matches. <br />
 	 * <strong>NOTE</strong> If more than one file matches the given query the resulting {@link Mono} emits an error. If
@@ -194,6 +208,19 @@ public interface ReactiveGridFsOperations {
 	Mono<GridFSFile> findOne(Query query);
 
 	/**
+	 * Returns a {@link Mono} emitting a single {@link com.mongodb.client.gridfs.model.GridFSFile} matching the given
+	 * {@link CriteriaDefinition criteria} or {@link Mono#empty()} in case no file matches. <br />
+	 * <strong>NOTE</strong> If more than one file matches the given query the resulting {@link Mono} emits an error. If
+	 * you want to obtain the first found file use {@link #findFirst(CriteriaDefinition)}.
+	 *
+	 * @param criteria must not be {@literal null}.
+	 * @return {@link Mono#empty()} if not match found.
+	 */
+	default Mono<GridFSFile> findOne(CriteriaDefinition criteria) {
+		return findOne(Query.query(criteria));
+	}
+
+	/**
 	 * Returns a {@link Mono} emitting the frist {@link com.mongodb.client.gridfs.model.GridFSFile} matching the given
 	 * query or {@link Mono#empty()} in case no file matches.
 	 *
@@ -203,12 +230,33 @@ public interface ReactiveGridFsOperations {
 	Mono<GridFSFile> findFirst(Query query);
 
 	/**
+	 * Returns a {@link Mono} emitting the frist {@link com.mongodb.client.gridfs.model.GridFSFile} matching the given
+	 * {@link CriteriaDefinition criteria} or {@link Mono#empty()} in case no file matches.
+	 *
+	 * @param criteria must not be {@literal null}.
+	 * @return {@link Mono#empty()} if not match found.
+	 */
+	default Mono<GridFSFile> findFirst(CriteriaDefinition criteria) {
+		return findFirst(Query.query(criteria));
+	}
+
+	/**
 	 * Deletes all files matching the given {@link Query}.
 	 *
 	 * @param query must not be {@literal null}.
 	 * @return a {@link Mono} signalling operation completion.
 	 */
 	Mono<Void> delete(Query query);
+
+	/**
+	 * Deletes all files matching the given {@link CriteriaDefinition criteria}.
+	 *
+	 * @param criteria must not be {@literal null}.
+	 * @return a {@link Mono} signalling operation completion.
+	 */
+	default Mono<Void> delete(CriteriaDefinition criteria) {
+		return delete(Query.query(criteria));
+	}
 
 	/**
 	 * Returns a {@link Mono} emitting the {@link ReactiveGridFsResource} with the given file name.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsTemplateTests.java
@@ -65,6 +65,7 @@ import com.mongodb.internal.HexUtils;
  * @author Christoph Strobl
  * @author Nick Stolwijk
  * @author Denis Zavedeev
+ * @author Juergen Zimmermann
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration("classpath:gridfs/reactive-gridfs.xml")
@@ -95,6 +96,23 @@ public class ReactiveGridFsTemplateTests {
 		ObjectId reference = operations.store(Flux.just(first, second), "foo.xml").block();
 
 		operations.find(query(where("_id").is(reference))) //
+				.as(StepVerifier::create) //
+				.assertNext(actual -> {
+					assertThat(((BsonObjectId) actual.getId()).getValue()).isEqualTo(reference);
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-2519
+	public void storesAndFindsSimpleDocumentByCriteria() {
+
+		DefaultDataBufferFactory factory = new DefaultDataBufferFactory();
+		DefaultDataBuffer first = factory.wrap("first".getBytes());
+		DefaultDataBuffer second = factory.wrap("second".getBytes());
+
+		ObjectId reference = operations.store(Flux.just(first, second), "foo.xml").block();
+
+		operations.find(where("_id").is(reference)) //
 				.as(StepVerifier::create) //
 				.assertNext(actual -> {
 					assertThat(((BsonObjectId) actual.getId()).getValue()).isEqualTo(reference);
@@ -141,6 +159,45 @@ public class ReactiveGridFsTemplateTests {
 				}).verifyComplete();
 	}
 
+	@Test // DATAMONGO-2519
+	public void storesAndLoadsLargeFileCorrectlyByCriteria() {
+
+		ByteBuffer buffer = ByteBuffer.allocate(1000 * 1000); // 1 mb
+		int i = 0;
+		while (buffer.remaining() != 0) {
+			buffer.put(HexUtils.toHex(new byte[] { (byte) (i++ % 16) }).getBytes());
+		}
+		buffer.flip();
+
+		DefaultDataBufferFactory factory = new DefaultDataBufferFactory();
+
+		ObjectId reference = operations.store(Flux.just(factory.wrap(buffer)), "large.txt").block();
+
+		buffer.clear();
+
+		// default chunk size
+		operations.findOne(where("_id").is(reference)).flatMap(operations::getResource)
+				.flatMapMany(ReactiveGridFsResource::getDownloadStream) //
+				.transform(DataBufferUtils::join) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(dataBuffer -> {
+
+					assertThat(dataBuffer.readableByteCount()).isEqualTo(buffer.remaining());
+					assertThat(dataBuffer.asByteBuffer()).isEqualTo(buffer);
+				}).verifyComplete();
+
+		// small chunk size
+		operations.findOne(where("_id").is(reference)).flatMap(operations::getResource)
+				.flatMapMany(reactiveGridFsResource -> reactiveGridFsResource.getDownloadStream(256)) //
+				.transform(DataBufferUtils::join) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(dataBuffer -> {
+
+					assertThat(dataBuffer.readableByteCount()).isEqualTo(buffer.remaining());
+					assertThat(dataBuffer.asByteBuffer()).isEqualTo(buffer);
+				}).verifyComplete();
+	}
+
 	@Test // DATAMONGO-1855
 	public void writesMetadataCorrectly() throws IOException {
 
@@ -150,6 +207,22 @@ public class ReactiveGridFsTemplateTests {
 		ObjectId reference = operations.store(source, "foo.xml", "binary/octet-stream", metadata).block();
 
 		operations.find(query(whereMetaData("key").is("value"))) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual.getObjectId()).isEqualTo(reference);
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-2519
+	public void writesMetadataCorrectlyByCriteria() throws IOException {
+
+		Document metadata = new Document("key", "value");
+
+		Flux<DataBuffer> source = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+		ObjectId reference = operations.store(source, "foo.xml", "binary/octet-stream", metadata).block();
+
+		operations.find(whereMetaData("key").is("value")) //
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
 					assertThat(actual.getObjectId()).isEqualTo(reference);
@@ -175,6 +248,24 @@ public class ReactiveGridFsTemplateTests {
 				.verifyComplete();
 	}
 
+	@Test // DATAMONGO-2519
+	public void marshalsComplexMetadataByCriteria() {
+
+		Metadata metadata = new Metadata();
+		metadata.version = "1.0";
+
+		Flux<DataBuffer> source = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+		ObjectId reference = operations.store(source, "foo.xml", "binary/octet-stream", metadata).block();
+
+		operations.find(whereMetaData("version").is("1.0")) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual.getObjectId()).isEqualTo(reference);
+					assertThat(actual.getMetadata()).containsEntry("version", "1.0");
+				}) //
+				.verifyComplete();
+	}
+
 	@Test // DATAMONGO-1855
 	public void getResourceShouldRetrieveContentByIdentity() throws IOException {
 
@@ -183,6 +274,27 @@ public class ReactiveGridFsTemplateTests {
 		ObjectId reference = operations.store(source, "foo.xml", null, null).block();
 
 		operations.findOne(query(where("_id").is(reference))).flatMap(operations::getResource)
+				.flatMapMany(ReactiveGridFsResource::getDownloadStream) //
+				.transform(DataBufferUtils::join) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(dataBuffer -> {
+
+					byte[] actual = new byte[dataBuffer.readableByteCount()];
+					dataBuffer.read(actual);
+
+					assertThat(actual).isEqualTo(content);
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-2519
+	public void getResourceShouldRetrieveContentByIdentityByCriteria() throws IOException {
+
+		byte[] content = StreamUtils.copyToByteArray(resource.getInputStream());
+		Flux<DataBuffer> source = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+		ObjectId reference = operations.store(source, "foo.xml", null, null).block();
+
+		operations.findOne(where("_id").is(reference)).flatMap(operations::getResource)
 				.flatMapMany(ReactiveGridFsResource::getDownloadStream) //
 				.transform(DataBufferUtils::join) //
 				.as(StepVerifier::create) //
@@ -215,6 +327,25 @@ public class ReactiveGridFsTemplateTests {
 				}).verifyComplete();
 	}
 
+	@Test // DATAMONGO-2519
+	public void shouldEmitFirstEntryWhenFindFirstRetrievesMoreThanOneResultByCriteria() throws IOException {
+
+		Flux<DataBuffer> upload1 = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+		Flux<DataBuffer> upload2 = DataBufferUtils.read(new ClassPathResource("gridfs/another-resource.xml"),
+				new DefaultDataBufferFactory(), 256);
+
+		operations.store(upload1, "foo.xml", null, null).block();
+		operations.store(upload2, "foo2.xml", null, null).block();
+
+		operations.findFirst(where("filename").regex("foo*")) //
+				.flatMap(operations::getResource) //
+				.as(StepVerifier::create) //
+				.assertNext(actual -> {
+
+					assertThat(actual.getGridFSFile()).isNotNull();
+				}).verifyComplete();
+	}
+
 	@Test // DATAMONGO-2240
 	public void shouldReturnNoGridFsFileWhenAbsent() {
 
@@ -238,6 +369,22 @@ public class ReactiveGridFsTemplateTests {
 		operations.store(upload2, "foo2.xml", null, null).block();
 
 		operations.findOne(query(where("filename").regex("foo*"))) //
+				.as(StepVerifier::create) //
+				.expectError(IncorrectResultSizeDataAccessException.class) //
+				.verify();
+	}
+
+	@Test // DATAMONGO-2519
+	public void shouldEmitErrorWhenFindOneRetrievesMoreThanOneResultByCriteria() throws IOException {
+
+		Flux<DataBuffer> upload1 = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+		Flux<DataBuffer> upload2 = DataBufferUtils.read(new ClassPathResource("gridfs/another-resource.xml"),
+				new DefaultDataBufferFactory(), 256);
+
+		operations.store(upload1, "foo.xml", null, null).block();
+		operations.store(upload2, "foo2.xml", null, null).block();
+
+		operations.findOne(where("filename").regex("foo*")) //
 				.as(StepVerifier::create) //
 				.expectError(IncorrectResultSizeDataAccessException.class) //
 				.verify();
@@ -294,6 +441,41 @@ public class ReactiveGridFsTemplateTests {
 				.verifyComplete();
 
 		operations.findOne(query(where("_id").is(id))).as(StepVerifier::create).consumeNextWith(it -> {
+			assertThat(it.getFilename()).isEqualTo("gridFsUpload.xml");
+			assertThat(it.getId()).isEqualTo(new BsonString(id));
+			assertThat(it.getMetadata()).containsValue("xml");
+		}).verifyComplete();
+	}
+
+	@Test // DATAMONGO-2519
+	public void storeSavesGridFsUploadWithGivenIdCorrectlyByCriteria() throws IOException {
+
+		String id = "id-1";
+		byte[] content = StreamUtils.copyToByteArray(resource.getInputStream());
+		Flux<DataBuffer> data = DataBufferUtils.read(resource, new DefaultDataBufferFactory(), 256);
+
+		ReactiveGridFsUpload<String> upload = ReactiveGridFsUpload.fromPublisher(data) //
+				.id(id) //
+				.filename("gridFsUpload.xml") //
+				.contentType("xml") //
+				.build();
+
+		operations.store(upload).as(StepVerifier::create).expectNext(id).verifyComplete();
+
+		operations.findOne(where("_id").is(id)).flatMap(operations::getResource)
+				.flatMapMany(ReactiveGridFsResource::getDownloadStream) //
+				.transform(DataBufferUtils::join) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(dataBuffer -> {
+
+					byte[] actual = new byte[dataBuffer.readableByteCount()];
+					dataBuffer.read(actual);
+
+					assertThat(actual).isEqualTo(content);
+				}) //
+				.verifyComplete();
+
+		operations.findOne(where("_id").is(id)).as(StepVerifier::create).consumeNextWith(it -> {
 			assertThat(it.getFilename()).isEqualTo("gridFsUpload.xml");
 			assertThat(it.getId()).isEqualTo(new BsonString(id));
 			assertThat(it.getMetadata()).containsValue("xml");


### PR DESCRIPTION
A PR for https://jira.spring.io/browse/DATAMONGO-2519 to add default methods accepting a CriteriaDefinition on ReactiveGridFsOperations,

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x ] You submit test cases (unit or integration tests) that back your changes.
- [x ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
