### PR TITLE
DATAMONGO-2542 - Shortcut PersistentPropertyPath resolution during query creation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATAMONGO-2542-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATAMONGO-2542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -965,7 +965,7 @@ public class QueryMapper {
 			this.entity = entity;
 			this.mappingContext = context;
 
-			this.path = getPath(removePlaceholders(POSITIONAL_PARAMETER_PATTERN, name));
+			this.path = getPath(removePlaceholders(POSITIONAL_PARAMETER_PATTERN, name), property);
 			this.property = path == null ? property : path.getLeafProperty();
 			this.association = findAssociation();
 		}
@@ -1079,10 +1079,16 @@ public class QueryMapper {
 		 * @return
 		 */
 		@Nullable
-		private PersistentPropertyPath<MongoPersistentProperty> getPath(String pathExpression) {
+		private PersistentPropertyPath<MongoPersistentProperty> getPath(String pathExpression,
+				MongoPersistentProperty sourceProperty) {
 
 			String rawPath = removePlaceholders(POSITIONAL_OPERATOR,
 					removePlaceholders(DOT_POSITIONAL_PATTERN, pathExpression));
+
+			if (sourceProperty != null && sourceProperty.getOwner().equals(entity)) {
+				return mappingContext
+						.getPersistentPropertyPath(PropertyPath.from(sourceProperty.getName(), entity.getTypeInformation()));
+			}
 
 			PropertyPath path = forName(rawPath);
 			if (path == null || isPathToJavaLangClassProperty(path)) {


### PR DESCRIPTION
By shortcutting the path resolution we avoid checking keywords like `$in` against a potential path expression.