### PR TITLE
DATAMONGO-2545 - Fix regression in String query SpEL parameter binding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-DATAMONGO-2545-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2545-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2545-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2545-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -494,6 +495,9 @@ public class ParameterBindingJsonReader extends AbstractBsonReader {
 		}
 		if (ClassUtils.isAssignable(Iterable.class, type)) {
 			return BsonType.ARRAY;
+		}
+		if (ClassUtils.isAssignable(Map.class, type)) {
+			return BsonType.DOCUMENT;
 		}
 
 		return BsonType.UNDEFINED;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
@@ -370,23 +370,30 @@ public class ParameterBindingJsonReader extends AbstractBsonReader {
 
 		if (token.getType().equals(JsonTokenType.UNQUOTED_STRING)) {
 
-			if (matcher.find()) {
-
-				int index = computeParameterIndex(matcher.group());
-				bindableValue.setValue(getBindableValueForIndex(index));
-				bindableValue.setType(bsonTypeForValue(getBindableValueForIndex(index)));
-				return bindableValue;
-			}
-
 			Matcher regexMatcher = EXPRESSION_BINDING_PATTERN.matcher(tokenValue);
 			if (regexMatcher.find()) {
 
 				String binding = regexMatcher.group();
 				String expression = binding.substring(3, binding.length() - 1);
 
+				Matcher inSpelMatcher = PARAMETER_BINDING_PATTERN.matcher(expression);
+				while (inSpelMatcher.find()) {
+
+					int index = computeParameterIndex(inSpelMatcher.group());
+					expression = expression.replace(inSpelMatcher.group(), getBindableValueForIndex(index).toString());
+				}
+
 				Object value = evaluateExpression(expression);
 				bindableValue.setValue(value);
 				bindableValue.setType(bsonTypeForValue(value));
+				return bindableValue;
+			}
+
+			if (matcher.find()) {
+
+				int index = computeParameterIndex(matcher.group());
+				bindableValue.setValue(getBindableValueForIndex(index));
+				bindableValue.setType(bsonTypeForValue(getBindableValueForIndex(index)));
 				return bindableValue;
 			}
 
@@ -398,26 +405,35 @@ public class ParameterBindingJsonReader extends AbstractBsonReader {
 
 		String computedValue = tokenValue;
 
-		boolean matched = false;
+
+
+		Matcher regexMatcher = EXPRESSION_BINDING_PATTERN.matcher(computedValue);
+
+		while (regexMatcher.find()) {
+
+			String binding = regexMatcher.group();
+			String expression = binding.substring(3, binding.length() - 1);
+
+			Matcher inSpelMatcher = PARAMETER_BINDING_PATTERN.matcher(expression);
+			while (inSpelMatcher.find()) {
+
+				int index = computeParameterIndex(inSpelMatcher.group());
+				expression = expression.replace(inSpelMatcher.group(), getBindableValueForIndex(index).toString());
+			}
+
+			computedValue = computedValue.replace(binding, nullSafeToString(evaluateExpression(expression)));
+
+			bindableValue.setValue(computedValue);
+			bindableValue.setType(BsonType.STRING);
+
+			return bindableValue;
+		}
+
 		while (matcher.find()) {
 
-			matched = true;
 			String group = matcher.group();
 			int index = computeParameterIndex(group);
 			computedValue = computedValue.replace(group, nullSafeToString(getBindableValueForIndex(index)));
-		}
-
-		if (!matched) {
-
-			Matcher regexMatcher = EXPRESSION_BINDING_PATTERN.matcher(tokenValue);
-
-			while (regexMatcher.find()) {
-
-				String binding = regexMatcher.group();
-				String expression = binding.substring(3, binding.length() - 1);
-
-				computedValue = computedValue.replace(binding, nullSafeToString(evaluateExpression(expression)));
-			}
 		}
 
 		bindableValue.setValue(computedValue);


### PR DESCRIPTION
The PR includes a fix for parameter binding within a SpEL expression using query parameter placeholders `?0`, `?1`,... instead of the array index `[0]`,`[1]`,...

```java
@Query("{ 'hidden' : ?#{ hasRole('batman') ? '?0' : '?1' } }"
List<User> findAllUsingSpelBy(String arg0, String arg1);
```

It also fixes the case where the SpEL expression actually results in the query document to use.

```java
@Query("?#{ hasRole('admin') ? { 'region': 'all' } : { 'user.superviser':  principal.id } }")
List<User> findAllUsingSpelBy();
```