### PR TITLE
DATAMONGO-2547 - Use target class ClassLoader instead of default CL when creating proxy instances.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>2.2.8.BUILD-SNAPSHOT</version>
+	<version>2.2.x.DATAMONGO-2547-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.8.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2547-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.8.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2547-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>2.2.8.BUILD-SNAPSHOT</version>
+		<version>2.2.x.DATAMONGO-2547-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbFactorySupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoDbFactorySupport.java
@@ -265,7 +265,7 @@ public abstract class MongoDbFactorySupport<C> implements MongoDbFactory {
 			factory.addAdvice(new SessionAwareMethodInterceptor<>(session, target, ClientSession.class, MongoDatabase.class,
 					this::proxyDatabase, MongoCollection.class, this::proxyCollection));
 
-			return targetType.cast(factory.getProxy());
+			return targetType.cast(factory.getProxy(target.getClass().getClassLoader()));
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactory.java
@@ -242,7 +242,7 @@ public class SimpleReactiveMongoDatabaseFactory implements DisposableBean, React
 			factory.addAdvice(new SessionAwareMethodInterceptor<>(session, target, ClientSession.class, MongoDatabase.class,
 					this::proxyDatabase, MongoCollection.class, this::proxyCollection));
 
-			return targetType.cast(factory.getProxy());
+			return targetType.cast(factory.getProxy(target.getClass().getClassLoader()));
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultDbRefResolver.java
@@ -202,7 +202,7 @@ public class DefaultDbRefResolver implements DbRefResolver {
 		proxyFactory.addInterface(propertyType);
 		proxyFactory.addAdvice(interceptor);
 
-		return handler.populateId(property, dbref, proxyFactory.getProxy());
+		return handler.populateId(property, dbref, proxyFactory.getProxy(LazyLoadingProxy.class.getClassLoader()));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/QueryUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/QueryUtils.java
@@ -61,7 +61,7 @@ class QueryUtils {
 			return combinedSort;
 		});
 
-		return (Query) factory.getProxy();
+		return (Query) factory.getProxy(query.getClass().getClassLoader());
 	}
 
 	/**


### PR DESCRIPTION
related to: spring-projects/spring-boot#21438