### PR TITLE
Do not overwrite contentType for GridFsFile

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/GridFsOperations.java
@@ -140,11 +140,11 @@ public interface GridFsOperations extends ResourcePatternResolver {
 		if (StringUtils.hasText(filename)) {
 			uploadBuilder.filename(filename);
 		}
-		if (StringUtils.hasText(contentType)) {
-			uploadBuilder.contentType(contentType);
-		}
 		if (!ObjectUtils.isEmpty(metadata)) {
 			uploadBuilder.metadata(metadata);
+		}
+		if (StringUtils.hasText(contentType)) {
+			uploadBuilder.contentType(contentType);
 		}
 
 		return store(uploadBuilder.build());


### PR DESCRIPTION
When calling store method on GridFSOperations I've found that contentType has been overwritten. This is very simple fix.