### PR TITLE
DATAMONGO-2572 - Remove black list and slaveOk from code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-DATAMONGO-2572-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2572-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2572-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-DATAMONGO-2572-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1172,7 +1172,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 	/**
 	 * Prepare the collection before any processing is done using it. This allows a convenient way to apply settings like
-	 * slaveOk() etc. Can be overridden in sub-classes.
+	 * withCodecRegistry() etc. Can be overridden in sub-classes.
 	 *
 	 * @param collection
 	 */
@@ -3274,6 +3274,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 							case PARTIAL:
 								cursorToUse = cursorToUse.partial(true);
 								break;
+							case SECONDARY_READS:
 							case SLAVE_OK:
 								break;
 							default:
@@ -3291,7 +3292,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		@Override
 		public ReadPreference getReadPreference() {
-			return query.getMeta().getFlags().contains(CursorOption.SLAVE_OK) ? ReadPreference.primaryPreferred() : null;
+			return (query.getMeta().getFlags().contains(CursorOption.SECONDARY_READS)
+					|| query.getMeta().getFlags().contains(CursorOption.SLAVE_OK)) ? ReadPreference.primaryPreferred() : null;
 		}
 	}
 
@@ -3368,7 +3370,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		CloseableIterableCursorAdapter(MongoCursor<Document> cursor, PersistenceExceptionTranslator exceptionTranslator,
 				DocumentCallback<T> objectReadCallback) {
-			
+
 			this.cursor = cursor;
 			this.exceptionTranslator = exceptionTranslator;
 			this.objectReadCallback = objectReadCallback;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2679,7 +2679,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 	/**
 	 * Prepare the collection before any processing is done using it. This allows a convenient way to apply settings like
-	 * slaveOk() etc. Can be overridden in sub-classes.
+	 * withCodecRegistry() etc. Can be overridden in sub-classes.
 	 *
 	 * @param collection
 	 */
@@ -3324,7 +3324,8 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		@Override
 		public ReadPreference getReadPreference() {
-			return query.getMeta().getFlags().contains(CursorOption.SLAVE_OK) ? ReadPreference.primaryPreferred() : null;
+			return (query.getMeta().getFlags().contains(CursorOption.SECONDARY_READS)
+					|| query.getMeta().getFlags().contains(CursorOption.SLAVE_OK)) ? ReadPreference.primaryPreferred() : null;
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
@@ -31,7 +31,7 @@ import org.springframework.lang.Nullable;
  * {@link AggregationOperationContext} implementation prefixing non-command keys on root level with the given prefix.
  * Useful when mapping fields to domain specific types while having to prefix keys for query purpose.
  * <p />
- * Fields to be excluded from prefixing my be added to a {@literal blacklist}.
+ * Fields to be excluded from prefixing my be added to a {@literal denylist}.
  *
  * @author Christoph Strobl
  * @author Mark Paluch
@@ -41,18 +41,18 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 
 	private final AggregationOperationContext delegate;
 	private final String prefix;
-	private final Set<String> blacklist;
+	private final Set<String> denylist;
 
 	public PrefixingDelegatingAggregationOperationContext(AggregationOperationContext delegate, String prefix) {
 		this(delegate, prefix, Collections.emptySet());
 	}
 
 	public PrefixingDelegatingAggregationOperationContext(AggregationOperationContext delegate, String prefix,
-			Collection<String> blacklist) {
+			Collection<String> denylist) {
 
 		this.delegate = delegate;
 		this.prefix = prefix;
-		this.blacklist = new HashSet<>(blacklist);
+		this.denylist = new HashSet<>(denylist);
 	}
 
 	/*
@@ -121,7 +121,7 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 	}
 
 	private String prefixKey(String key) {
-		return (key.startsWith("$") || isBlacklisted(key)) ? key : (prefix + "." + key);
+		return (key.startsWith("$") || isDenied(key)) ? key : (prefix + "." + key);
 	}
 
 	private Object prefixCollection(Collection<Object> sourceCollection) {
@@ -139,9 +139,9 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 		return prefixed;
 	}
 
-	private boolean isBlacklisted(String key) {
+	private boolean isDenied(String key) {
 
-		if (blacklist.contains(key)) {
+		if (denylist.contains(key)) {
 			return true;
 		}
 
@@ -149,8 +149,8 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 			return false;
 		}
 
-		for (String blacklisted : blacklist) {
-			if (key.startsWith(blacklisted + ".")) {
+		for (String denied : denylist) {
+			if (key.startsWith(denied + ".")) {
 				return true;
 			}
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
@@ -62,7 +62,7 @@ import com.mongodb.client.model.changestream.FullDocument;
  */
 class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>, Object> {
 
-	private final Set<String> blacklist = new HashSet<>(
+	private final Set<String> denylist = new HashSet<>(
 			Arrays.asList("operationType", "fullDocument", "documentKey", "updateDescription", "ns"));
 
 	private final QueryMapper queryMapper;
@@ -176,7 +176,7 @@ class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>,
 							template.getConverter().getMappingContext(), queryMapper)
 					: Aggregation.DEFAULT_CONTEXT;
 
-			return agg.toPipeline(new PrefixingDelegatingAggregationOperationContext(context, "fullDocument", blacklist));
+			return agg.toPipeline(new PrefixingDelegatingAggregationOperationContext(context, "fullDocument", denylist));
 		}
 
 		if (filter instanceof List) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Meta.java
@@ -284,8 +284,20 @@ public class Meta {
 		 */
 		EXHAUST,
 
-		/** Allows querying of a replica slave. */
+		/**
+		 * Allows querying of a replica.
+		 *
+		 * @deprecated since 3.0.2, use {@link #SECONDARY_READS} instead.
+		 */
+		@Deprecated
 		SLAVE_OK,
+
+		/**
+		 * Allows querying of a replica.
+		 *
+		 * @since 3.0.2
+		 */
+		SECONDARY_READS,
 
 		/**
 		 * Sets the cursor to return partial data from a query against a sharded cluster in which some shards do not respond

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -411,15 +411,30 @@ public class Query {
 	}
 
 	/**
-	 * Allows querying of a replica slave.
+	 * Allows querying of a replica.
 	 *
 	 * @return this.
 	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#SLAVE_OK
 	 * @since 1.10
+	 * @deprecated since 3.0.2, use {@link #allowSecondaryReads()}.
 	 */
+	@Deprecated
 	public Query slaveOk() {
 
 		meta.addFlag(Meta.CursorOption.SLAVE_OK);
+		return this;
+	}
+
+	/**
+	 * Allows querying of a replica.
+	 *
+	 * @return this.
+	 * @see org.springframework.data.mongodb.core.query.Meta.CursorOption#SECONDARY_READS
+	 * @since 3.0.2
+	 */
+	public Query allowSecondaryReads() {
+
+		meta.addFlag(Meta.CursorOption.SECONDARY_READS);
 		return this;
 	}
 

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.0.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.0.xsd
@@ -318,8 +318,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:ID" use="optional">
@@ -348,14 +348,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -363,22 +363,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -395,18 +395,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -430,14 +430,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.1.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.1.xsd
@@ -316,8 +316,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:ID" use="optional">
@@ -346,14 +346,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -361,22 +361,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -393,18 +393,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -428,14 +428,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.2.xsd
@@ -531,7 +531,7 @@ This controls whether or not to fsync.  The 'fsync' option to the getlasterror c
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.10.xsd
@@ -531,7 +531,7 @@ This controls whether or not to fsync.  The 'fsync' option to the getlasterror c
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.2.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.2.xsd
@@ -230,7 +230,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -331,8 +331,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -361,14 +361,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -376,22 +376,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -408,18 +408,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -443,14 +443,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.3.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.3.xsd
@@ -234,7 +234,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -346,8 +346,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -376,14 +376,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -391,22 +391,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -423,18 +423,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -458,14 +458,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">
@@ -557,7 +557,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.4.xsd
@@ -241,7 +241,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -300,7 +300,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 		</xsd:annotation>
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="sslSocketFactoryRef">
 	<xsd:annotation>
 			<xsd:appinfo>
@@ -364,8 +364,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -394,14 +394,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -409,22 +409,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -441,18 +441,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -476,14 +476,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -589,7 +589,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.5.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.5.xsd
@@ -248,7 +248,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -318,7 +318,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 		</xsd:annotation>
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="sslSocketFactoryRef">
 	<xsd:annotation>
 			<xsd:appinfo>
@@ -382,8 +382,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -412,14 +412,14 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -427,22 +427,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -459,18 +459,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -494,14 +494,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -607,7 +607,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.7.xsd
@@ -27,7 +27,7 @@ Deprecated since 1.7 - use mongo-client instead. Defines a Mongo instance used f
 			</xsd:appinfo>
 		</xsd:annotation>
 	</xsd:element>
-	
+
 	<xsd:element name="mongo-client" type="mongoClientType">
 	  <xsd:annotation>
 		<xsd:documentation source="org.springframework.data.mongodb.core.MongoClientFactoryBean"><![CDATA[
@@ -37,7 +37,7 @@ Defines a MongoClient instance used for accessing MongoDB.
 				<tool:annotation>
 					<tool:exports type="com.mongodb.MongoClient"/>
 				</tool:annotation>
-			</xsd:appinfo>	  
+			</xsd:appinfo>
 	  </xsd:annotation>
 	</xsd:element>
 
@@ -261,7 +261,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -331,7 +331,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 		</xsd:annotation>
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="sslSocketFactoryRef">
 	<xsd:annotation>
 			<xsd:appinfo>
@@ -354,7 +354,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			<xsd:enumeration value="MAJORITY" />
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="readPreferenceEnumeration">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="PRIMARY" />
@@ -384,7 +384,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 	<xsd:complexType name="mongoType">
 		<xsd:annotation>
 	    	<xsd:documentation><![CDATA[
-Deprecated since 1.7.    	
+Deprecated since 1.7.
 	    	]]></xsd:documentation>
 	    </xsd:annotation>
 		<xsd:sequence minOccurs="0" maxOccurs="1">
@@ -410,8 +410,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -440,19 +440,19 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
 		<xsd:annotation>
 	    	<xsd:documentation><![CDATA[
-Deprecated since 1.7.    	
+Deprecated since 1.7.
 	    	]]></xsd:documentation>
 	    </xsd:annotation>
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -460,22 +460,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -492,18 +492,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -527,14 +527,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -550,11 +550,11 @@ The SSLSocketFactory to use for the SSL connection. If none is configured here, 
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="mongoClientType">
 		<xsd:annotation>
 	    	<xsd:documentation><![CDATA[
-Configuration options for 'MongoClient' - @since 1.7	    	
+Configuration options for 'MongoClient' - @since 1.7
 	    	]]></xsd:documentation>
 	    </xsd:annotation>
 		<xsd:sequence minOccurs="0" maxOccurs="1">
@@ -606,11 +606,11 @@ The comma delimited list of username:password@database entries to use for authen
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="clientOptionsType">
 	    <xsd:annotation>
 	    	<xsd:documentation><![CDATA[
-Configuration options for 'MongoClientOptions' - @since 1.7	    	
+Configuration options for 'MongoClientOptions' - @since 1.7
 	    	]]></xsd:documentation>
 	    </xsd:annotation>
 		<xsd:attribute name="description" type="xsd:string">
@@ -626,11 +626,11 @@ The MongoClient description.
 The minimum number of connections per host.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -638,36 +638,36 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-idle-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum idle time for a pooled connection.	
+The maximum idle time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-life-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum life time for a pooled connection.	
+The maximum life time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -684,7 +684,7 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="read-preference">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -694,7 +694,7 @@ The read preference.
 			<xsd:simpleType>
 				<xsd:union memberTypes="readPreferenceEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="write-concern">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -704,25 +704,25 @@ The WriteConcern that will be the default value used when asking the MongoDbFact
 			<xsd:simpleType>
 				<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This is the frequency that the driver will attempt to determine the current state of each server in the cluster. 
+This is the frequency that the driver will attempt to determine the current state of each server in the cluster.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="min-heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort. 
+In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout for connections used for the cluster heartbeat. 
+The connect timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -732,7 +732,7 @@ The connect timeout for connections used for the cluster heartbeat.
 The socket timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -746,7 +746,7 @@ This controls if the driver should us an SSL connection.  Defaults to false.
 The SSLSocketFactory to use for the SSL connection. If none is configured here, SSLSocketFactory#getDefault() will be used.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>									
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:group name="beanElementGroup">
@@ -838,7 +838,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
+++ b/spring-data-mongodb/src/main/resources/org/springframework/data/mongodb/config/spring-mongo-1.8.xsd
@@ -27,7 +27,7 @@ Deprecated since 1.7 - use mongo-client instead. Defines a Mongo instance used f
 			</xsd:appinfo>
 		</xsd:annotation>
 	</xsd:element>
-	
+
 	<xsd:element name="mongo-client" type="mongoClientType">
 	  <xsd:annotation>
 		<xsd:documentation source="org.springframework.data.mongodb.core.MongoClientFactoryBean"><![CDATA[
@@ -267,7 +267,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="auditing">
 		<xsd:annotation>
 			<xsd:appinfo>
@@ -337,7 +337,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 		</xsd:annotation>
 		<xsd:union memberTypes="xsd:string"/>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="sslSocketFactoryRef">
 	<xsd:annotation>
 			<xsd:appinfo>
@@ -360,7 +360,7 @@ The name of the Mongo object that determines what server to monitor. (by default
 			<xsd:enumeration value="MAJORITY" />
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="readPreferenceEnumeration">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="PRIMARY" />
@@ -416,8 +416,8 @@ The Mongo driver options
 				<xsd:simpleType>
 					<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 				</xsd:simpleType>
-			</xsd:attribute>		
-		<!-- MLP 
+			</xsd:attribute>
+		<!-- MLP
 		<xsd:attributeGroup ref="writeConcern" />
 		-->
 		<xsd:attribute name="id" type="xsd:string" use="optional">
@@ -446,7 +446,7 @@ The host to connect to a MongoDB server.  Default is localhost
 The comma delimited list of host:port entries to use for replica set/pairs.
 							]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="optionsType">
@@ -466,22 +466,22 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -498,18 +498,18 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="auto-connect-retry" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls whether or not on a connect, the system retries automatically.  Default is false. 
+This controls whether or not on a connect, the system retries automatically.  Default is false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-auto-connect-retry-time" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on. 
+The maximum amount of time in millisecons to spend retrying to open connection to the same server. Default is 0, which means to use the default 15s if autoConnectRetry is on.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -533,14 +533,14 @@ This controls timeout for write operations in milliseconds.  The 'wtimeout' opti
 This controls whether or not to fsync.  The 'fsync' option to the getlasterror command. Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>						
+		</xsd:attribute>
 		<xsd:attribute name="slave-ok" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This controls if the driver is allowed to read from secondaries or slaves.  Defaults to false.
+This controls if the driver is allowed to read from secondaries or replicas.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>				
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -556,7 +556,7 @@ The SSLSocketFactory to use for the SSL connection. If none is configured here, 
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="mongoClientType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -612,7 +612,7 @@ The comma delimited list of username:password@database entries to use for authen
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="clientOptionsType">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -632,11 +632,11 @@ The MongoClient description.
 The minimum number of connections per host.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="connections-per-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override	
+The number of connections allowed per host.  Will block if run out.	 Default is 10.  System property MONGO.POOLSIZE can override
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -644,36 +644,36 @@ The number of connections allowed per host.  Will block if run out.	 Default is 
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The multiplier for connectionsPerHost for # of threads that can block.  Default is 5.
-If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5, 
-then 50 threads can block more than that and an exception will be thrown.			
+If connectionsPerHost is 10, and threadsAllowedToBlockForConnectionMultiplier is 5,
+then 50 threads can block more than that and an exception will be thrown.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-wait-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)	
+The max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-idle-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum idle time for a pooled connection.	
+The maximum idle time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-connection-life-time" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The maximum life time for a pooled connection.	
+The maximum life time for a pooled connection.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout in milliseconds. 0 is default and infinite.	
+The connect timeout in milliseconds. 0 is default and infinite.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -690,7 +690,7 @@ The socket timeout.  0 is default and infinite.
 The keep alive flag, controls whether or not to have socket keep alive timeout.  Defaults to false.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="read-preference">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -700,7 +700,7 @@ The read preference.
 			<xsd:simpleType>
 				<xsd:union memberTypes="readPreferenceEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="write-concern">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -710,25 +710,25 @@ The WriteConcern that will be the default value used when asking the MongoDbFact
 			<xsd:simpleType>
 				<xsd:union memberTypes="writeConcernEnumeration xsd:string"/>
 			</xsd:simpleType>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-This is the frequency that the driver will attempt to determine the current state of each server in the cluster. 
+This is the frequency that the driver will attempt to determine the current state of each server in the cluster.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="min-heartbeat-frequency" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort. 
+In the event that the driver has to frequently re-check a server's availability, it will wait at least this long since the previous check to avoid wasted effort.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-connect-timeout" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The connect timeout for connections used for the cluster heartbeat. 
+The connect timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -738,7 +738,7 @@ The connect timeout for connections used for the cluster heartbeat.
 The socket timeout for connections used for the cluster heartbeat.
 				]]></xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>	
+		</xsd:attribute>
 		<xsd:attribute name="ssl" type="xsd:boolean">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -844,7 +844,7 @@ The reference to a Mongoconverter instance.
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="gridFsTemplate">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1162,7 +1162,7 @@ public class MongoTemplateTests {
 		assertThat(p5.getFirstName()).isEqualTo("Mark");
 	}
 
-	@Test
+	@Test // DATAMONGO-2572
 	public void testUsingReadPreference() throws Exception {
 		this.template.execute("readPref", new CollectionCallback<Object>() {
 			public Object doInCollection(MongoCollection<org.bson.Document> collection)
@@ -1173,9 +1173,9 @@ public class MongoTemplateTests {
 				return null;
 			}
 		});
-		MongoTemplate slaveTemplate = new MongoTemplate(factory);
-		slaveTemplate.setReadPreference(ReadPreference.secondary());
-		slaveTemplate.execute("readPref", new CollectionCallback<Object>() {
+		MongoTemplate secondaryTemplate = new MongoTemplate(factory);
+		secondaryTemplate.setReadPreference(ReadPreference.secondary());
+		secondaryTemplate.execute("readPref", new CollectionCallback<Object>() {
 			public Object doInCollection(MongoCollection<org.bson.Document> collection)
 					throws MongoException, DataAccessException {
 				assertThat(collection.getReadPreference()).isEqualTo(ReadPreference.secondary());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -1714,34 +1714,34 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		Assertions.assertThat(ReflectionTestUtils.getField(template, "entityCallbacks")).isSameAs(callbacks);
 	}
 
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFind() {
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFind() {
 
-		template.find(new Query().slaveOk(), AutogenerateableId.class);
-
-		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
-	}
-
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindOne() {
-
-		template.findOne(new Query().slaveOk(), AutogenerateableId.class);
+		template.find(new Query().allowSecondaryReads(), AutogenerateableId.class);
 
 		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
 	}
 
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindDistinct() {
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindOne() {
 
-		template.findDistinct(new Query().slaveOk(), "name", AutogenerateableId.class, String.class);
+		template.findOne(new Query().allowSecondaryReads(), AutogenerateableId.class);
 
 		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
 	}
 
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForStream() {
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindDistinct() {
 
-		template.stream(new Query().slaveOk(), AutogenerateableId.class);
+		template.findDistinct(new Query().allowSecondaryReads(), "name", AutogenerateableId.class, String.class);
+
+		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
+	}
+
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForStream() {
+
+		template.stream(new Query().allowSecondaryReads(), AutogenerateableId.class);
 		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -896,26 +896,26 @@ public class ReactiveMongoTemplateUnitTests {
 		Assertions.assertThat(ReflectionTestUtils.getField(template, "entityCallbacks")).isSameAs(callbacks);
 	}
 
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFind() {
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFind() {
 
-		template.find(new Query().slaveOk(), AutogenerateableId.class).subscribe();
-
-		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
-	}
-
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindOne() {
-
-		template.findOne(new Query().slaveOk(), AutogenerateableId.class).subscribe();
+		template.find(new Query().allowSecondaryReads(), AutogenerateableId.class).subscribe();
 
 		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
 	}
 
-	@Test // DATAMONGO-2344
-	void slaveOkQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindDistinct() {
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindOne() {
 
-		template.findDistinct(new Query().slaveOk(), "name", AutogenerateableId.class, String.class).subscribe();
+		template.findOne(new Query().allowSecondaryReads(), AutogenerateableId.class).subscribe();
+
+		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
+	}
+
+	@Test // DATAMONGO-2344, DATAMONGO-2572
+	void allowSecondaryReadsQueryOptionShouldApplyPrimaryPreferredReadPreferenceForFindDistinct() {
+
+		template.findDistinct(new Query().allowSecondaryReads(), "name", AutogenerateableId.class, String.class).subscribe();
 
 		verify(collection).withReadPreference(eq(ReadPreference.primaryPreferred()));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/QueryTests.java
@@ -297,14 +297,14 @@ class QueryTests {
 				.isNotEqualTo(source.getFieldsObject());
 	}
 
-	@Test // DATAMONGO-1783
+	@Test // DATAMONGO-1783, DATAMONGO-2572
 	void clonedQueryShouldNotDependOnMetaFromSource() {
 
 		Query source = new Query().maxTimeMsec(100);
 		Query target = Query.of(source);
 
 		compareQueries(target, source);
-		source.slaveOk();
+		source.allowSecondaryReads();
 
 		Meta meta = new Meta();
 		meta.setMaxTimeMsec(100);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/MongoQueryMethodUnitTests.java
@@ -194,7 +194,7 @@ public class MongoQueryMethodUnitTests {
 				.contains(org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT);
 	}
 
-	@Test // DATAMONGO-1480
+	@Test // DATAMONGO-1480, DATAMONGO-2572
 	public void createsMongoQueryMethodWithMultipleFlagsCorrectly() throws Exception {
 
 		MongoQueryMethod method = queryMethod(PersonRepository.class, "metaWithMultipleFlags");
@@ -202,7 +202,7 @@ public class MongoQueryMethodUnitTests {
 		assertThat(method.hasQueryMetaAttributes()).isTrue();
 		assertThat(method.getQueryMetaAttributes().getFlags()).contains(
 				org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT,
-				org.springframework.data.mongodb.core.query.Meta.CursorOption.SLAVE_OK);
+				org.springframework.data.mongodb.core.query.Meta.CursorOption.SECONDARY_READS);
 	}
 
 	@Test // DATAMONGO-1266
@@ -273,7 +273,7 @@ public class MongoQueryMethodUnitTests {
 		List<User> metaWithNoCursorTimeout();
 
 		@Meta(flags = { org.springframework.data.mongodb.core.query.Meta.CursorOption.NO_TIMEOUT,
-				org.springframework.data.mongodb.core.query.Meta.CursorOption.SLAVE_OK })
+				org.springframework.data.mongodb.core.query.Meta.CursorOption.SECONDARY_READS })
 		List<User> metaWithMultipleFlags();
 
 		// DATAMONGO-1266

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2205,7 +2205,7 @@ On the repository level the `@Meta` annotation provides means to add query optio
 ====
 [source,java]
 ----
-@Meta(comment = "find luke", batchSize = 100, flags = { SLAVE_OK })
+@Meta(comment = "find luke", batchSize = 100, flags = { SECONDARY_READS })
 List<Person> findByFirstname(String firstname);
 ----
 ====


### PR DESCRIPTION
Replaced blacklist with denylist and introduce meta keyword `SECONDARY_READS` as we no longer use MongoDB API with the initial replication concept.

---

Related ticket: DATAMONGO-2572
Should be backported to all maintained branches.