### PR TITLE
DATAMONGO-2635 - Enforce aggregation pipeline mapping.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-DATAMONGO-2635-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/AggregationUtil.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/AggregationUtil.java
@@ -77,7 +77,7 @@ class AggregationUtil {
 		}
 
 		if (!(aggregation instanceof TypedAggregation)) {
-			return Aggregation.DEFAULT_CONTEXT;
+			return new RelaxedTypeBasedAggregationOperationContext(Object.class, mappingContext, queryMapper);
 		}
 
 		Class<?> inputType = ((TypedAggregation) aggregation).getInputType();
@@ -98,7 +98,7 @@ class AggregationUtil {
 	 */
 	List<Document> createPipeline(Aggregation aggregation, AggregationOperationContext context) {
 
-		if (!ObjectUtils.nullSafeEquals(context, Aggregation.DEFAULT_CONTEXT)) {
+		if (ObjectUtils.nullSafeEquals(context, Aggregation.DEFAULT_CONTEXT)) {
 			return aggregation.toPipeline(context);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
@@ -707,10 +707,9 @@ class QueryOperations {
 		 */
 		List<Document> getUpdatePipeline(@Nullable Class<?> domainType) {
 
-			AggregationOperationContext context = domainType != null
-					? new RelaxedTypeBasedAggregationOperationContext(domainType, mappingContext, queryMapper)
-					: Aggregation.DEFAULT_CONTEXT;
+			Class<?> type = domainType != null ? domainType : Object.class;
 
+			AggregationOperationContext context = new RelaxedTypeBasedAggregationOperationContext(type, mappingContext, queryMapper);
 			return aggregationUtil.createPipeline((AggregationUpdate) update, context);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.core;
 
 import static org.springframework.data.mongodb.core.query.SerializationUtils.*;
 
+import org.springframework.data.mongodb.core.aggregation.RelaxedTypeBasedAggregationOperationContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
@@ -2112,7 +2113,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			AggregationOperationContext context = agg instanceof TypedAggregation
 					? new TypeBasedAggregationOperationContext(((TypedAggregation<?>) agg).getInputType(),
 							getConverter().getMappingContext(), queryMapper)
-					: Aggregation.DEFAULT_CONTEXT;
+					: new RelaxedTypeBasedAggregationOperationContext(Object.class, mappingContext, queryMapper);
 
 			return agg.toPipeline(new PrefixingDelegatingAggregationOperationContext(context, "fullDocument",
 					Arrays.asList("operationType", "fullDocument", "documentKey", "updateDescription", "ns")));

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -1450,6 +1450,14 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 						return field.getTarget();
 					}
 
+					if(field.getTarget().equals(Fields.UNDERSCORE_ID)) {
+						try {
+							return context.getReference(field).getReferenceValue();
+						} catch (java.lang.IllegalArgumentException e) {
+							return Fields.UNDERSCORE_ID_REF;
+						}
+					}
+
 					// check whether referenced field exists in the context
 					return context.getReference(field).getReferenceValue();
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/UnionWithOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/UnionWithOperation.java
@@ -142,12 +142,8 @@ public class UnionWithOperation implements AggregationOperation {
 
 	private AggregationOperationContext computeContext(AggregationOperationContext source) {
 
-		if (domainType == null) {
-			return Aggregation.DEFAULT_CONTEXT;
-		}
-
 		if (source instanceof TypeBasedAggregationOperationContext) {
-			return ((TypeBasedAggregationOperationContext) source).continueOnMissingFieldReference(domainType);
+			return ((TypeBasedAggregationOperationContext) source).continueOnMissingFieldReference(domainType != null ? domainType : Object.class);
 		}
 
 		if (source instanceof ExposedFieldsAggregationOperationContext) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -1928,6 +1928,22 @@ public class AggregationTests {
 		assertThat(results.getRawResults()).isEmpty();
 	}
 
+	@Test // DATAMONGO-2635
+	void mapsEnumsInMatchClauseUsingInCriteriaCorrectly() {
+
+		WithEnum source = new WithEnum();
+		source.enumValue = MyEnum.TWO;
+		source.id = "id-1";
+
+		mongoTemplate.save(source);
+
+		Aggregation agg = newAggregation(match(where("enumValue").in(Collections.singletonList(MyEnum.TWO))));
+
+		AggregationResults<Document> results = mongoTemplate.aggregate(agg, mongoTemplate.getCollectionName(WithEnum.class),
+				Document.class);
+		assertThat(results.getMappedResults()).hasSize(1);
+	}
+
 	private void createUsersWithReferencedPersons() {
 
 		mongoTemplate.dropCollection(User.class);
@@ -2239,5 +2255,16 @@ public class AggregationTests {
 	static class ComplexId {
 		String p1;
 		String p2;
+	}
+
+	static enum MyEnum {
+		ONE, TWO
+	}
+
+	@lombok.Data
+	static class WithEnum {
+
+		@Id String id;
+		MyEnum enumValue;
 	}
 }


### PR DESCRIPTION
Avoid using the `Aggregation.DEFAULT_CONTEXT` which does not map contained values to the according MongoDB representation. We now use a relaxed aggregation context, preserving given field names, where possible.
Along the lines also change the behaviour of `_id` field projections to allow the inclusion of the filed nevertheless the current `AggregationOperationContext` is aware of it. 