### PR TITLE
DATAMONGO-2659 - Allow disk use on query

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -3289,6 +3289,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 						cursorToUse = cursorToUse.batchSize(meta.getCursorBatchSize());
 					}
 
+					if (meta.getAllowDiskUse() != null) {
+						cursorToUse = cursorToUse.allowDiskUse(meta.getAllowDiskUse());
+					}
+
 					for (Meta.CursorOption option : meta.getFlags()) {
 
 						switch (option) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -156,6 +156,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Michael J. Simons
  * @author Roman Puchkovskiy
  * @author Yadhukrishna S Pai
+ * @author Anton Barkan
  */
 public class MongoTemplate implements MongoOperations, ApplicationContextAware, IndexOperationsProvider {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -373,6 +373,19 @@ public class Query {
 	}
 
 	/**
+	 * Add a comment to the query that is propagated to the profile log.
+	 *
+	 * @param allowDiskUse must not be {@literal null}.
+	 * @return this.
+	 * @see Meta#setAllowDiskUse(Boolean)
+	 */
+	public Query allowDiskUse(Boolean allowDiskUse) {
+
+		meta.setAllowDiskUse(allowDiskUse);
+		return this;
+	}
+
+	/**
 	 * Set the number of documents to return in each response batch. <br />
 	 * Use {@literal 0 (zero)} for no limit. A <strong>negative limit</strong> closes the cursor after returning a single
 	 * batch indicating to the server that the client will not ask for a subsequent one.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Anton Barkan
  */
 public class Query {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -373,7 +373,7 @@ public class Query {
 	}
 
 	/**
-	 * Add a comment to the query that is propagated to the profile log.
+	 * Set a allowDiskUse to the query that is propagated to the profile log.
 	 *
 	 * @param allowDiskUse must not be {@literal null}.
 	 * @return this.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
@@ -45,6 +45,7 @@ import com.mongodb.client.FindIterable;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Anton Barkan
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryCursorPreparerUnitTests.java
@@ -61,6 +61,7 @@ class QueryCursorPreparerUnitTests {
 		when(factory.getCodecRegistry()).thenReturn(MongoClientSettings.getDefaultCodecRegistry());
 		when(cursor.batchSize(anyInt())).thenReturn(cursor);
 		when(cursor.comment(anyString())).thenReturn(cursor);
+		when(cursor.allowDiskUse(anyBoolean())).thenReturn(cursor);
 		when(cursor.maxTime(anyLong(), any())).thenReturn(cursor);
 		when(cursor.hint(any())).thenReturn(cursor);
 		when(cursor.noCursorTimeout(anyBoolean())).thenReturn(cursor);
@@ -131,6 +132,15 @@ class QueryCursorPreparerUnitTests {
 		prepare(query);
 
 		verify(cursor).comment("spring data");
+	}
+
+	@Test
+	void appliesAllowDiskUseCorrectly() {
+
+		Query query = query(where("foo").is("bar")).allowDiskUse(true);
+		prepare(query);
+
+		verify(cursor).allowDiskUse(true);
 	}
 
 	// TODO


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


implementation for https://docs.mongodb.com/manual/reference/method/cursor.allowDiskUse/