### PR TITLE
DATAMONGO-2661 - Handle nullable types for KPropertyPath

### DIFF
--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/KPropertyPath.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/KPropertyPath.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KProperty1
  * @since 2.2
  */
 class KPropertyPath<T, U>(
-		internal val parent: KProperty<U>,
+		internal val parent: KProperty<U?>,
 		internal val child: KProperty1<U, T>
 ) : KProperty<T> by child
 
@@ -52,7 +52,8 @@ internal fun asString(property: KProperty<*>): String {
  * Book::author / Author::name isEqualTo "Herman Melville"
  * ```
  * @author Tjeu Kayim
+ * @author Yoann de Martino
  * @since 2.2
  */
-operator fun <T, U> KProperty<T>.div(other: KProperty1<T, U>) =
+operator fun <T, U> KProperty<T?>.div(other: KProperty1<T, U>) =
 		KPropertyPath(this, other)

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/KPropertyPathTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/KPropertyPathTests.kt
@@ -93,6 +93,15 @@ class KPropertyPathTests {
 		assertThat(property).isEqualTo("entity.book.author.name")
 	}
 
+	@Test
+	fun `Convert nullable KProperty to field name`() {
+		class Cat(val name: String)
+		class Owner(val cat: Cat?)
+
+		val property = asString(Owner::cat / Cat::name)
+		assertThat(property).isEqualTo("cat.name")
+	}
+
 	class Book(val title: String, val author: Author)
 	class Author(val name: String)
 }


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAMONGO-2661).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
