### PR TITLE
DATAMONGO-2663 - Document Spring Data to MongoDB compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-DATAMONGO-2663-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2663-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2663-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2663-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -43,6 +43,61 @@ The Spring Data MongoDB 3.x binaries require JDK level 8.0 and above and https:/
 
 In terms of document stores, you need at least version 2.6 of https://www.mongodb.org/[MongoDB].
 
+[[compatibility.matrix]]
+=== Compatibility Matrix
+
+The following compatibility matrix summarizes Spring Data versions to MongoDB driver/database versions.
+Database versions show the highest supported server version that pass the Spring Data test suite.
+You can use newer server versions unless your application uses functionality that is affected by <<compatibility.changes,changes in the MongoDB server>>.
+
+[cols="h,m,m,m", options="header"]
+|===
+
+|Spring Data Release Train
+|Spring Data MongoDB
+|Driver Version
+|Server Version
+
+|2021.0
+|3.2.x
+|4.1.x
+|4.4.x
+
+|2020.0
+|3.1.x
+|4.1.x
+|4.4.x
+
+|Neumann
+|3.0.x
+|4.0.x
+|4.4.x
+
+|Moore
+|2.2.x
+|3.11.x/Reactive Streams 1.12.x
+|4.2.x
+
+|Lovelace
+|2.1.x
+|3.8.x/Reactive Streams 1.9.x
+|4.0.x
+
+|===
+
+[[compatibility.changes]]
+[[compatibility.changes-4.4]]
+==== Relevant Changes in MongoDB 4.4
+
+* Fields list must not contain text search score property when no `$text` criteria present. See also https://docs.mongodb.com/manual/reference/operator/query/text/[`$text` operator]
+* Sort must not be an empty document when running map reduce.
+
+[[compatibility.changes-4.2]]
+==== Relevant Changes in MongoDB 4.2
+
+* Removal of `geoNear` command. See also https://docs.mongodb.com/manual/release-notes/4.2-compatibility/#remove-support-for-the-geonear-command[Removal of `geoNear`]
+* Removal of `eval` command. See also https://docs.mongodb.com/manual/release-notes/4.2-compatibility/#remove-support-for-the-eval-command[Removal of `eval`]
+
 [[get-started:help]]
 == Additional Help Resources
 


### PR DESCRIPTION
Related ticket: [DATAMONGO-2663](https://jira.spring.io/browse/DATAMONGO-2663).
Should be backported up to 2.2.x.