### PR TITLE
DATAMONGO-1902 - Add support for embedding objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-DATAMONGO-1902-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -26,7 +26,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.5.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.5.0-DATACMNS-1699-SNAPSHOT</springdata.commons>
 		<mongo>4.1.1</mongo>
 		<mongo.reactivestreams>${mongo}</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.5.0-DATACMNS-1699-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.5.0-SNAPSHOT</springdata.commons>
 		<mongo>4.1.1</mongo>
 		<mongo.reactivestreams>${mongo}</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-1902-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-1902-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-1902-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperationsProvider.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/DefaultIndexOperationsProvider.java
@@ -47,7 +47,7 @@ class DefaultIndexOperationsProvider implements IndexOperationsProvider {
 	 * @see org.springframework.data.mongodb.core.index.IndexOperationsProvider#reactiveIndexOps(java.lang.String)
 	 */
 	@Override
-	public IndexOperations indexOps(String collectionName) {
-		return new DefaultIndexOperations(mongoDbFactory, collectionName, mapper);
+	public IndexOperations indexOps(String collectionName, Class<?> type) {
+		return new DefaultIndexOperations(mongoDbFactory, collectionName, mapper, type);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -715,12 +715,18 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		});
 	}
 
+
+	@Override
+	public IndexOperations indexOps(String collectionName) {
+		return indexOps(collectionName, null);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.ExecutableInsertOperation#indexOps(java.lang.String)
 	 */
-	public IndexOperations indexOps(String collectionName) {
-		return new DefaultIndexOperations(this, collectionName, null);
+	public IndexOperations indexOps(String collectionName, @Nullable Class<?> type) {
+		return new DefaultIndexOperations(this, collectionName, type);
 	}
 
 	/*
@@ -728,7 +734,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @see org.springframework.data.mongodb.core.ExecutableInsertOperation#indexOps(java.lang.Class)
 	 */
 	public IndexOperations indexOps(Class<?> entityClass) {
-		return new DefaultIndexOperations(this, getCollectionName(entityClass), entityClass);
+		return indexOps(getCollectionName(entityClass), entityClass);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -67,6 +67,10 @@ class DocumentAccessor {
 		return this.document;
 	}
 
+	public void putAll(MongoPersistentProperty prop,  Document value) {
+		value.entrySet().forEach(entry -> BsonUtils.asMap(document).put(entry.getKey(), entry.getValue()));
+	}
+
 	/**
 	 * Puts the given value into the backing {@link Document} based on the coordinates defined through the given
 	 * {@link MongoPersistentProperty}. By default this will be the plain field name. But field names might also consist

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -67,8 +67,17 @@ class DocumentAccessor {
 		return this.document;
 	}
 
-	public void putAll(MongoPersistentProperty prop,  Document value) {
-		value.entrySet().forEach(entry -> BsonUtils.asMap(document).put(entry.getKey(), entry.getValue()));
+	/**
+	 * Copies all of the mappings from the given {@link Document} to the underlying target {@link Document}. These
+	 * mappings will replace any mappings that the target document had for any of the keys currently in the specified map.
+	 *
+	 * @param source
+	 */
+	public void putAll(Document source) {
+
+		Map<String, Object> target = BsonUtils.asMap(document);
+
+		target.putAll(source);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -672,7 +672,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			Document target = new Document();
 			writeInternal(obj, target, mappingContext.getPersistentEntity(prop));
 
-			accessor.putAll(prop, target);
+			accessor.putAll(target);
 			return;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -26,6 +26,7 @@ import org.springframework.data.convert.TypeMapper;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.util.BsonUtils;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -144,9 +145,9 @@ public interface MongoConverter
 		try {
 			return getConversionService().canConvert(id.getClass(), targetType)
 					? getConversionService().convert(id, targetType)
-					: convertToMongoType(id, null);
+					: convertToMongoType(id, (TypeInformation<?>) null);
 		} catch (ConversionException o_O) {
-			return convertToMongoType(id, null);
+			return convertToMongoType(id,(TypeInformation<?>)  null);
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoExampleMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoExampleMapper.java
@@ -40,6 +40,7 @@ import org.springframework.data.mongodb.core.query.MongoRegexCreator;
 import org.springframework.data.mongodb.core.query.MongoRegexCreator.MatchMode;
 import org.springframework.data.mongodb.core.query.SerializationUtils;
 import org.springframework.data.mongodb.core.query.UntypedExampleMatcher;
+import org.springframework.data.mongodb.util.DotPath;
 import org.springframework.data.support.ExampleMatcherAccessor;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
@@ -134,7 +135,7 @@ public class MongoExampleMapper {
 		while (iter.hasNext()) {
 
 			Map.Entry<String, Object> entry = iter.next();
-			String propertyPath = StringUtils.hasText(path) ? path + "." + entry.getKey() : entry.getKey();
+			String propertyPath = DotPath.from(path).append(entry.getKey()).toString();
 			String mappedPropertyPath = getMappedPropertyPath(propertyPath, probeType);
 
 			if (isEmptyIdProperty(entry)) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoWriter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoWriter.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.core.convert;
 
 import org.bson.conversions.Bson;
 import org.springframework.data.convert.EntityWriter;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -43,7 +44,7 @@ public interface MongoWriter<T> extends EntityWriter<T, Bson> {
 	 */
 	@Nullable
 	default Object convertToMongoType(@Nullable Object obj) {
-		return convertToMongoType(obj, null);
+		return convertToMongoType(obj, (TypeInformation<?>) null);
 	}
 
 	/**
@@ -57,6 +58,9 @@ public interface MongoWriter<T> extends EntityWriter<T, Bson> {
 	@Nullable
 	Object convertToMongoType(@Nullable Object obj, @Nullable TypeInformation<?> typeInformation);
 
+	default Object convertToMongoType(@Nullable Object obj, MongoPersistentEntity<?> entity) {
+		return convertToMongoType(obj, entity.getTypeInformation());
+	}
 	/**
 	 * Creates a {@link DBRef} to refer to the given object.
 	 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -32,6 +32,7 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.mapping.context.InvalidPersistentPropertyPath;
@@ -140,9 +141,23 @@ public class QueryMapper {
 			try {
 
 				Field field = createPropertyField(entity, key, mappingContext);
-				Entry<String, Object> entry = getMappedObjectForField(field, BsonUtils.get(query, key));
 
-				result.put(entry.getKey(), entry.getValue());
+				// TODO: move to dedicated method
+				if (field.getProperty() != null && field.getProperty().isEmbedded()) {
+
+					Object theNestedObject = BsonUtils.get(query, key);
+					Document mappedValue = (Document) getMappedValue(field, theNestedObject);
+					if (!StringUtils.hasText(field.getMappedKey())) {
+						result.putAll(mappedValue);
+					} else {
+						result.put(field.getMappedKey(), mappedValue);
+					}
+				} else {
+
+					Entry<String, Object> entry = getMappedObjectForField(field, BsonUtils.get(query, key));
+
+					result.put(entry.getKey(), entry.getValue());
+				}
 			} catch (InvalidPersistentPropertyPath invalidPathException) {
 
 				// in case the object has not already been mapped
@@ -173,10 +188,16 @@ public class QueryMapper {
 			return new Document();
 		}
 
+		sortObject = filterEmbeddedObjects(sortObject, entity);
+
 		Document mappedSort = new Document();
 		for (Map.Entry<String, Object> entry : BsonUtils.asMap(sortObject).entrySet()) {
 
 			Field field = createPropertyField(entity, entry.getKey(), mappingContext);
+			if (field.getProperty() != null && field.getProperty().isEmbedded()) {
+				continue;
+			}
+
 			mappedSort.put(field.getMappedKey(), entry.getValue());
 		}
 
@@ -197,7 +218,9 @@ public class QueryMapper {
 
 		Assert.notNull(fieldsObject, "FieldsObject must not be null!");
 
-		Document mappedFields = fieldsObject.isEmpty() ? new Document() : getMappedObject(fieldsObject, entity);
+		fieldsObject = filterEmbeddedObjects(fieldsObject, entity);
+
+		Document mappedFields = getMappedObject(fieldsObject, entity);
 		mapMetaAttributes(mappedFields, entity, MetaMapping.FORCE);
 		return mappedFields;
 	}
@@ -215,6 +238,43 @@ public class QueryMapper {
 				source.putAll(getMappedTextScoreField(textScoreProperty));
 			}
 		}
+	}
+
+	private Document filterEmbeddedObjects(Document fieldsObject, @Nullable MongoPersistentEntity<?> entity) {
+
+		if (fieldsObject.isEmpty() || entity == null) {
+			return fieldsObject;
+		}
+
+		Document target = new Document();
+
+		for (Entry<String, Object> field : fieldsObject.entrySet()) {
+
+			try {
+
+				PropertyPath path = PropertyPath.from(field.getKey(), entity.getTypeInformation());
+				PersistentPropertyPath<MongoPersistentProperty> persistentPropertyPath = mappingContext
+						.getPersistentPropertyPath(path);
+				MongoPersistentProperty property = mappingContext.getPersistentPropertyPath(path).getLeafProperty();
+
+				if (property.isEmbedded() && property.isEntity()) {
+
+					mappingContext.getPersistentEntity(property)
+							.doWithProperties((PropertyHandler<MongoPersistentProperty>) embedded -> {
+
+								String dotPath = persistentPropertyPath.toDotPath();
+								dotPath = dotPath + (StringUtils.hasText(dotPath) ? "." : "") + embedded.getName();
+								target.put(dotPath, field.getValue());
+							});
+				} else {
+					target.put(field.getKey(), field.getValue());
+				}
+			} catch (RuntimeException e) {
+				target.put(field.getKey(), field.getValue());
+			}
+
+		}
+		return target;
 	}
 
 	private Document getMappedTextScoreField(MongoPersistentProperty property) {
@@ -497,6 +557,11 @@ public class QueryMapper {
 	 */
 	@Nullable
 	protected Object delegateConvertToMongoType(Object source, @Nullable MongoPersistentEntity<?> entity) {
+
+		if (entity != null && entity.isEmbedded()) {
+			return converter.convertToMongoType(source, entity);
+		}
+
 		return converter.convertToMongoType(source, entity == null ? null : entity.getTypeInformation());
 	}
 
@@ -912,6 +977,7 @@ public class QueryMapper {
 		public TypeInformation<?> getTypeHint() {
 			return ClassTypeInformation.OBJECT;
 		}
+
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.core.mapping.EmbeddedMongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.Query;
@@ -132,6 +133,11 @@ public class UpdateMapper extends QueryMapper {
 	 */
 	@Override
 	protected Object delegateConvertToMongoType(Object source, @Nullable MongoPersistentEntity<?> entity) {
+
+		if(entity != null && entity.isEmbedded()) {
+			return converter.convertToMongoType(source, entity);
+		}
+
 		return converter.convertToMongoType(source,
 				entity == null ? ClassTypeInformation.OBJECT : getTypeHintForEntity(source, entity));
 	}
@@ -156,6 +162,10 @@ public class UpdateMapper extends QueryMapper {
 
 		if (isUpdateModifier(rawValue)) {
 			return getMappedUpdateModifier(field, rawValue);
+		}
+
+		if(field.getProperty() != null && field.getProperty().isEmbedded()) {
+			System.out.println("here we are: ");
 		}
 
 		return super.getMappedObjectForField(field, rawValue);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -26,7 +26,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mongodb.core.mapping.EmbeddedMongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.Query;
@@ -162,10 +161,6 @@ public class UpdateMapper extends QueryMapper {
 
 		if (isUpdateModifier(rawValue)) {
 			return getMappedUpdateModifier(field, rawValue);
-		}
-
-		if(field.getProperty() != null && field.getProperty().isEmbedded()) {
-			System.out.println("here we are: ");
 		}
 
 		return super.getMappedObjectForField(field, rawValue);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.mongodb.core.index;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Provider interface to obtain {@link IndexOperations} by MongoDB collection name.
  *
@@ -29,7 +31,19 @@ public interface IndexOperationsProvider {
 	 * Returns the operations that can be performed on indexes
 	 *
 	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
+	 * @param type the type used for field mapping. Can be {@literal null}.
+	 * @return index operations on the named collection
+	 * @since 2.5
+	 */
+	IndexOperations indexOps(String collectionName, @Nullable Class<?> type);
+
+	/**
+	 * Returns the operations that can be performed on indexes
+	 *
+	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
 	 * @return index operations on the named collection
 	 */
-	IndexOperations indexOps(String collectionName);
+	default IndexOperations indexOps(String collectionName) {
+		return indexOps(collectionName, null);
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexOperationsProvider.java
@@ -28,17 +28,7 @@ import org.springframework.lang.Nullable;
 public interface IndexOperationsProvider {
 
 	/**
-	 * Returns the operations that can be performed on indexes
-	 *
-	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
-	 * @param type the type used for field mapping. Can be {@literal null}.
-	 * @return index operations on the named collection
-	 * @since 2.5
-	 */
-	IndexOperations indexOps(String collectionName, @Nullable Class<?> type);
-
-	/**
-	 * Returns the operations that can be performed on indexes
+	 * Returns the operations that can be performed on indexes.
 	 *
 	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
 	 * @return index operations on the named collection
@@ -46,4 +36,14 @@ public interface IndexOperationsProvider {
 	default IndexOperations indexOps(String collectionName) {
 		return indexOps(collectionName, null);
 	}
+
+	/**
+	 * Returns the operations that can be performed on indexes.
+	 *
+	 * @param collectionName name of the MongoDB collection, must not be {@literal null}.
+	 * @param type the type used for field mapping. Can be {@literal null}.
+	 * @return index operations on the named collection
+	 * @since 3.2
+	 */
+	IndexOperations indexOps(String collectionName, @Nullable Class<?> type);
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
@@ -164,7 +164,8 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 	@Override
 	public org.springframework.data.mongodb.core.query.Collation getCollation() {
 
-		Object collationValue = collationExpression != null ? collationExpression.getValue(getEvaluationContext(null), String.class)
+		Object collationValue = collationExpression != null
+				? collationExpression.getValue(getEvaluationContext(null), String.class)
 				: this.collation;
 
 		if (collationValue == null) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Embedded.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Embedded.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.annotation.meta.When;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * The annotation to configure a value object as embedded (flattened out) in the target document.
+ * <p />
+ * Depending on the {@link OnEmpty value} of {@link #onEmpty()} the property is set to {@literal null} or an empty
+ * instance in the case all embedded values are {@literal null} when reading from the result set.
+ *
+ * @author Christoph Strobl
+ * @since 3.2
+ */
+@Documented
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
+public @interface Embedded {
+
+	/**
+	 * Set the load strategy for the embedded object if all contained fields yield {@literal null} values.
+	 * <p />
+	 * {@link Nullable @Embedded.Nullable} and {@link Empty @Embedded.Empty} offer shortcuts for this.
+	 *
+	 * @return never {@link} null.
+	 */
+	OnEmpty onEmpty();
+
+	/**
+	 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+	 */
+	String prefix() default "";
+
+	/**
+	 * Load strategy to be used {@link Embedded#onEmpty()}.
+	 *
+	 * @author Christoph Strobl
+	 */
+	enum OnEmpty {
+		USE_NULL, USE_EMPTY
+	}
+
+	/**
+	 * Shortcut for a nullable embedded property.
+	 *
+	 * <pre class="code">
+	 * &#64;Embedded.Nullable private Address address;
+	 * </pre>
+	 *
+	 * as alternative to the more verbose
+	 *
+	 * <pre class="code">
+	 * &#64;Embedded(onEmpty = USE_NULL) &#64;javax.annotation.Nonnull(when = When.MAYBE) private Address address;
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_NULL)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.MAYBE)
+	@interface Nullable {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
+
+		/**
+		 * @return value for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String value() default "";
+	}
+
+	/**
+	 * Shortcut for an empty embedded property.
+	 *
+	 * <pre class="code">
+	 * &#64;Embedded.Empty private Address address;
+	 * </pre>
+	 *
+	 * as alternative to the more verbose
+	 *
+	 * <pre class="code">
+	 * &#64;Embedded(onEmpty = USE_EMPTY) &#64;javax.annotation.Nonnull(when = When.NEVER) private Address address;
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_EMPTY)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.NEVER)
+	@interface Empty {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
+
+		/**
+		 * @return value for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String value() default "";
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedEntityContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedEntityContext.java
@@ -19,7 +19,7 @@ package org.springframework.data.mongodb.core.mapping;
  * @author Christoph Strobl
  * @since 3.2
  */
-public class EmbeddedEntityContext {
+class EmbeddedEntityContext {
 
 	private final MongoPersistentProperty property;
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedEntityContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedEntityContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.2
+ */
+public class EmbeddedEntityContext {
+
+	private final MongoPersistentProperty property;
+
+	public EmbeddedEntityContext(MongoPersistentProperty property) {
+		this.property = property;
+	}
+
+	public MongoPersistentProperty getProperty() {
+		return property;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentEntity.java
@@ -32,13 +32,15 @@ import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 
 /**
+ * Embedded variant of {@link MongoPersistentEntity}.
+ *
  * @author Christoph Strobl
- * @since 2020/12
+ * @see Embedded
  */
-public class EmbeddedMongoPersistentEntity<T> implements MongoPersistentEntity<T> {
+class EmbeddedMongoPersistentEntity<T> implements MongoPersistentEntity<T> {
 
-	private EmbeddedEntityContext context;
-	private MongoPersistentEntity<T> delegate;
+	private final EmbeddedEntityContext context;
+	private final MongoPersistentEntity<T> delegate;
 
 	public EmbeddedMongoPersistentEntity(MongoPersistentEntity<T> delegate, EmbeddedEntityContext context) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentEntity.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.springframework.data.mapping.*;
+import org.springframework.data.mapping.model.PersistentPropertyAccessorFactory;
+import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.data.spel.EvaluationContextProvider;
+import org.springframework.data.util.Streamable;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2020/12
+ */
+public class EmbeddedMongoPersistentEntity<T> implements MongoPersistentEntity<T> {
+
+	private EmbeddedEntityContext context;
+	private MongoPersistentEntity<T> delegate;
+
+	public EmbeddedMongoPersistentEntity(MongoPersistentEntity<T> delegate, EmbeddedEntityContext context) {
+
+		this.context = context;
+		this.delegate = delegate;
+	}
+
+	public String getCollection() {
+		return delegate.getCollection();
+	}
+
+	public String getLanguage() {
+		return delegate.getLanguage();
+	}
+
+	@Nullable
+	public MongoPersistentProperty getTextScoreProperty() {
+		return delegate.getTextScoreProperty();
+	}
+
+	public boolean hasTextScoreProperty() {
+		return delegate.hasTextScoreProperty();
+	}
+
+	@Nullable
+	public Collation getCollation() {
+		return delegate.getCollation();
+	}
+
+	public boolean hasCollation() {
+		return delegate.hasCollation();
+	}
+
+	public ShardKey getShardKey() {
+		return delegate.getShardKey();
+	}
+
+	public boolean isSharded() {
+		return delegate.isSharded();
+	}
+
+	public String getName() {
+		return delegate.getName();
+	}
+
+	@Nullable
+	public PreferredConstructor<T, MongoPersistentProperty> getPersistenceConstructor() {
+		return delegate.getPersistenceConstructor();
+	}
+
+	public boolean isConstructorArgument(PersistentProperty<?> property) {
+		return delegate.isConstructorArgument(property);
+	}
+
+	public boolean isIdProperty(PersistentProperty<?> property) {
+		return delegate.isIdProperty(property);
+	}
+
+	public boolean isVersionProperty(PersistentProperty<?> property) {
+		return delegate.isVersionProperty(property);
+	}
+
+	@Nullable
+	public MongoPersistentProperty getIdProperty() {
+		return delegate.getIdProperty();
+	}
+
+	public MongoPersistentProperty getRequiredIdProperty() {
+		return delegate.getRequiredIdProperty();
+	}
+
+	@Nullable
+	public MongoPersistentProperty getVersionProperty() {
+		return delegate.getVersionProperty();
+	}
+
+	public MongoPersistentProperty getRequiredVersionProperty() {
+		return delegate.getRequiredVersionProperty();
+	}
+
+	@Nullable
+	public MongoPersistentProperty getPersistentProperty(String name) {
+		return wrap(delegate.getPersistentProperty(name));
+	}
+
+	public MongoPersistentProperty getRequiredPersistentProperty(String name) {
+
+		MongoPersistentProperty persistentProperty = getPersistentProperty(name);
+		if (persistentProperty != null) {
+			return persistentProperty;
+		}
+
+		throw new RuntimeException(":kladjnf");
+	}
+
+	@Nullable
+	public MongoPersistentProperty getPersistentProperty(Class<? extends Annotation> annotationType) {
+		return wrap(delegate.getPersistentProperty(annotationType));
+	}
+
+	public Iterable<MongoPersistentProperty> getPersistentProperties(Class<? extends Annotation> annotationType) {
+		return Streamable.of(delegate.getPersistentProperties(annotationType)).stream().map(this::wrap)
+				.collect(Collectors.toList());
+	}
+
+	public boolean hasIdProperty() {
+		return delegate.hasIdProperty();
+	}
+
+	public boolean hasVersionProperty() {
+		return delegate.hasVersionProperty();
+	}
+
+	public Class<T> getType() {
+		return delegate.getType();
+	}
+
+	public Alias getTypeAlias() {
+		return delegate.getTypeAlias();
+	}
+
+	public TypeInformation<T> getTypeInformation() {
+		return delegate.getTypeInformation();
+	}
+
+	public void doWithProperties(PropertyHandler<MongoPersistentProperty> handler) {
+
+		delegate.doWithProperties((PropertyHandler<MongoPersistentProperty>) property -> {
+			handler.doWithPersistentProperty(wrap(property));
+		});
+	}
+
+	public void doWithProperties(SimplePropertyHandler handler) {
+
+		delegate.doWithProperties((SimplePropertyHandler) property -> {
+			if (property instanceof MongoPersistentProperty) {
+				handler.doWithPersistentProperty(wrap((MongoPersistentProperty) property));
+			} else {
+				handler.doWithPersistentProperty(property);
+			}
+		});
+	}
+
+	public void doWithAssociations(AssociationHandler<MongoPersistentProperty> handler) {
+		delegate.doWithAssociations(handler);
+	}
+
+	public void doWithAssociations(SimpleAssociationHandler handler) {
+		delegate.doWithAssociations(handler);
+	}
+
+	@Nullable
+	public <A extends Annotation> A findAnnotation(Class<A> annotationType) {
+		return delegate.findAnnotation(annotationType);
+	}
+
+	public <A extends Annotation> A getRequiredAnnotation(Class<A> annotationType) throws IllegalStateException {
+		return delegate.getRequiredAnnotation(annotationType);
+	}
+
+	public <A extends Annotation> boolean isAnnotationPresent(Class<A> annotationType) {
+		return delegate.isAnnotationPresent(annotationType);
+	}
+
+	public <B> PersistentPropertyAccessor<B> getPropertyAccessor(B bean) {
+		return delegate.getPropertyAccessor(bean);
+	}
+
+	public <B> PersistentPropertyPathAccessor<B> getPropertyPathAccessor(B bean) {
+		return delegate.getPropertyPathAccessor(bean);
+	}
+
+	public IdentifierAccessor getIdentifierAccessor(Object bean) {
+		return delegate.getIdentifierAccessor(bean);
+	}
+
+	public boolean isNew(Object bean) {
+		return delegate.isNew(bean);
+	}
+
+	public boolean isImmutable() {
+		return delegate.isImmutable();
+	}
+
+	public boolean requiresPropertyPopulation() {
+		return delegate.requiresPropertyPopulation();
+	}
+
+	public Iterator<MongoPersistentProperty> iterator() {
+
+		List<MongoPersistentProperty> target = new ArrayList<>();
+		delegate.iterator().forEachRemaining(it -> target.add(wrap(it)));
+		return target.iterator();
+	}
+
+	public void forEach(Consumer<? super MongoPersistentProperty> action) {
+		delegate.forEach(it -> action.accept(wrap(it)));
+	}
+
+	public Spliterator<MongoPersistentProperty> spliterator() {
+		return delegate.spliterator();
+	}
+
+	private MongoPersistentProperty wrap(MongoPersistentProperty source) {
+		if (source == null) {
+			return source;
+		}
+		return new EmbeddedMongoPersistentProperty(source, context);
+	}
+
+	@Override
+	public void addPersistentProperty(MongoPersistentProperty property) {
+
+	}
+
+	@Override
+	public void addAssociation(Association<MongoPersistentProperty> association) {
+
+	}
+
+	@Override
+	public void verify() throws MappingException {
+
+	}
+
+	@Override
+	public void setPersistentPropertyAccessorFactory(PersistentPropertyAccessorFactory factory) {
+
+	}
+
+	@Override
+	public void setEvaluationContextProvider(EvaluationContextProvider provider) {
+
+	}
+
+	@Override
+	public boolean isEmbedded() {
+		return context.getProperty().isEmbedded();
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentProperty.java
@@ -26,10 +26,12 @@ import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 
 /**
+ * Embedded variant of {@link MongoPersistentProperty}.
+ *
  * @author Christoph Strobl
- * @since 2020/12
+ * @see Embedded
  */
-public class EmbeddedMongoPersistentProperty implements MongoPersistentProperty {
+class EmbeddedMongoPersistentProperty implements MongoPersistentProperty {
 
 	private final MongoPersistentProperty delegate;
 	private final EmbeddedEntityContext context;
@@ -202,10 +204,6 @@ public class EmbeddedMongoPersistentProperty implements MongoPersistentProperty 
 
 	public boolean isEmbedded() {
 		return delegate.isEmbedded();
-	}
-
-	public boolean isNullable() {
-		return delegate.isNullable();
 	}
 
 	@Nullable

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/EmbeddedMongoPersistentProperty.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.data.mapping.Association;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2020/12
+ */
+public class EmbeddedMongoPersistentProperty implements MongoPersistentProperty {
+
+	private final MongoPersistentProperty delegate;
+	private final EmbeddedEntityContext context;
+
+	public EmbeddedMongoPersistentProperty(MongoPersistentProperty delegate, EmbeddedEntityContext context) {
+
+		this.delegate = delegate;
+		this.context = context;
+	}
+
+	public String getFieldName() {
+
+		if (!context.getProperty().isEmbedded()) {
+			return delegate.getFieldName();
+		}
+
+		return context.getProperty().findAnnotation(Embedded.class).prefix() + delegate.getFieldName();
+	}
+
+	public Class<?> getFieldType() {
+		return delegate.getFieldType();
+	}
+
+	public int getFieldOrder() {
+		return delegate.getFieldOrder();
+	}
+
+	public boolean isDbReference() {
+		return delegate.isDbReference();
+	}
+
+	public boolean isExplicitIdProperty() {
+		return delegate.isExplicitIdProperty();
+	}
+
+	public boolean isLanguageProperty() {
+		return delegate.isLanguageProperty();
+	}
+
+	public boolean isExplicitLanguageProperty() {
+		return delegate.isExplicitLanguageProperty();
+	}
+
+	public boolean isTextScoreProperty() {
+		return delegate.isTextScoreProperty();
+	}
+
+	@Nullable
+	public DBRef getDBRef() {
+		return delegate.getDBRef();
+	}
+
+	public boolean usePropertyAccess() {
+		return delegate.usePropertyAccess();
+	}
+
+	public boolean hasExplicitWriteTarget() {
+		return delegate.hasExplicitWriteTarget();
+	}
+
+	public PersistentEntity<?, MongoPersistentProperty> getOwner() {
+		return delegate.getOwner();
+	}
+
+	public String getName() {
+		return delegate.getName();
+	}
+
+	public Class<?> getType() {
+		return delegate.getType();
+	}
+
+	public TypeInformation<?> getTypeInformation() {
+		return delegate.getTypeInformation();
+	}
+
+	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
+		return delegate.getPersistentEntityTypes();
+	}
+
+	@Nullable
+	public Method getGetter() {
+		return delegate.getGetter();
+	}
+
+	public Method getRequiredGetter() {
+		return delegate.getRequiredGetter();
+	}
+
+	@Nullable
+	public Method getSetter() {
+		return delegate.getSetter();
+	}
+
+	public Method getRequiredSetter() {
+		return delegate.getRequiredSetter();
+	}
+
+	@Nullable
+	public Method getWither() {
+		return delegate.getWither();
+	}
+
+	public Method getRequiredWither() {
+		return delegate.getRequiredWither();
+	}
+
+	@Nullable
+	public Field getField() {
+		return delegate.getField();
+	}
+
+	public Field getRequiredField() {
+		return delegate.getRequiredField();
+	}
+
+	@Nullable
+	public String getSpelExpression() {
+		return delegate.getSpelExpression();
+	}
+
+	@Nullable
+	public Association<MongoPersistentProperty> getAssociation() {
+		return delegate.getAssociation();
+	}
+
+	public Association<MongoPersistentProperty> getRequiredAssociation() {
+		return delegate.getRequiredAssociation();
+	}
+
+	public boolean isEntity() {
+		return delegate.isEntity();
+	}
+
+	public boolean isIdProperty() {
+		return delegate.isIdProperty();
+	}
+
+	public boolean isVersionProperty() {
+		return delegate.isVersionProperty();
+	}
+
+	public boolean isCollectionLike() {
+		return delegate.isCollectionLike();
+	}
+
+	public boolean isMap() {
+		return delegate.isMap();
+	}
+
+	public boolean isArray() {
+		return delegate.isArray();
+	}
+
+	public boolean isTransient() {
+		return delegate.isTransient();
+	}
+
+	public boolean isWritable() {
+		return delegate.isWritable();
+	}
+
+	public boolean isImmutable() {
+		return delegate.isImmutable();
+	}
+
+	public boolean isAssociation() {
+		return delegate.isAssociation();
+	}
+
+	public boolean isEmbedded() {
+		return delegate.isEmbedded();
+	}
+
+	public boolean isNullable() {
+		return delegate.isNullable();
+	}
+
+	@Nullable
+	public Class<?> getComponentType() {
+		return delegate.getComponentType();
+	}
+
+	public Class<?> getRawType() {
+		return delegate.getRawType();
+	}
+
+	@Nullable
+	public Class<?> getMapValueType() {
+		return delegate.getMapValueType();
+	}
+
+	public Class<?> getActualType() {
+		return delegate.getActualType();
+	}
+
+	@Nullable
+	public <A extends Annotation> A findAnnotation(Class<A> annotationType) {
+		return delegate.findAnnotation(annotationType);
+	}
+
+	public <A extends Annotation> A getRequiredAnnotation(Class<A> annotationType) throws IllegalStateException {
+		return delegate.getRequiredAnnotation(annotationType);
+	}
+
+	@Nullable
+	public <A extends Annotation> A findPropertyOrOwnerAnnotation(Class<A> annotationType) {
+		return delegate.findPropertyOrOwnerAnnotation(annotationType);
+	}
+
+	public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+		return delegate.isAnnotationPresent(annotationType);
+	}
+
+	public boolean hasActualTypeAnnotation(Class<? extends Annotation> annotationType) {
+		return delegate.hasActualTypeAnnotation(annotationType);
+	}
+
+	@Nullable
+	public Class<?> getAssociationTargetType() {
+		return delegate.getAssociationTargetType();
+	}
+
+	public <T> PersistentPropertyAccessor<T> getAccessorForOwner(T owner) {
+		return delegate.getAccessorForOwner(owner);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
@@ -36,7 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Jon Brisbin
  * @author Oliver Gierke
  */
-public class MongoMappingContext extends AbstractMappingContext<BasicMongoPersistentEntity<?>, MongoPersistentProperty>
+public class MongoMappingContext extends AbstractMappingContext<MongoPersistentEntity<?>, MongoPersistentProperty>
 		implements ApplicationContextAware {
 
 	private static final FieldNamingStrategy DEFAULT_NAMING_STRATEGY = PropertyNameFieldNamingStrategy.INSTANCE;
@@ -76,10 +76,15 @@ public class MongoMappingContext extends AbstractMappingContext<BasicMongoPersis
 	 * @see org.springframework.data.mapping.AbstractMappingContext#createPersistentProperty(java.lang.reflect.Field, java.beans.PropertyDescriptor, org.springframework.data.mapping.MutablePersistentEntity, org.springframework.data.mapping.SimpleTypeHolder)
 	 */
 	@Override
-	public MongoPersistentProperty createPersistentProperty(Property property, BasicMongoPersistentEntity<?> owner,
+	public MongoPersistentProperty createPersistentProperty(Property property, MongoPersistentEntity<?> owner,
 			SimpleTypeHolder simpleTypeHolder) {
 		return new CachingMongoPersistentProperty(property, owner, simpleTypeHolder, fieldNamingStrategy);
 	}
+
+//	@Override
+//	protected MongoPersistentProperty createPersistentProperty(Property property, MongoPersistentEntity<?> owner, SimpleTypeHolder simpleTypeHolder) {
+//		return null;
+//	}
 
 	/*
 	 * (non-Javadoc)
@@ -125,5 +130,18 @@ public class MongoMappingContext extends AbstractMappingContext<BasicMongoPersis
 	 */
 	public void setAutoIndexCreation(boolean autoCreateIndexes) {
 		this.autoIndexCreation = autoCreateIndexes;
+	}
+
+
+	@Nullable
+	@Override
+	public MongoPersistentEntity<?> getPersistentEntity(MongoPersistentProperty persistentProperty) {
+
+		MongoPersistentEntity entity = super.getPersistentEntity(persistentProperty);
+		if(entity == null || !persistentProperty.isEmbedded()) {
+			return entity;
+		}
+
+		return new EmbeddedMongoPersistentEntity(entity, new EmbeddedEntityContext(persistentProperty));
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
@@ -35,6 +35,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Jon Brisbin
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 public class MongoMappingContext extends AbstractMappingContext<MongoPersistentEntity<?>, MongoPersistentProperty>
 		implements ApplicationContextAware {
@@ -81,18 +82,13 @@ public class MongoMappingContext extends AbstractMappingContext<MongoPersistentE
 		return new CachingMongoPersistentProperty(property, owner, simpleTypeHolder, fieldNamingStrategy);
 	}
 
-//	@Override
-//	protected MongoPersistentProperty createPersistentProperty(Property property, MongoPersistentEntity<?> owner, SimpleTypeHolder simpleTypeHolder) {
-//		return null;
-//	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.BasicMappingContext#createPersistentEntity(org.springframework.data.util.TypeInformation, org.springframework.data.mapping.model.MappingContext)
 	 */
 	@Override
 	protected <T> BasicMongoPersistentEntity<T> createPersistentEntity(TypeInformation<T> typeInformation) {
-		return new BasicMongoPersistentEntity<T>(typeInformation);
+		return new BasicMongoPersistentEntity<>(typeInformation);
 	}
 
 	/*
@@ -101,7 +97,6 @@ public class MongoMappingContext extends AbstractMappingContext<MongoPersistentE
 	 */
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-
 		super.setApplicationContext(applicationContext);
 	}
 
@@ -132,16 +127,16 @@ public class MongoMappingContext extends AbstractMappingContext<MongoPersistentE
 		this.autoIndexCreation = autoCreateIndexes;
 	}
 
-
 	@Nullable
 	@Override
 	public MongoPersistentEntity<?> getPersistentEntity(MongoPersistentProperty persistentProperty) {
 
-		MongoPersistentEntity entity = super.getPersistentEntity(persistentProperty);
+		MongoPersistentEntity<?> entity = super.getPersistentEntity(persistentProperty);
+
 		if(entity == null || !persistentProperty.isEmbedded()) {
 			return entity;
 		}
 
-		return new EmbeddedMongoPersistentEntity(entity, new EmbeddedEntityContext(persistentProperty));
+		return new EmbeddedMongoPersistentEntity<>(entity, new EmbeddedEntityContext(persistentProperty));
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.model.MutablePersistentEntity;
 import org.springframework.lang.Nullable;
 
 /**
@@ -24,7 +25,7 @@ import org.springframework.lang.Nullable;
  * @author Oliver Gierke
  * @author Christoph Strobl
  */
-public interface MongoPersistentEntity<T> extends PersistentEntity<T, MongoPersistentProperty> {
+public interface MongoPersistentEntity<T> extends MutablePersistentEntity<T, MongoPersistentProperty> {
 
 	/**
 	 * Returns the collection the entity shall be persisted to.
@@ -91,6 +92,10 @@ public interface MongoPersistentEntity<T> extends PersistentEntity<T, MongoPersi
 	 */
 	default boolean isSharded() {
 		return getShardKey().isSharded();
+	}
+
+	default boolean isEmbedded() {
+		return false;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentEntity.java
@@ -94,6 +94,10 @@ public interface MongoPersistentEntity<T> extends MutablePersistentEntity<T, Mon
 		return getShardKey().isSharded();
 	}
 
+	/**
+	 * @return {@literal true} if the entity should be embedded.
+	 * @since 3.2
+	 */
 	default boolean isEmbedded() {
 		return false;
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.data.mongodb.core.mapping;
 
+import java.lang.annotation.ElementType;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mongodb.core.mapping.Embedded.OnEmpty;
+import org.springframework.data.util.NullableUtils;
 import org.springframework.lang.Nullable;
 
 /**
@@ -124,6 +128,24 @@ public interface MongoPersistentProperty extends PersistentProperty<MongoPersist
 	}
 
 	/**
+	 * @return {@literal true} if the property should be embedded.
+	 * @since 3.2
+	 */
+	default boolean isEmbedded() {
+		return isEntity() && findAnnotation(Embedded.class) != null;
+	}
+
+	/**
+	 * @return {@literal true} if the property generally allows {@literal null} values;
+	 * @since 3.2
+	 */
+	default boolean isNullable() {
+
+		return (isEmbedded() && findAnnotation(Embedded.class).onEmpty().equals(OnEmpty.USE_NULL))
+				&& !NullableUtils.isNonNull(getField(), ElementType.FIELD);
+	}
+
+	/**
 	 * Simple {@link Converter} implementation to transform a {@link MongoPersistentProperty} into its field name.
 	 *
 	 * @author Oliver Gierke
@@ -137,7 +159,10 @@ public interface MongoPersistentProperty extends PersistentProperty<MongoPersist
 		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
 		 */
 		public String convert(MongoPersistentProperty source) {
-			return source.getFieldName();
+			if (!source.isEmbedded()) {
+				return source.getFieldName();
+			}
+			return "";
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
@@ -15,14 +15,10 @@
  */
 package org.springframework.data.mongodb.core.mapping;
 
-import java.lang.annotation.ElementType;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
-import org.springframework.data.mongodb.core.mapping.Embedded.OnEmpty;
-import org.springframework.data.util.NullableUtils;
 import org.springframework.lang.Nullable;
 
 /**
@@ -132,17 +128,7 @@ public interface MongoPersistentProperty extends PersistentProperty<MongoPersist
 	 * @since 3.2
 	 */
 	default boolean isEmbedded() {
-		return isEntity() && findAnnotation(Embedded.class) != null;
-	}
-
-	/**
-	 * @return {@literal true} if the property generally allows {@literal null} values;
-	 * @since 3.2
-	 */
-	default boolean isNullable() {
-
-		return (isEmbedded() && findAnnotation(Embedded.class).onEmpty().equals(OnEmpty.USE_NULL))
-				&& !NullableUtils.isNonNull(getField(), ElementType.FIELD);
+		return isEntity() && isAnnotationPresent(Embedded.class);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactoryBean.java
@@ -90,7 +90,7 @@ public class MongoRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 
 		if (createIndexesForQueryMethods) {
 			factory.addQueryCreationListener(
-					new IndexEnsuringQueryCreationListener(collectionName -> operations.indexOps(collectionName)));
+					new IndexEnsuringQueryCreationListener((collectionName, javaType) -> operations.indexOps(javaType)));
 		}
 
 		return factory;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveMongoRepositoryFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveMongoRepositoryFactoryBean.java
@@ -97,7 +97,7 @@ public class ReactiveMongoRepositoryFactoryBean<T extends Repository<S, ID>, S, 
 
 		if (createIndexesForQueryMethods) {
 			factory.addQueryCreationListener(new IndexEnsuringQueryCreationListener(
-					collectionName -> IndexOperationsAdapter.blocking(operations.indexOps(collectionName))));
+					(collectionName, javaType) -> IndexOperationsAdapter.blocking(operations.indexOps(javaType))));
 		}
 
 		return factory;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/DotPath.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/DotPath.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.util;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * Value object representing a dot path.
+ *
+ * @author Mark Paluch
+ * @since 3.2
+ */
+public class DotPath {
+
+	private static final DotPath EMPTY = new DotPath("");
+
+	private final String path;
+
+	private DotPath(String path) {
+		this.path = path;
+	}
+
+	/**
+	 * Creates a new {@link DotPath} from {@code dotPath}.
+	 *
+	 * @param dotPath the dot path, can be empty or {@literal null}.
+	 * @return the {@link DotPath} representing {@code dotPath}.
+	 */
+	public static DotPath from(@Nullable String dotPath) {
+
+		if (StringUtils.hasLength(dotPath)) {
+			return new DotPath(dotPath);
+		}
+
+		return EMPTY;
+	}
+
+	/**
+	 * Returns an empty dotpath.
+	 *
+	 * @return an empty dotpath.
+	 */
+	public static DotPath empty() {
+		return EMPTY;
+	}
+
+	/**
+	 * Append a segment to the dotpath. If the dotpath is not empty, then segments are separated with a dot.
+	 *
+	 * @param segment the segment to append.
+	 * @return
+	 */
+	public DotPath append(String segment) {
+
+		if (isEmpty()) {
+			return new DotPath(segment);
+		}
+
+		return new DotPath(path + "." + segment);
+	}
+
+	/**
+	 * Returns whether this dotpath is empty.
+	 *
+	 * @return whether this dotpath is empty.
+	 */
+	public boolean isEmpty() {
+		return !StringUtils.hasLength(path);
+	}
+
+	@Override
+	public String toString() {
+		return path;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractMongoConfigurationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractMongoConfigurationUnitTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.mongodb.core.convert.MongoTypeMapper;
 import org.springframework.data.mongodb.core.mapping.BasicMongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -103,7 +104,7 @@ public class AbstractMongoConfigurationUnitTests {
 
 		AbstractApplicationContext context = new AnnotationConfigApplicationContext(SampleMongoConfiguration.class);
 		MongoMappingContext mappingContext = context.getBean(MongoMappingContext.class);
-		BasicMongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(Entity.class);
+		MongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(Entity.class);
 		EvaluationContextProvider provider = (EvaluationContextProvider) ReflectionTestUtils.getField(entity,
 				"evaluationContextProvider");
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/config/AbstractReactiveMongoConfigurationUnitTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.mongodb.core.convert.MongoTypeMapper;
 import org.springframework.data.mongodb.core.mapping.BasicMongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.test.util.MongoTestUtils;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
@@ -103,7 +104,7 @@ public class AbstractReactiveMongoConfigurationUnitTests {
 
 		AbstractApplicationContext context = new AnnotationConfigApplicationContext(SampleMongoConfiguration.class);
 		MongoMappingContext mappingContext = context.getBean(MongoMappingContext.class);
-		BasicMongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(Entity.class);
+		MongoPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(Entity.class);
 		EvaluationContextProvider provider = (EvaluationContextProvider) ReflectionTestUtils.getField(entity,
 				"evaluationContextProvider");
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateEmbeddedTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateEmbeddedTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.query.Query.*;
+
+import lombok.EqualsAndHashCode;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.mongodb.core.mapping.Embedded;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.test.util.MongoTemplateExtension;
+import org.springframework.data.mongodb.test.util.Template;
+
+/**
+ * @author Christoph Strobl
+ */
+@ExtendWith(MongoTemplateExtension.class)
+class MongoTemplateEmbeddedTests {
+
+	private static @Template MongoTemplate template;
+
+	@Test // DATAMONGO-1902
+	void readWrite() {
+
+		WithEmbedded source = new WithEmbedded();
+		source.id = "id-1";
+		source.embeddableValue = new EmbeddableType();
+		source.embeddableValue.stringValue = "string-val";
+		source.embeddableValue.listValue = Arrays.asList("list-val-1", "list-val-2");
+		source.embeddableValue.atFieldAnnotatedValue = "@Field";
+
+		template.save(source);
+
+		assertThat(template.findOne(query(where("id").is(source.id)), WithEmbedded.class)).isEqualTo(source);
+	}
+
+	@Test // DATAMONGO-1902
+	void filterOnEmbeddedValue() {
+
+		WithEmbedded source = new WithEmbedded();
+		source.id = "id-1";
+		source.embeddableValue = new EmbeddableType();
+		source.embeddableValue.stringValue = "string-val";
+		source.embeddableValue.listValue = Arrays.asList("list-val-1", "list-val-2");
+		source.embeddableValue.atFieldAnnotatedValue = "@Field";
+
+		template.save(source);
+
+		assertThat(template.findOne(
+				Query.query(where("embeddableValue.stringValue").is(source.embeddableValue.stringValue)), WithEmbedded.class))
+						.isEqualTo(source);
+	}
+
+	@Test // DATAMONGO-1902
+	void readWritePrefixed() {
+
+		WithPrefixedEmbedded source = new WithPrefixedEmbedded();
+		source.id = "id-1";
+		source.embeddableValue = new EmbeddableType();
+		source.embeddableValue.stringValue = "string-val";
+		source.embeddableValue.listValue = Arrays.asList("list-val-1", "list-val-2");
+		source.embeddableValue.atFieldAnnotatedValue = "@Field";
+
+		template.save(source);
+
+		assertThat(template.findOne(query(where("id").is(source.id)), WithPrefixedEmbedded.class)).isEqualTo(source);
+	}
+
+	@Test // DATAMONGO-1902
+	void filterOnPrefixedEmbeddedValue() {
+
+		WithPrefixedEmbedded source = new WithPrefixedEmbedded();
+		source.id = "id-1";
+		source.embeddableValue = new EmbeddableType();
+		source.embeddableValue.stringValue = "string-val";
+		source.embeddableValue.listValue = Arrays.asList("list-val-1", "list-val-2");
+		source.embeddableValue.atFieldAnnotatedValue = "@Field";
+
+		template.save(source);
+
+		assertThat(
+				template.findOne(Query.query(where("embeddableValue.stringValue").is(source.embeddableValue.stringValue)),
+						WithPrefixedEmbedded.class)).isEqualTo(source);
+	}
+
+	@EqualsAndHashCode
+	static class WithEmbedded {
+
+		String id;
+
+		@Embedded.Nullable EmbeddableType embeddableValue;
+	}
+
+	@EqualsAndHashCode
+	static class WithPrefixedEmbedded {
+
+		String id;
+
+		@Embedded.Nullable("prefix-") EmbeddableType embeddableValue;
+	}
+
+	@EqualsAndHashCode
+	static class EmbeddableType {
+
+		String stringValue;
+		List<String> listValue;
+
+		@Field("with-at-field-annotation") //
+		String atFieldAnnotatedValue;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateEmbeddedTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateEmbeddedTests.java
@@ -24,6 +24,7 @@ import lombok.EqualsAndHashCode;
 import java.util.Arrays;
 import java.util.List;
 
+import lombok.ToString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.mongodb.core.mapping.Embedded;
@@ -33,6 +34,8 @@ import org.springframework.data.mongodb.test.util.MongoTemplateExtension;
 import org.springframework.data.mongodb.test.util.Template;
 
 /**
+ * Integration tests for {@link Embedded}.
+ *
  * @author Christoph Strobl
  */
 @ExtendWith(MongoTemplateExtension.class)
@@ -105,6 +108,7 @@ class MongoTemplateEmbeddedTests {
 	}
 
 	@EqualsAndHashCode
+	@ToString
 	static class WithEmbedded {
 
 		String id;
@@ -113,6 +117,7 @@ class MongoTemplateEmbeddedTests {
 	}
 
 	@EqualsAndHashCode
+	@ToString
 	static class WithPrefixedEmbedded {
 
 		String id;
@@ -121,6 +126,7 @@ class MongoTemplateEmbeddedTests {
 	}
 
 	@EqualsAndHashCode
+	@ToString
 	static class EmbeddableType {
 
 		String stringValue;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/UnionWithOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/UnionWithOperationUnitTests.java
@@ -83,7 +83,6 @@ class UnionWithOperationUnitTests {
 				UnionWithOperation.unionWith("coll-1").pipeline(Aggregation.project().and("name").as("name")));
 
 		List<Document> pipeline = agg.toPipeline(contextFor(Supplier.class));
-		System.out.println("pipeline: " + pipeline);
 		assertThat(pipeline).containsExactly(new Document("$project", new Document("supplier", 1)), //
 				new Document("$unionWith", new Document("coll", "coll-1").append("pipeline",
 						Arrays.asList(new Document("$project", new Document("name", 1))))));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -1155,7 +1155,6 @@ class UpdateMapperUnitTests {
 		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
 				context.getPersistentEntity(WrapperAroundWithEmbedded.class));
 
-		System.out.println("mappedUpdate.toJson(): " + mappedUpdate.toJson());
 		assertThat(mappedUpdate).isEqualTo(new Document("$set", new Document("withPrefixedEmbedded",
 				new Document("prefix-stringValue", "updated").append("prefix-listValue", Arrays.asList("val-1", "val-2")))));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
@@ -30,10 +30,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
@@ -63,8 +64,7 @@ public class BasicMongoPersistentEntityUnitTests {
 	@Test
 	void evaluatesSpELExpression() {
 
-		MongoPersistentEntity<Company> entity = new BasicMongoPersistentEntity<>(
-				ClassTypeInformation.from(Company.class));
+		MongoPersistentEntity<Company> entity = new BasicMongoPersistentEntity<>(ClassTypeInformation.from(Company.class));
 		assertThat(entity.getCollection()).isEqualTo("35");
 	}
 
@@ -364,16 +364,13 @@ public class BasicMongoPersistentEntityUnitTests {
 	class WithDocumentCollation {}
 
 	@Sharded
-	private
-	class WithDefaultShardKey {}
+	private class WithDefaultShardKey {}
 
 	@Sharded("country")
-	private
-	class WithSingleShardKey {}
+	private class WithSingleShardKey {}
 
 	@Sharded({ "country", "userid" })
-	private
-	class WithMultiShardKey {}
+	private class WithMultiShardKey {}
 
 	static class SampleExtension implements EvaluationContextExtension {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
@@ -187,7 +187,7 @@ public class BasicMongoPersistentPropertyUnitTests {
 	public void honorsFieldOrderWhenIteratingOverProperties() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		BasicMongoPersistentEntity<?> entity = context.getPersistentEntity(Sample.class);
+		MongoPersistentEntity<?> entity = context.getPersistentEntity(Sample.class);
 
 		List<String> properties = new ArrayList<>();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/MongoMappingContextUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/MongoMappingContextUnitTests.java
@@ -111,7 +111,7 @@ public class MongoMappingContextUnitTests {
 	void mappingContextShouldAcceptClassWithImplicitIdProperty() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithImplicitId.class);
+		MongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithImplicitId.class);
 
 		assertThat(pe).isNotNull();
 		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("id"))).isTrue();
@@ -121,7 +121,7 @@ public class MongoMappingContextUnitTests {
 	void mappingContextShouldAcceptClassWithExplicitIdProperty() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitId.class);
+		MongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitId.class);
 
 		assertThat(pe).isNotNull();
 		assertThat(pe.isIdProperty(pe.getRequiredPersistentProperty("myId"))).isTrue();
@@ -131,7 +131,7 @@ public class MongoMappingContextUnitTests {
 	void mappingContextShouldAcceptClassWithExplicitAndImplicitIdPropertyByGivingPrecedenceToExplicitIdProperty() {
 
 		MongoMappingContext context = new MongoMappingContext();
-		BasicMongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitIdAndImplicitId.class);
+		MongoPersistentEntity<?> pe = context.getRequiredPersistentEntity(ClassWithExplicitIdAndImplicitId.class);
 		assertThat(pe).isNotNull();
 	}
 
@@ -166,7 +166,7 @@ public class MongoMappingContextUnitTests {
 
 		MongoMappingContext context = new MongoMappingContext();
 
-		BasicMongoPersistentEntity<?> entity = context.getRequiredPersistentEntity(ClassWithChronoUnit.class);
+		MongoPersistentEntity<?> entity = context.getRequiredPersistentEntity(ClassWithChronoUnit.class);
 
 		assertThat(entity.getPersistentProperty("unit").isEntity()).isFalse();
 		assertThat(context.hasPersistentEntityFor(ChronoUnit.class)).isFalse();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapreduce/MapReduceTests.java
@@ -79,19 +79,6 @@ public class MapReduceTests {
 		template.getMongoDbFactory().getMongoDatabase("jmr1-out-db").drop();
 	}
 
-	@Test // DATADOC-7
-	@Ignore
-	public void testForDocs() {
-
-		createMapReduceData();
-		MapReduceResults<ValueObject> results = mongoTemplate.mapReduce("jmr1", MAP_FUNCTION, REDUCE_FUNCTION,
-				ValueObject.class);
-
-		for (ValueObject valueObject : results) {
-			System.out.println(valueObject);
-		}
-	}
-
 	@Test // DATAMONGO-260
 	public void testIssue260() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -1361,6 +1361,41 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	void spelExpressionArgumentsGetReevaluatedOnEveryInvocation() {
 
 		assertThat(repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Dave")).containsExactly(dave);
-		assertThat(repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Carter")).containsExactly(carter);
+		assertThat(repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Carter"))
+				.containsExactly(carter);
+	}
+
+	@Test // DATAMONGO-1902
+	void findByValueInsideEmbedded() {
+
+		Person bart = new Person("bart", "simpson");
+		User user = new User();
+		user.setUsername("bartman");
+		user.setId("84r1m4n");
+		bart.setEmbeddedUser(user);
+
+		operations.save(bart);
+
+		List<Person> result = repository.findByEmbeddedUserUsername(user.getUsername());
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getId().equals(bart.getId()));
+	}
+
+	@Test // DATAMONGO-1902
+	void findByEmbedded() {
+
+		Person bart = new Person("bart", "simpson");
+		User user = new User();
+		user.setUsername("bartman");
+		user.setId("84r1m4n");
+		bart.setEmbeddedUser(user);
+
+		operations.save(bart);
+
+		List<Person> result = repository.findByEmbeddedUser(user);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getId().equals(bart.getId()));
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
@@ -27,6 +27,7 @@ import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Embedded;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
@@ -69,6 +70,9 @@ public class Person extends Contact {
 	@DBRef(lazy = true) ArrayList<User> realFans;
 
 	Credentials credentials;
+
+	@Embedded.Nullable(prefix = "u") //
+	User embeddedUser;
 
 	public Person() {
 
@@ -294,6 +298,14 @@ public class Person extends Contact {
 
 	public List<String> getSkills() {
 		return skills;
+	}
+
+	public User getEmbeddedUser() {
+		return embeddedUser;
+	}
+
+	public void setEmbeddedUser(User embeddedUser) {
+		this.embeddedUser = embeddedUser;
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -401,4 +401,8 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	Person findPersonByManyArguments(String firstname, String lastname, String email, Integer age, Sex sex,
 			Date createdAt, List<String> skills, String street, String zipCode, //
 			String city, UUID uniqueId, String username, String password);
+
+	List<Person> findByEmbeddedUserUsername(String username);
+
+	List<Person> findByEmbeddedUser(User user);
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
@@ -78,6 +78,7 @@ public class RepositoryIndexCreationIntegrationTests {
 
 		assertHasIndexForField(indexInfo, "lastname");
 		assertHasIndexForField(indexInfo, "firstname");
+		assertHasIndexForField(indexInfo, "add");
 	}
 
 	private static void assertHasIndexForField(List<IndexInfo> indexInfo, String... fields) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/IndexEnsuringQueryCreationListenerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/IndexEnsuringQueryCreationListenerUnitTests.java
@@ -66,7 +66,7 @@ class IndexEnsuringQueryCreationListenerUnitTests {
 
 		partTreeQuery = mock(PartTreeMongoQuery.class, Answers.RETURNS_MOCKS);
 		when(partTreeQuery.getTree()).thenReturn(partTree);
-		when(provider.indexOps(anyString())).thenReturn(indexOperations);
+		when(provider.indexOps(anyString(), any())).thenReturn(indexOperations);
 		when(queryMethod.getEntityInformation()).thenReturn(entityInformation);
 		when(entityInformation.getCollectionName()).thenReturn("persons");
 	}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -1,6 +1,11 @@
 [[new-features]]
 = New & Noteworthy
 
+[[new-features.3.2]]
+== What's New in Spring Data MongoDB 3.2
+
+* Support for <<embedded-entities,Embedded Types>> to unwrap nested objects into the parent `Document`.
+
 [[new-features.3.1]]
 == What's New in Spring Data MongoDB 3.1
 

--- a/src/main/asciidoc/reference/embedded-documents.adoc
+++ b/src/main/asciidoc/reference/embedded-documents.adoc
@@ -1,0 +1,370 @@
+[[embedded-entities]]
+== Embedded Types
+
+Embedded entities are used to design value objects in your Java domain model whose properties are flattened out into the MongoDB Document.
+
+[[embedded-entities.mapping]]
+=== Embedded Types Mapping
+
+In the example below you see, that `User.name` is annotated with `@Embedded`.
+The consequence of this is that all properties of `UserName` are folded into the `user` document.
+
+.Sample Code of embedding objects
+====
+[source,java]
+----
+public class User {
+
+	@Id
+    private String userId;
+
+    @Embedded(onEmpty = USE_NULL) <1>
+    UserName name;
+}
+
+public class UserName {
+    private String firstname;
+    private String lastname;
+}
+----
+
+[source,json]
+----
+{
+  "_id" : "1da2ba06-3ba7",
+  "firstname" : "Emma",
+  "lastname" : "Frost"
+}
+----
+<1> When loading the `name` property its value is set to `null` if both `firstname` and `lastname` are either `null` or not present.
+By using `onEmpty=USE_EMPTY` an empty `UserName`, with potential `null` value for its properties, will be created.
+====
+
+For less verbose embeddable type declarations use `@Embedded.Nullable` and `@Embedded.Empty` instead `@Embedded(onEmpty = USE_NULL)` and `@Embedded(onEmpty = USE_EMPTY)`.
+Using those annotations simultaneously set JSR-305 `@javax.annotation.Nonnull` accordingly.
+
+[WARNING]
+====
+It is possible to use complex types within an embedded object.
+However those must not be, nor contain embedded fields themselves.
+====
+
+[[embedded-entities.mapping.field-names]]
+=== Embedded Types field names
+
+A value object can be embedded multiple times by using the optional `prefix` attribute of the `@Embedded` annotation.
+By dosing so the chosen prefix is prepended to each property or `@Field("...")` name in the embedded object.
+Please note that values will overwrite each other if multiple properties render to the same field name.
+
+.Sample Code of embedded object with name prefix
+====
+[source,java]
+----
+public class User {
+
+	@Id
+    private String userId;
+
+    @Embedded.Nullable(prefix = "u") <1>
+    UserName name;
+}
+
+public class UserName {
+    private String firstname;
+    private String lastname;
+}
+----
+
+[source,json]
+----
+{
+  "_id" : "a6a805bd-f95f",
+  "ufirstname" : "Jean",
+  "ulastname" : "Grey"
+}
+----
+<1> The prefix `u` is prepended to all properties of `UserName`.
+====
+
+While combining the `@Field` annotation with `@Embedded` on the very same property does not make sense and therefore leads to an error.
+It is a totally valid approach to use `@Field` on any of the embedded types properties.
+
+.Sample Code embedded object with `@Field` annotation
+====
+[source,java]
+----
+public class User {
+
+	@Id
+    private String userId;
+
+    @Embedded.Nullable(prefix = "u-") <1>
+    UserName name;
+}
+
+public class UserName {
+
+	@Field("first-name") <2>
+    private String firstname;
+
+	@Field("last-name")
+    private String lastname;
+}
+----
+
+[source,json]
+----
+{
+  "_id" : "2647f7b9-89da",
+  "u-first-name" : "Barbara", <2>
+  "u-last-name" : "Gordon"
+}
+----
+<1> The prefix `u-` is prepended to all properties of `UserName`.
+<2> The field name is the result of the combination of the annotated field name an the chosen prefix.
+====
+
+[[embedded-entities.queries]]
+=== Query on Embedded Objects
+
+Defining queries on embedded properties is possible on type as well as field level as the provided `Critieria` is matched against the domain type.
+Prefixes and potential custom field names will be considered when rendering the actual query.
+Use the property name of the embedded object to match against all contained fields as shown in the sample below.
+
+.Query on embedded object
+====
+[source,java]
+----
+UserName userName = new UserName("Carol", "Danvers")
+Query findByUserName = query(where("name").is(userName));
+User user = template.findOne(findByUserName, User.class);
+----
+
+[source,json]
+----
+db.collection.find({
+  "firstname" : "Carol",
+  "lastname" : "Danvers"
+})
+----
+====
+
+It is also possible to address any field of the embedded object directly via its property name as shown in the snippet below.
+
+.Query on field of embedded object
+====
+[source,java]
+----
+Query findByUserFirstName = query(where("name.firstname").is("Shuri"));
+List<User> users = template.findAll(findByUserFirstName, User.class);
+----
+
+[source,json]
+----
+db.collection.find({
+  "firstname" : "Shuri"
+})
+----
+====
+
+[[embedded-entities.queries.sort]]
+==== Sort by embedded field.
+
+Fields of embedded objects can be used for sorting via their property path as shown in the sample below.
+
+.Sort on embedded field
+====
+[source,java]
+----
+Query findByUserLastName = query(where("name.lastname").is("Romanoff"));
+List<User> user = template.findAll(findByUserName.withSort(Sort.by("name.firstname")), User.class);
+----
+
+[source,json]
+----
+db.collection.find({
+  "lastname" : "Romanoff"
+}).sort({ "firstname" : 1 })
+----
+====
+
+[NOTE]
+====
+Though possible, using the embedded object itself as sort criteria includes all of its fields in unpredictable order and may result in inaccurate ordering.
+====
+
+[[embedded-entities.queries.project]]
+==== Project on embedded object
+
+Fields of embedded objects can be subject for projection either as a whole or via single fields as shown in the samples below.
+
+.Project on embedded object.
+====
+[source,java]
+----
+Query findByUserLastName = query(where("name.firstname").is("Gamora"));
+findByUserLastName.fields().include("name"); <1>
+List<User> user = template.findAll(findByUserName, User.class);
+----
+
+[source,json]
+----
+db.collection.find({
+  "lastname" : "Gamora"
+},
+{
+  "firstname" : 1,
+  "lastname" : 1
+})
+----
+<1> A field projection on an embedded object includes all of its properties.
+====
+
+.Project on a field of an embedded object.
+====
+[source,java]
+----
+Query findByUserLastName = query(where("name.lastname").is("Smoak"));
+findByUserLastName.fields().include("name.firstname"); <1>
+List<User> user = template.findAll(findByUserName, User.class);
+----
+
+[source,json]
+----
+db.collection.find({
+  "lastname" : "Smoak"
+},
+{
+  "firstname" : 1
+})
+----
+<1> A field projection on an embedded object includes all of its properties.
+====
+
+[[embedded-entities.queries.by-example]]
+==== Query By Example on embedded object.
+
+Embedded objects can be used within an `Example` probe just as any other type.
+Please review the <<query-by-example.running,Query By Example>> section, to learn more about this feature.
+
+[[embedded-entities.queries.repository]]
+==== Repository Queries on embedded objects.
+
+The `Repository` abstraction allows deriving queries on fields of embedded objects as well as the entire object.
+
+.Repository queries on embedded objects.
+====
+[source,java]
+----
+interface UserRepository extends CrudRepository<User, String> {
+
+	List<User> findByName(UserName username); <1>
+
+	List<User> findByNameFirstname(String firstname); <1>
+}
+----
+<1> Matches against all fields of the embedded object.
+<2> Matches against the `firstname`.
+====
+
+[NOTE]
+====
+Index creation for embedded objects is suspended even if the repository `create-query-indexes` namespace attribute is set to `true`.
+====
+
+[[embedded-entities.update]]
+=== Update on Embedded Objects
+
+Embedded objects can be updated as any other object that is part of the domain model.
+The mapping layer takes care of flattening embedded structures into their surroundings.
+It is possible to update single attributes of the embedded object as well as the entire value as shown in the examples below.
+
+.Update a single field of an embedded object.
+====
+[source,java]
+----
+Update update = new Update().set("name.firstname", "Janet");
+template.update(User.class).matching(where("id").is("Wasp"))
+   .apply(update).first()
+----
+
+[source,json]
+----
+db.collection.update({
+  "_id" : "Wasp"
+},
+{
+  "$set" { "firstname" : "Janet" }
+},
+{ ... }
+)
+----
+====
+
+.Update an embedded object.
+====
+[source,java]
+----
+Update update = new Update().set("name", new Name("Janet", "van Dyne"));
+template.update(User.class).matching(where("id").is("Wasp"))
+   .apply(update).first()
+----
+
+[source,json]
+----
+db.collection.update({
+  "_id" : "Wasp"
+},
+{
+  "$set" {
+    "firstname" : "Janet",
+    "lastname" : "van Dyne",
+  }
+},
+{ ... }
+)
+----
+====
+
+[[embedded-entities.aggregations]]
+=== Aggregations on Embedded Objects
+
+The <<mongo.aggregation,Aggregation Framework>> will attempt to map embedded values of typed aggregations.
+Please make sure to work with the properties path including the embedded wrapper object when referencing one of it's values.
+Other than that no special action is required.
+
+[[embedded-entities.indexes]]
+=== Index on Embedded Objects
+
+It is possible to attach the `@Indexed` annotation to properties of an embedded type just as it is done with regular objects.
+However it is not possible to use `@Indexed` along with the `@Embedded` annotation on the very same property of an object.
+
+====
+[source,java]
+----
+public class User {
+
+	@Id
+    private String userId;
+
+    @Embedded(onEmpty = USE_NULL)
+    UserName name; <1>
+
+    @Indexed <2> // Invalid -> InvalidDataAccessApiUsageException
+    @Embedded(onEmpty = USE_Empty)
+    Address address;
+}
+
+public class UserName {
+
+    private String firstname;
+
+    @Indexed
+    private String lastname; <1>
+}
+----
+<1> Index created for `lastname` in `users` collection.
+<2> Invalid `@Indexed` usage along with `@Embedded`
+====
+
+

--- a/src/main/asciidoc/reference/embedded-documents.adoc
+++ b/src/main/asciidoc/reference/embedded-documents.adoc
@@ -1,30 +1,33 @@
 [[embedded-entities]]
 == Embedded Types
 
-Embedded entities are used to design value objects in your Java domain model whose properties are flattened out into the MongoDB Document.
+Embedded entities are used to design value objects in your Java domain model whose properties are flattened out into the parent's MongoDB Document.
 
 [[embedded-entities.mapping]]
 === Embedded Types Mapping
 
-In the example below you see, that `User.name` is annotated with `@Embedded`.
-The consequence of this is that all properties of `UserName` are folded into the `user` document.
+Consider the following domain model where `User.name` is annotated with `@Embedded`.
+The `@Embedded` annotation signals that all properties of `UserName` should be unwrapped into the `user` document that owns the `name` property.
 
 .Sample Code of embedding objects
 ====
 [source,java]
 ----
-public class User {
+class User {
 
-	@Id
-    private String userId;
+    @Id
+    String userId;
 
     @Embedded(onEmpty = USE_NULL) <1>
     UserName name;
 }
 
-public class UserName {
-    private String firstname;
-    private String lastname;
+class UserName {
+
+    String firstname;
+
+    String lastname;
+
 }
 ----
 
@@ -41,37 +44,42 @@ By using `onEmpty=USE_EMPTY` an empty `UserName`, with potential `null` value fo
 ====
 
 For less verbose embeddable type declarations use `@Embedded.Nullable` and `@Embedded.Empty` instead `@Embedded(onEmpty = USE_NULL)` and `@Embedded(onEmpty = USE_EMPTY)`.
-Using those annotations simultaneously set JSR-305 `@javax.annotation.Nonnull` accordingly.
+Both annotations are meta-annotated with JSR-305 `@javax.annotation.Nonnull` to aid with nullability inspections.
 
 [WARNING]
 ====
 It is possible to use complex types within an embedded object.
-However those must not be, nor contain embedded fields themselves.
+However, those must not be, nor contain embedded fields themselves.
 ====
 
 [[embedded-entities.mapping.field-names]]
 === Embedded Types field names
 
 A value object can be embedded multiple times by using the optional `prefix` attribute of the `@Embedded` annotation.
-By dosing so the chosen prefix is prepended to each property or `@Field("...")` name in the embedded object.
+By dosing so the chosen prefix is prepended to each property or `@Field("…")` name in the embedded object.
 Please note that values will overwrite each other if multiple properties render to the same field name.
 
 .Sample Code of embedded object with name prefix
 ====
 [source,java]
 ----
-public class User {
+class User {
 
-	@Id
-    private String userId;
+    @Id
+    String userId;
 
-    @Embedded.Nullable(prefix = "u") <1>
+    @Embedded.Nullable(prefix = "u_") <1>
+    UserName name;
+
+    @Embedded.Nullable(prefix = "a_") <2>
     UserName name;
 }
 
-public class UserName {
-    private String firstname;
-    private String lastname;
+class UserName {
+
+    String firstname;
+
+    String lastname;
 }
 ----
 
@@ -79,11 +87,14 @@ public class UserName {
 ----
 {
   "_id" : "a6a805bd-f95f",
-  "ufirstname" : "Jean",
-  "ulastname" : "Grey"
+  "u_firstname" : "Jean",             <1>
+  "u_lastname" : "Grey",
+  "a_firstname" : "Something",        <2>
+  "a_lastname" : "Else"
 }
 ----
-<1> The prefix `u` is prepended to all properties of `UserName`.
+<1> All properties of `UserName` are prefixed with `u_`.
+<2> All properties of `UserName` are prefixed with `a_`.
 ====
 
 While combining the `@Field` annotation with `@Embedded` on the very same property does not make sense and therefore leads to an error.
@@ -104,7 +115,7 @@ public class User {
 
 public class UserName {
 
-	@Field("first-name") <2>
+	@Field("first-name")              <2>
     private String firstname;
 
 	@Field("last-name")
@@ -116,18 +127,18 @@ public class UserName {
 ----
 {
   "_id" : "2647f7b9-89da",
-  "u-first-name" : "Barbara", <2>
+  "u-first-name" : "Barbara",         <2>
   "u-last-name" : "Gordon"
 }
 ----
-<1> The prefix `u-` is prepended to all properties of `UserName`.
-<2> The field name is the result of the combination of the annotated field name an the chosen prefix.
+<1> All properties of `UserName` are prefixed with `u-`.
+<2> Final field names are a result of concatenating `@Embedded(prefix)` and `@Field(name)`.
 ====
 
 [[embedded-entities.queries]]
 === Query on Embedded Objects
 
-Defining queries on embedded properties is possible on type as well as field level as the provided `Critieria` is matched against the domain type.
+Defining queries on embedded properties is possible on type- as well as field-level as the provided `Criteria` is matched against the domain type.
 Prefixes and potential custom field names will be considered when rendering the actual query.
 Use the property name of the embedded object to match against all contained fields as shown in the sample below.
 
@@ -149,7 +160,7 @@ db.collection.find({
 ----
 ====
 
-It is also possible to address any field of the embedded object directly via its property name as shown in the snippet below.
+It is also possible to address any field of the embedded object directly using its property name as shown in the snippet below.
 
 .Query on field of embedded object
 ====
@@ -194,7 +205,7 @@ Though possible, using the embedded object itself as sort criteria includes all 
 ====
 
 [[embedded-entities.queries.project]]
-==== Project on embedded object
+==== Field projection on embedded objects
 
 Fields of embedded objects can be subject for projection either as a whole or via single fields as shown in the samples below.
 
@@ -203,7 +214,7 @@ Fields of embedded objects can be subject for projection either as a whole or vi
 [source,java]
 ----
 Query findByUserLastName = query(where("name.firstname").is("Gamora"));
-findByUserLastName.fields().include("name"); <1>
+findByUserLastName.fields().include("name");                             <1>
 List<User> user = template.findAll(findByUserName, User.class);
 ----
 
@@ -225,7 +236,7 @@ db.collection.find({
 [source,java]
 ----
 Query findByUserLastName = query(where("name.lastname").is("Smoak"));
-findByUserLastName.fields().include("name.firstname"); <1>
+findByUserLastName.fields().include("name.firstname");                   <1>
 List<User> user = template.findAll(findByUserName, User.class);
 ----
 
@@ -258,9 +269,9 @@ The `Repository` abstraction allows deriving queries on fields of embedded objec
 ----
 interface UserRepository extends CrudRepository<User, String> {
 
-	List<User> findByName(UserName username); <1>
+	List<User> findByName(UserName username);         <1>
 
-	List<User> findByNameFirstname(String firstname); <1>
+	List<User> findByNameFirstname(String firstname); <2>
 }
 ----
 <1> Matches against all fields of the embedded object.
@@ -330,14 +341,14 @@ db.collection.update({
 === Aggregations on Embedded Objects
 
 The <<mongo.aggregation,Aggregation Framework>> will attempt to map embedded values of typed aggregations.
-Please make sure to work with the properties path including the embedded wrapper object when referencing one of it's values.
+Please make sure to work with the property path including the embedded wrapper object when referencing one of its values.
 Other than that no special action is required.
 
 [[embedded-entities.indexes]]
 === Index on Embedded Objects
 
 It is possible to attach the `@Indexed` annotation to properties of an embedded type just as it is done with regular objects.
-However it is not possible to use `@Indexed` along with the `@Embedded` annotation on the very same property of an object.
+It is not possible to use `@Indexed` along with the `@Embedded` annotation on the owning property.
 
 ====
 [source,java]
@@ -348,9 +359,10 @@ public class User {
     private String userId;
 
     @Embedded(onEmpty = USE_NULL)
-    UserName name; <1>
+    UserName name;                    <1>
 
-    @Indexed <2> // Invalid -> InvalidDataAccessApiUsageException
+    // Invalid -> InvalidDataAccessApiUsageException
+    @Indexed                          <2>
     @Embedded(onEmpty = USE_Empty)
     Address address;
 }
@@ -360,7 +372,7 @@ public class UserName {
     private String firstname;
 
     @Indexed
-    private String lastname; <1>
+    private String lastname;           <1>
 }
 ----
 <1> Index created for `lastname` in `users` collection.

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -833,4 +833,6 @@ Events are fired throughout the lifecycle of the mapping process. This is descri
 
 Declaring these beans in your Spring ApplicationContext causes them to be invoked whenever the event is dispatched.
 
+include::embedded-documents.adoc[]
+
 include::mongo-custom-conversions.adoc[]


### PR DESCRIPTION
**Depends on:** spring-projects/spring-data-commons#2293

⚠️ Open for discussion -   do not merge! 

----

### Embedded Types

Embedded entities are used to design value objects in your Java domain model whose properties are flattened out into the MongoDB Document.

#### Embedded Types Mapping

In the example below you see, that `User.name` is annotated with `@Embedded`.
The consequence of this is that all properties of `UserName` are folded into the `user` document.

```java
public class User {
    @Id
    private String userId;

    @Embedded(onEmpty = USE_NULL)
    private UserName name;
}

public class UserName {
    private String firstname;
    private String lastname;
}
```

```json
{
  "_id" : "1da2ba06-3ba7",
  "firstname" : "Emma",
  "lastname" : "Frost"
}
```

It is possible to use complex types within an embedded object.
However those must not be, nor contain embedded fields themselves.
