### PR TITLE
DATAMONGO-2671 - Fix dateFromParts millisecond field name. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-DATAMONGO-2671-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2671-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2671-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-DATAMONGO-2671-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
@@ -1829,24 +1829,64 @@ public class DateOperators {
 		}
 
 		/**
-		 * Set the {@literal milliseconds} to the given value which must resolve to a value in range {@code 0 - 999}. Can be
+		 * Set the {@literal millisecond} to the given value which must resolve to a value in range {@code 0 - 999}. Can be
 		 * a simple value, {@link Field field reference} or {@link AggregationExpression expression}.
 		 *
-		 * @param milliseconds must not be {@literal null}.
+		 * @param millisecond must not be {@literal null}.
 		 * @return new instance.
-		 * @throws IllegalArgumentException if given {@literal milliseconds} is {@literal null}
+		 * @throws IllegalArgumentException if given {@literal millisecond} is {@literal null}
+		 * @deprecated use {@link #millisecond(Object)} instead.
 		 */
-		T milliseconds(Object milliseconds);
+		@Deprecated
+		default T milliseconds(Object millisecond) {
+			return millisecond(millisecond);
+		}
 
 		/**
-		 * Set the {@literal milliseconds} to the value resolved by following the given {@link Field field reference}.
+		 * Set the {@literal millisecond} to the given value which must resolve to a value in range {@code 0 - 999}. Can be
+		 * a simple value, {@link Field field reference} or {@link AggregationExpression expression}.
+		 *
+		 * @param millisecond must not be {@literal null}.
+		 * @return new instance.
+		 * @throws IllegalArgumentException if given {@literal millisecond} is {@literal null}
+		 */
+		T millisecond(Object millisecond);
+
+		/**
+		 * Set the {@literal millisecond} to the value resolved by following the given {@link Field field reference}.
+		 *
+		 * @param fieldReference must not be {@literal null}.
+		 * @return new instance.
+		 * @throws IllegalArgumentException if given {@literal fieldReference} is {@literal null}.
+		 * @deprecated use {@link #millisecondOf(String)} instead.
+		 */
+		@Deprecated
+		default T millisecondsOf(String fieldReference) {
+			return millisecondOf(fieldReference);
+		}
+
+		/**
+		 * Set the {@literal millisecond} to the value resolved by following the given {@link Field field reference}.
 		 *
 		 * @param fieldReference must not be {@literal null}.
 		 * @return new instance.
 		 * @throws IllegalArgumentException if given {@literal fieldReference} is {@literal null}.
 		 */
-		default T millisecondsOf(String fieldReference) {
+		default T millisecondOf(String fieldReference) {
 			return milliseconds(Fields.field(fieldReference));
+		}
+
+		/**
+		 * Set the {@literal millisecond} to the result of the given {@link AggregationExpression expression}.
+		 *
+		 * @param expression must not be {@literal null}.
+		 * @return new instance.
+		 * @throws IllegalArgumentException if given {@literal expression} is {@literal null}.
+		 * @deprecated use {@link #millisecondOf(AggregationExpression)} instead.
+		 */
+		@Deprecated
+		default T millisecondsOf(AggregationExpression expression) {
+			return millisecondOf(expression);
 		}
 
 		/**
@@ -1856,7 +1896,7 @@ public class DateOperators {
 		 * @return new instance.
 		 * @throws IllegalArgumentException if given {@literal expression} is {@literal null}.
 		 */
-		default T millisecondsOf(AggregationExpression expression) {
+		default T millisecondOf(AggregationExpression expression) {
 			return milliseconds(expression);
 		}
 	}
@@ -1971,8 +2011,8 @@ public class DateOperators {
 		}
 
 		@Override
-		public DateFromParts milliseconds(Object milliseconds) {
-			return new DateFromParts(append("milliseconds", milliseconds));
+		public DateFromParts millisecond(Object millisecond) {
+			return new DateFromParts(append("millisecond", millisecond));
 		}
 
 		/**
@@ -2147,8 +2187,8 @@ public class DateOperators {
 		}
 
 		@Override
-		public IsoDateFromParts milliseconds(Object milliseconds) {
-			return new IsoDateFromParts(append("milliseconds", milliseconds));
+		public IsoDateFromParts millisecond(Object millisecond) {
+			return new IsoDateFromParts(append("millisecond", millisecond));
 		}
 
 		/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/spel/MethodReferenceNode.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/spel/MethodReferenceNode.java
@@ -145,9 +145,9 @@ public class MethodReferenceNode extends ExpressionNode {
 		map.put("dateFromString", mapArgRef().forOperator("$dateFromString") //
 				.mappingParametersTo("dateString", "format", "timezone", "onError", "onNull"));
 		map.put("dateFromParts", mapArgRef().forOperator("$dateFromParts").mappingParametersTo("year", "month", "day",
-				"hour", "minute", "second", "milliseconds", "timezone"));
+				"hour", "minute", "second", "millisecond", "timezone"));
 		map.put("isoDateFromParts", mapArgRef().forOperator("$dateFromParts").mappingParametersTo("isoWeekYear", "isoWeek",
-				"isoDayOfWeek", "hour", "minute", "second", "milliseconds", "timezone"));
+				"isoDayOfWeek", "hour", "minute", "second", "millisecond", "timezone"));
 		map.put("dateToParts", mapArgRef().forOperator("$dateToParts") //
 				.mappingParametersTo("date", "timezone", "iso8601"));
 		map.put("isoDayOfWeek", singleArgRef().forOperator("$isoDayOfWeek"));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -1990,15 +1990,15 @@ public class ProjectionOperationUnitTests {
 		assertThat(agg).isEqualTo(Document.parse("{ $project : { newDate: { $dateFromParts: { year : 2018 } } } }"));
 	}
 
-	@Test // DATAMONGO-1834
+	@Test // DATAMONGO-1834, DATAMONGO-2671
 	public void shouldRenderDateFromParts() {
 
 		Document agg = project()
-				.and(DateOperators.dateFromParts().year(2018).month(3).day(23).hour(14).minute(25).second(10).milliseconds(2))
+				.and(DateOperators.dateFromParts().year(2018).month(3).day(23).hour(14).minute(25).second(10).millisecond(2))
 				.as("newDate").toDocument(Aggregation.DEFAULT_CONTEXT);
 
 		assertThat(agg).isEqualTo(Document.parse(
-				"{ $project : { newDate: { $dateFromParts: { year : 2018, month : 3, day : 23, hour : 14, minute : 25, second : 10, milliseconds : 2 } } } }"));
+				"{ $project : { newDate: { $dateFromParts: { year : 2018, month : 3, day : 23, hour : 14, minute : 25, second : 10, millisecond : 2 } } } }"));
 	}
 
 	@Test // DATAMONGO-1834
@@ -2021,14 +2021,14 @@ public class ProjectionOperationUnitTests {
 		assertThat(agg).isEqualTo(Document.parse("{ $project : { newDate: { $dateFromParts: { isoWeekYear : 2018 } } } }"));
 	}
 
-	@Test // DATAMONGO-1834
+	@Test // DATAMONGO-1834, DATAMONGO-2671
 	public void shouldRenderIsoDateFromParts() {
 
 		Document agg = project().and(DateOperators.dateFromParts().isoWeekYear(2018).isoWeek(12).isoDayOfWeek(5).hour(14)
-				.minute(30).second(42).milliseconds(2)).as("newDate").toDocument(Aggregation.DEFAULT_CONTEXT);
+				.minute(30).second(42).millisecond(2)).as("newDate").toDocument(Aggregation.DEFAULT_CONTEXT);
 
 		assertThat(agg).isEqualTo(Document.parse(
-				"{ $project : { newDate: { $dateFromParts: { isoWeekYear : 2018, isoWeek : 12, isoDayOfWeek : 5, hour : 14, minute : 30, second : 42, milliseconds : 2 } } } }"));
+				"{ $project : { newDate: { $dateFromParts: { isoWeekYear : 2018, isoWeek : 12, isoDayOfWeek : 5, hour : 14, minute : 30, second : 42, millisecond : 2 } } } }"));
 	}
 
 	@Test // DATAMONGO-1834

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SpelExpressionTransformerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/SpelExpressionTransformerUnitTests.java
@@ -902,18 +902,18 @@ public class SpelExpressionTransformerUnitTests {
 				"{ \"$dateFromString\" : {\"dateString\" : \"$field\", \"format\" : \"DD-MM-YYYY\", \"timezone\" : \"UTC\", \"onError\" : -1,  \"onNull\" : -2}}"));
 	}
 
-	@Test // DATAMONGO-2077
+	@Test // DATAMONGO-2077, DATAMONGO-2671
 	public void shouldRenderDateFromParts() {
 
 		assertThat(transform("dateFromParts(y, m, d, h, mm, s, ms, 'UTC')")).isEqualTo(Document.parse(
-				"{ \"$dateFromParts\" : {\"year\" : \"$y\", \"month\" : \"$m\", \"day\" : \"$d\", \"hour\" : \"$h\",  \"minute\" : \"$mm\",  \"second\" : \"$s\", \"milliseconds\" : \"$ms\", \"timezone\" : \"UTC\"}}"));
+				"{ \"$dateFromParts\" : {\"year\" : \"$y\", \"month\" : \"$m\", \"day\" : \"$d\", \"hour\" : \"$h\",  \"minute\" : \"$mm\",  \"second\" : \"$s\", \"millisecond\" : \"$ms\", \"timezone\" : \"UTC\"}}"));
 	}
 
-	@Test // DATAMONGO-2077
+	@Test // DATAMONGO-2077, DATAMONGO-2671
 	public void shouldRenderIsoDateFromParts() {
 
 		assertThat(transform("isoDateFromParts(y, m, d, h, mm, s, ms, 'UTC')")).isEqualTo(Document.parse(
-				"{ \"$dateFromParts\" : {\"isoWeekYear\" : \"$y\", \"isoWeek\" : \"$m\", \"isoDayOfWeek\" : \"$d\", \"hour\" : \"$h\",  \"minute\" : \"$mm\",  \"second\" : \"$s\", \"milliseconds\" : \"$ms\", \"timezone\" : \"UTC\"}}"));
+				"{ \"$dateFromParts\" : {\"isoWeekYear\" : \"$y\", \"isoWeek\" : \"$m\", \"isoDayOfWeek\" : \"$d\", \"hour\" : \"$h\",  \"minute\" : \"$mm\",  \"second\" : \"$s\", \"millisecond\" : \"$ms\", \"timezone\" : \"UTC\"}}"));
 	}
 
 	@Test // DATAMONGO-2077


### PR DESCRIPTION
Use `millisecond` instead of `milliseconds` field name.

Related to: https://jira.mongodb.org/browse/DOCS-10652