### PR TITLE
Use relaxed type mapping for aggregations by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3542-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3542-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
@@ -56,6 +56,7 @@ public class AggregationOptions {
 	private final Optional<Document> hint;
 	private Duration maxTime = Duration.ZERO;
 	private ResultOptions resultOptions = ResultOptions.READ;
+	private DomainTypeMapping domainTypeMapping = DomainTypeMapping.RELAXED;
 
 	/**
 	 * Creates a new {@link AggregationOptions}.
@@ -262,6 +263,14 @@ public class AggregationOptions {
 	}
 
 	/**
+	 * @return the domain type mapping strategy do apply. Never {@literal null}.
+	 * @since 3.2
+	 */
+	public DomainTypeMapping getDomainTypeMapping() {
+		return domainTypeMapping;
+	}
+
+	/**
 	 * Returns a new potentially adjusted copy for the given {@code aggregationCommandObject} with the configuration
 	 * applied.
 	 *
@@ -358,6 +367,7 @@ public class AggregationOptions {
 		private @Nullable Document hint;
 		private @Nullable Duration maxTime;
 		private @Nullable ResultOptions resultOptions;
+		private @Nullable DomainTypeMapping domainTypeMapping;
 
 		/**
 		 * Defines whether to off-load intensive sort-operations to disk.
@@ -476,6 +486,44 @@ public class AggregationOptions {
 		}
 
 		/**
+		 * Apply a strict domain type mapping considering {@link org.springframework.data.mongodb.core.mapping.Field}
+		 * annotations throwing errors for non existing, but referenced fields.
+		 *
+		 * @return this.
+		 * @since 3.2
+		 */
+		public Builder strictMapping() {
+
+			this.domainTypeMapping = DomainTypeMapping.STRICT;
+			return this;
+		}
+
+		/**
+		 * Apply a relaxed domain type mapping considering {@link org.springframework.data.mongodb.core.mapping.Field}
+		 * annotations using the user provided name if a referenced field does not exist.
+		 *
+		 * @return this.
+		 * @since 3.2
+		 */
+		public Builder relaxedMapping() {
+
+			this.domainTypeMapping = DomainTypeMapping.RELAXED;
+			return this;
+		}
+
+		/**
+		 * Apply no domain type mapping at all taking the pipeline as is.
+		 *
+		 * @return this.
+		 * @since 3.2
+		 */
+		public Builder noMapping() {
+
+			this.domainTypeMapping = DomainTypeMapping.NONE;
+			return this;
+		}
+
+		/**
 		 * Returns a new {@link AggregationOptions} instance with the given configuration.
 		 *
 		 * @return new instance of {@link AggregationOptions}.
@@ -488,6 +536,9 @@ public class AggregationOptions {
 			}
 			if (resultOptions != null) {
 				options.resultOptions = resultOptions;
+			}
+			if (domainTypeMapping != null) {
+				options.domainTypeMapping = domainTypeMapping;
 			}
 
 			return options;
@@ -507,5 +558,26 @@ public class AggregationOptions {
 		 * Read the aggregation result from the cursor.
 		 */
 		READ;
+	}
+
+	/**
+	 * Aggregation pipeline Domain type mappings supported by the mapping layer.
+	 *
+	 * @since 3.2
+	 */
+	public enum DomainTypeMapping {
+
+		/**
+		 * Mapping throws errors for non existing, but referenced fields.
+		 */
+		STRICT,
+		/**
+		 * Fields that do not exist in the model are treated as is.
+		 */
+		RELAXED,
+		/**
+		 * Do not attempt to map fields against the model and treat the entire pipeline as is.
+		 */
+		NONE
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/RelaxedTypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/RelaxedTypeBasedAggregationOperationContext.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
+import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.context.InvalidPersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.DirectFieldReference;
@@ -55,7 +56,7 @@ public class RelaxedTypeBasedAggregationOperationContext extends TypeBasedAggreg
 
 		try {
 			return super.getReferenceFor(field);
-		} catch (InvalidPersistentPropertyPath e) {
+		} catch (MappingException e) {
 			return new DirectFieldReference(new ExposedField(field, true));
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
@@ -166,4 +166,8 @@ public class TypeBasedAggregationOperationContext implements AggregationOperatio
 
 		return new DirectFieldReference(new ExposedField(mappedField, true));
 	}
+
+	public Class<?> getType() {
+		return type;
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/QueryOperationsUnitTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.QueryOperations.AggregateContext;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
+import org.springframework.data.mongodb.core.aggregation.RelaxedTypeBasedAggregationOperationContext;
+import org.springframework.data.mongodb.core.aggregation.TypeBasedAggregationOperationContext;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.convert.UpdateMapper;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+/**
+ * @author Christoph Strobl
+ * @since 2021/01
+ */
+@ExtendWith(MockitoExtension.class)
+class QueryOperationsUnitTests {
+
+	static final AggregationOptions NO_MAPPING = AggregationOptions.builder().noMapping().build();
+	static final AggregationOptions STRICT_MAPPING = AggregationOptions.builder().strictMapping().build();
+
+	@Mock QueryMapper queryMapper;
+	@Mock UpdateMapper updateMapper;
+	@Mock EntityOperations entityOperations;
+	@Mock PropertyOperations propertyOperations;
+	@Mock MongoDatabaseFactory mongoDbFactory;
+	@Mock MongoMappingContext mappingContext;
+
+	QueryOperations queryOperations;
+
+	@BeforeEach
+	void beforeEach() {
+
+		when(queryMapper.getMappingContext()).thenReturn((MappingContext) mappingContext);
+
+		queryOperations = new QueryOperations(queryMapper, updateMapper, entityOperations, propertyOperations,
+				mongoDbFactory);
+	}
+
+	@Test // GH-3542
+	void createAggregationContextUsesRelaxedOneForUntypedAggregationsWhenNoInputTypeProvided() {
+
+		Aggregation aggregation = Aggregation.newAggregation(Aggregation.project("name"));
+		AggregateContext ctx = queryOperations.createAggregationContext(aggregation, (Class<?>) null);
+
+		assertThat(ctx.getAggregationOperationContext()).isInstanceOf(RelaxedTypeBasedAggregationOperationContext.class);
+	}
+
+	@Test // GH-3542
+	void createAggregationContextUsesRelaxedOneForTypedAggregationsWhenNoInputTypeProvided() {
+
+		Aggregation aggregation = Aggregation.newAggregation(Person.class, Aggregation.project("name"));
+		AggregateContext ctx = queryOperations.createAggregationContext(aggregation, (Class<?>) null);
+
+		assertThat(ctx.getAggregationOperationContext()).isInstanceOf(RelaxedTypeBasedAggregationOperationContext.class);
+	}
+
+	@Test // GH-3542
+	void createAggregationContextUsesRelaxedOneForUntypedAggregationsWhenInputTypeProvided() {
+
+		Aggregation aggregation = Aggregation.newAggregation(Aggregation.project("name"));
+		AggregateContext ctx = queryOperations.createAggregationContext(aggregation, Person.class);
+
+		assertThat(ctx.getAggregationOperationContext()).isInstanceOf(RelaxedTypeBasedAggregationOperationContext.class);
+	}
+
+	@Test // GH-3542
+	void createAggregationContextUsesDefaultIfNoMappingDesired() {
+
+		Aggregation aggregation = Aggregation.newAggregation(Aggregation.project("name")).withOptions(NO_MAPPING);
+		AggregateContext ctx = queryOperations.createAggregationContext(aggregation, Person.class);
+
+		assertThat(ctx.getAggregationOperationContext()).isEqualTo(Aggregation.DEFAULT_CONTEXT);
+	}
+
+	@Test // GH-3542
+	void createAggregationContextUsesStrictlyTypedContextForTypedAggregationsWhenRequested() {
+
+		Aggregation aggregation = Aggregation.newAggregation(Person.class, Aggregation.project("name"))
+				.withOptions(STRICT_MAPPING);
+		AggregateContext ctx = queryOperations.createAggregationContext(aggregation, (Class<?>) null);
+
+		assertThat(ctx.getAggregationOperationContext()).isInstanceOf(TypeBasedAggregationOperationContext.class);
+	}
+
+	static class Person {
+
+	}
+}

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2514,7 +2514,11 @@ The actual aggregate operation is run by the `aggregate` method of the `MongoTem
 +
 A `TypedAggregation`, just like an `Aggregation`, holds the instructions of the aggregation pipeline and a reference to the input type, that is used for mapping domain properties to actual document fields.
 +
-At runtime, field references get checked against the given input type, considering potential `@Field` annotations and raising errors when referencing nonexistent properties.
+At runtime, field references get checked against the given input type, considering potential `@Field` annotations.
+[NOTE]
+====
+Changed in 3.2 referencing nonexistent properties does no longer raise errors. To restore the previous behaviour use the `strictMapping` option of `AggregationOptions`.
+====
 +
 * `AggregationOperation`
 +


### PR DESCRIPTION
Switch from a _strict_ to a _relaxed_ type mapping for aggregation executions. 
This allows users to add fields to the `Aggregation` that might be part of the stored document but not necessarily of its java model representation.
Instead of throwing an `Exception` the relaxed type check will go on with the user provided field names.
To restore the original behaviour use the `strictMapping` option on `AggregationOptions`.