### PR TITLE
Use UUID toString representation for UUID values when converting org.bson.Document to json String

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3546-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3546-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3546-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3546-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -294,7 +294,7 @@ abstract class MongoConverters {
 		@Override
 		public NamedMongoScript convert(Document source) {
 
-			if(source.isEmpty()) {
+			if (source.isEmpty()) {
 				return null;
 			}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverters.java
@@ -32,6 +32,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.bson.BsonTimestamp;
 import org.bson.Document;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.Codec;
+import org.bson.internal.CodecRegistryHelper;
 import org.bson.types.Binary;
 import org.bson.types.Code;
 import org.bson.types.Decimal128;
@@ -45,10 +48,11 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mongodb.core.query.Term;
 import org.springframework.data.mongodb.core.script.NamedMongoScript;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
+
+import com.mongodb.MongoClientSettings;
 
 /**
  * Wrapper class to contain useful converters for the usage with Mongo.
@@ -236,9 +240,13 @@ abstract class MongoConverters {
 
 		INSTANCE;
 
+		private final Codec<Document> codec = CodecRegistryHelper
+				.createRegistry(MongoClientSettings.getDefaultCodecRegistry(), UuidRepresentation.JAVA_LEGACY)
+				.get(Document.class);
+
 		@Override
 		public String convert(Document source) {
-			return source.toJson();
+			return source.toJson(codec);
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2179,6 +2179,15 @@ public class MappingMongoConverterUnitTests {
 		assertThat(((LinkedHashMap) result.get("cluster")).get("_id")).isEqualTo(100L);
 	}
 
+	@Test // GH-3546
+	void readFlattensNestedDocumentToStringIfNecessary() {
+
+		org.bson.Document source = new org.bson.Document("street", new org.bson.Document("json", "string").append("_id", UUID.randomUUID()));
+
+		Address target = converter.read(Address.class, source);
+		assertThat(target.street).isNotNull();
+	}
+
 	static class GenericType<T> {
 		T content;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -97,7 +97,7 @@ import com.mongodb.DBRef;
  * @author Heesu Jung
  */
 @ExtendWith(MockitoExtension.class)
-public class MappingMongoConverterUnitTests {
+class MappingMongoConverterUnitTests {
 
 	private MappingMongoConverter converter;
 	private MongoMappingContext mappingContext;
@@ -105,7 +105,7 @@ public class MappingMongoConverterUnitTests {
 	@Mock DbRefResolver resolver;
 
 	@BeforeEach
-	void setUp() {
+	void beforeEach() {
 
 		MongoCustomConversions conversions = new MongoCustomConversions();
 
@@ -524,6 +524,7 @@ public class MappingMongoConverterUnitTests {
 		assertThat(result.get("_id")).isInstanceOf(String.class);
 	}
 
+	@Test
 	public void convertsObjectsIfNecessary() {
 
 		ObjectId id = new ObjectId();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
@@ -56,10 +56,10 @@ import org.springframework.data.mongodb.core.geo.Sphere;
  * @author Thomas Darimont
  * @author Christoph Strobl
  */
-public class MongoConvertersUnitTests {
+class MongoConvertersUnitTests {
 
 	@Test
-	public void convertsBigDecimalToStringAndBackCorrectly() {
+	void convertsBigDecimalToStringAndBackCorrectly() {
 
 		BigDecimal bigDecimal = BigDecimal.valueOf(254, 1);
 		String value = BigDecimalToStringConverter.INSTANCE.convert(bigDecimal);
@@ -70,7 +70,7 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-858
-	public void convertsBoxToDocumentAndBackCorrectly() {
+	void convertsBoxToDocumentAndBackCorrectly() {
 
 		Box box = new Box(new Point(1, 2), new Point(3, 4));
 
@@ -81,7 +81,7 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-858
-	public void convertsCircleToDocumentAndBackCorrectly() {
+	void convertsCircleToDocumentAndBackCorrectly() {
 
 		Circle circle = new Circle(new Point(1, 2), 3);
 
@@ -92,7 +92,7 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-858
-	public void convertsPolygonToDocumentAndBackCorrectly() {
+	void convertsPolygonToDocumentAndBackCorrectly() {
 
 		Polygon polygon = new Polygon(new Point(1, 2), new Point(2, 3), new Point(3, 4), new Point(5, 6));
 
@@ -103,7 +103,7 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-858
-	public void convertsSphereToDocumentAndBackCorrectly() {
+	void convertsSphereToDocumentAndBackCorrectly() {
 
 		Sphere sphere = new Sphere(new Point(1, 2), 3);
 
@@ -114,7 +114,7 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-858
-	public void convertsPointToListAndBackCorrectly() {
+	void convertsPointToListAndBackCorrectly() {
 
 		Point point = new Point(1, 2);
 
@@ -125,44 +125,44 @@ public class MongoConvertersUnitTests {
 	}
 
 	@Test // DATAMONGO-1372
-	public void convertsCurrencyToStringCorrectly() {
+	void convertsCurrencyToStringCorrectly() {
 		assertThat(CurrencyToStringConverter.INSTANCE.convert(Currency.getInstance("USD"))).isEqualTo("USD");
 	}
 
 	@Test // DATAMONGO-1372
-	public void convertsStringToCurrencyCorrectly() {
+	void convertsStringToCurrencyCorrectly() {
 		assertThat(StringToCurrencyConverter.INSTANCE.convert("USD")).isEqualTo(Currency.getInstance("USD"));
 	}
 
 	@Test // DATAMONGO-1416
-	public void convertsAtomicLongToLongCorrectly() {
+	void convertsAtomicLongToLongCorrectly() {
 		assertThat(AtomicLongToLongConverter.INSTANCE.convert(new AtomicLong(100L))).isEqualTo(100L);
 	}
 
 	@Test // DATAMONGO-1416
-	public void convertsAtomicIntegerToIntegerCorrectly() {
+	void convertsAtomicIntegerToIntegerCorrectly() {
 		assertThat(AtomicIntegerToIntegerConverter.INSTANCE.convert(new AtomicInteger(100))).isEqualTo(100);
 	}
 
 	@Test // DATAMONGO-1416
-	public void convertsLongToAtomicLongCorrectly() {
+	void convertsLongToAtomicLongCorrectly() {
 		assertThat(LongToAtomicLongConverter.INSTANCE.convert(100L)).isInstanceOf(AtomicLong.class);
 	}
 
 	@Test // DATAMONGO-1416
-	public void convertsIntegerToAtomicIntegerCorrectly() {
+	void convertsIntegerToAtomicIntegerCorrectly() {
 		assertThat(IntegerToAtomicIntegerConverter.INSTANCE.convert(100)).isInstanceOf(AtomicInteger.class);
 	}
 
 	@Test // DATAMONGO-2113
-	public void convertsBsonTimestampToInstantCorrectly() {
+	void convertsBsonTimestampToInstantCorrectly() {
 
 		assertThat(BsonTimestampToInstantConverter.INSTANCE.convert(new BsonTimestamp(6615900307735969796L)))
 				.isCloseTo(Instant.ofEpochSecond(1540384327), new TemporalUnitLessThanOffset(100, ChronoUnit.MILLIS));
 	}
 
 	@Test // DATAMONGO-2210
-	public void convertsUrisToString() {
+	void convertsUrisToString() {
 
 		MongoCustomConversions conversions = new MongoCustomConversions();
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MongoConvertersUnitTests.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Currency;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -29,7 +30,6 @@ import org.assertj.core.data.TemporalUnitLessThanOffset;
 import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.geo.Box;
@@ -42,6 +42,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverters.AtomicLongT
 import org.springframework.data.mongodb.core.convert.MongoConverters.BigDecimalToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.BsonTimestampToInstantConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.CurrencyToStringConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverters.DocumentToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.IntegerToAtomicIntegerConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.LongToAtomicLongConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToBigDecimalConverter;
@@ -172,5 +173,13 @@ public class MongoConvertersUnitTests {
 
 		assertThat(conversionService.convert(URI.create("/segment"), String.class)).isEqualTo("/segment");
 		assertThat(conversionService.convert("/segment", URI.class)).isEqualTo(URI.create("/segment"));
+	}
+
+	@Test // GH-3546
+	void convertsDocumentWithUUidToString() {
+
+		UUID uuid = UUID.randomUUID();
+		assertThat(DocumentToStringConverter.INSTANCE.convert(new Document("_id", uuid)))
+				.isEqualTo("{\"_id\": \"" + uuid.toString() + "\"}");
 	}
 }


### PR DESCRIPTION
This PR switches the rendering of `UUID` values to their `toString` format when converting `org.bson.Document` to json via the `DocumentToStringConverter`.

This will move the resulting representation from `{"$binary": "QUK3ZihZ9cdhWjTf5TZqrw==", "$type": "03"}` 
to `480971b0-7160-4120-acd0-6fd6b82418ad`.

The conversion only applies on read in cases where an entire `Document` (like a composite id), is mapped to a `String` property of the domain model. 
Obviously not the most common scenario but one that might easily happen during projections or aggregations.

Relates to: #3546