### PR TITLE
Fix case insensitive derived in queries on String properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3395-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3395-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3395-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3395-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MongoRegexCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MongoRegexCreator.java
@@ -17,6 +17,7 @@ package org.springframework.data.mongodb.core.query;
 
 import java.util.regex.Pattern;
 
+import org.bson.BsonRegularExpression;
 import org.springframework.lang.Nullable;
 
 /**
@@ -100,6 +101,10 @@ public enum MongoRegexCreator {
 			default:
 				return regex;
 		}
+	}
+
+	public Object toCaseInsensitiveMatch(Object source) {
+		return source instanceof String ? new BsonRegularExpression(Pattern.quote((String)source), "i") : source;
 	}
 
 	private String prepareAndEscapeStringBeforeApplyingLikeRegex(String source, MatchMode matcherType) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -1363,4 +1363,19 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 		assertThat(repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Dave")).containsExactly(dave);
 		assertThat(repository.findWithSpelByFirstnameForSpELExpressionWithParameterIndexOnly("Carter")).containsExactly(carter);
 	}
+
+	@Test // GH-3395
+	void caseInSensitiveInClause() {
+		assertThat(repository.findByLastnameIgnoreCaseIn("bEAuFoRd", "maTTheWs")).hasSize(3);
+	}
+
+	@Test // GH-3395
+	void caseInSensitiveInClauseQuotesExpressions() {
+		assertThat(repository.findByLastnameIgnoreCaseIn(".*")).isEmpty();
+	}
+
+	@Test // GH-3395
+	void caseSensitiveInClauseIgnoresExpressions() {
+		assertThat(repository.findByFirstnameIn(".*")).isEmpty();
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -125,6 +125,8 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	@Query("{ 'lastname' : { '$regex' : '?0', '$options' : 'i'}}")
 	Page<Person> findByLastnameLikeWithPageable(String lastname, Pageable pageable);
 
+	List<Person> findByLastnameIgnoreCaseIn(String... lastname);
+
 	/**
 	 * Returns all {@link Person}s with a firstname contained in the given varargs.
 	 *


### PR DESCRIPTION
We now consider the `IgnoreCase` part of a derived query when used along with `In`.
```java
repository.findByLastnameIgnoreCaseIn("bEAuFoRd", "maTTheWs")
```

Closes: #3395 