### PR TITLE
Translate MongoSocketException subclasses to DataAccessResourceFailureException

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core;
 
+import com.mongodb.MongoSocketException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -49,6 +50,7 @@ import com.mongodb.bulk.BulkWriteError;
  * @author Oliver Gierke
  * @author Michal Vich
  * @author Christoph Strobl
+ * @author Brice Vandeputte
  */
 public class MongoExceptionTranslator implements PersistenceExceptionTranslator {
 
@@ -78,6 +80,10 @@ public class MongoExceptionTranslator implements PersistenceExceptionTranslator 
 			throw new InvalidDataAccessApiUsageException(ex.getMessage(), ex);
 		}
 
+		if (ex instanceof MongoSocketException) {
+			return new DataAccessResourceFailureException(ex.getMessage(), ex);
+		}
+
 		String exception = ClassUtils.getShortName(ClassUtils.getUserClass(ex.getClass()));
 
 		if (DUPLICATE_KEY_EXCEPTIONS.contains(exception)) {
@@ -87,6 +93,7 @@ public class MongoExceptionTranslator implements PersistenceExceptionTranslator 
 		if (RESOURCE_FAILURE_EXCEPTIONS.contains(exception)) {
 			return new DataAccessResourceFailureException(ex.getMessage(), ex);
 		}
+
 
 		if (RESOURCE_USAGE_EXCEPTIONS.contains(exception)) {
 			return new InvalidDataAccessResourceUsageException(ex.getMessage(), ex);


### PR DESCRIPTION
Closes #3568

Improve `MongoExceptionTranslator` to accept direct children is some case. First use case : `MongoSocketException, MongoSocketException$children`.

NB/ historical contributors of this class: @christophstrobl, @michalvich, @odrotbohm (Oliver Gierke)

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
-->
