### PR TITLE
Reject saving collection like entities (Lists, Iterator,...) via MongoTemplate.save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3570-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3570-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3570-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3570-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -1319,9 +1319,12 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
 	 * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation" > Spring's
 	 * Type Conversion"</a> for more details.
+	 * <p />
+	 * The {@literal objectToSave} must not be collection like.
 	 *
 	 * @param objectToSave the object to store in the collection. Must not be {@literal null}.
 	 * @return the saved object.
+	 * @throws IllegalArgumentException in case the objectToSave is collection like.
 	 */
 	<T> T save(T objectToSave);
 
@@ -1337,10 +1340,14 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See <a
 	 * https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation">Spring's Type
 	 * Conversion"</a> for more details.
+	 * <p />
+	 * The {@literal objectToSave} must not be collection like.
+	 *
 	 *
 	 * @param objectToSave the object to store in the collection. Must not be {@literal null}.
 	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
 	 * @return the saved object.
+	 * @throws IllegalArgumentException in case the objectToSave is collection like.
 	 */
 	<T> T save(T objectToSave, String collectionName);
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1376,6 +1376,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Assert.notNull(objectToSave, "Object to save must not be null!");
 		Assert.hasText(collectionName, "Collection name must not be null or empty!");
+		ensureNotCollectionLike(objectToSave);
 
 		AdaptibleEntity<T> source = operations.forEntity(objectToSave, mongoConverter.getConversionService());
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -2213,6 +2213,13 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 				.isThrownBy(() -> template.insert(new TypeImplementingIterator()));
 	}
 
+	@Test // GH-3570
+	void saveErrorsOnCollectionLikeObjects() {
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> template.save(new ArrayList<>(Arrays.asList(1, 2, 3)), "myList"));
+	}
+
 	class AutogenerateableId {
 
 		@Id BigInteger id;


### PR DESCRIPTION
This PR makes sure to fail early when attempting to save a collection like object via one of the `save` methods of `MongoTemplate`. This avoids error in the mapping layer trying to convert eg. a list into a `Document`.

Closes: #3570 