### PR TITLE
Support expressions in query field projections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3583-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3583-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3583-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3583-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/BindableMongoExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/BindableMongoExpression.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb;
+
+import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.springframework.data.mongodb.util.json.ParameterBindingDocumentCodec;
+import org.springframework.data.util.Lazy;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * A {@link MongoExpression} using the {@link ParameterBindingDocumentCodec} for parsing the {@literal json} expression.
+ * The expression will be wrapped within <code>{ }</code> if necessary. Placeholders like {@code ?0} are resolved when
+ * first obtaining the target {@link Document} via {@link #toDocument()}.
+ * <p />
+ * 
+ * <pre class="code">
+ * $toUpper : $name                -> { '$toUpper' : '$name' }
+ * 
+ * { '$toUpper' : '$name' }        -> { '$toUpper' : '$name' }
+ * 
+ * { '$toUpper' : '?0' }, "$name"  -> { '$toUpper' : '$name' }
+ * </pre>
+ * 
+ * Some types (like {@link java.util.UUID}) cannot be used directly but require a special {@link org.bson.codecs.Codec}.
+ * Make sure to provide a {@link CodecRegistry} containing the required {@link org.bson.codecs.Codec codecs} via
+ * {@link #withCodecRegistry(CodecRegistry)}.
+ *
+ * @author Christoph Strobl
+ * @since 3.2
+ */
+public class BindableMongoExpression implements MongoExpression {
+
+	private final String json;
+
+	@Nullable //
+	private final CodecRegistryProvider codecRegistryProvider;
+
+	@Nullable //
+	private final Object[] args;
+
+	private final Lazy<Document> target;
+
+	/**
+	 * Create a new instance of {@link BindableMongoExpression}.
+	 *
+	 * @param json must not be {@literal null}.
+	 * @param args can be {@literal null}.
+	 */
+	public BindableMongoExpression(String json, @Nullable Object[] args) {
+		this(json, null, args);
+	}
+
+	/**
+	 * Create a new instance of {@link BindableMongoExpression}.
+	 *
+	 * @param json must not be {@literal null}.
+	 * @param codecRegistryProvider can be {@literal null}.
+	 * @param args can be {@literal null}.
+	 */
+	public BindableMongoExpression(String json, @Nullable CodecRegistryProvider codecRegistryProvider,
+			@Nullable Object[] args) {
+
+		this.json = wrapJsonIfNecessary(json);
+		this.codecRegistryProvider = codecRegistryProvider;
+		this.args = args;
+		this.target = Lazy.of(this::parse);
+	}
+
+	/**
+	 * Provide the {@link CodecRegistry} used to convert expressions.
+	 *
+	 * @param codecRegistry must not be {@literal null}.
+	 * @return new instance of {@link BindableMongoExpression}.
+	 */
+	public BindableMongoExpression withCodecRegistry(CodecRegistry codecRegistry) {
+		return new BindableMongoExpression(json, () -> codecRegistry, args);
+	}
+
+	/**
+	 * Provide the arguments to bind to the placeholders via their index.
+	 *
+	 * @param args must not be {@literal null}.
+	 * @return new instance of {@link BindableMongoExpression}.
+	 */
+	public BindableMongoExpression bind(Object... args) {
+		return new BindableMongoExpression(json, codecRegistryProvider, args);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.data.mongodb.MongoExpression#toDocument()
+	 */
+	@Override
+	public Document toDocument() {
+		return target.get();
+	}
+
+	private String wrapJsonIfNecessary(String json) {
+
+		if (StringUtils.hasText(json) && (json.startsWith("{") && json.endsWith("}"))) {
+			return json;
+		}
+
+		return "{" + json + "}";
+	}
+
+	private Document parse() {
+
+		if (ObjectUtils.isEmpty(args)) {
+
+			if (codecRegistryProvider == null) {
+				return Document.parse(json);
+			}
+
+			return Document.parse(json, codecRegistryProvider.getCodecFor(Document.class)
+					.orElseGet(() -> new DocumentCodec(codecRegistryProvider.getCodecRegistry())));
+		}
+
+		ParameterBindingDocumentCodec codec = codecRegistryProvider == null ? new ParameterBindingDocumentCodec()
+				: new ParameterBindingDocumentCodec(codecRegistryProvider.getCodecRegistry());
+		return codec.decode(json, args);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoExpression.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.mongodb;
 
-import java.util.function.Function;
-
 /**
  * Wrapper object for MongoDB expressions like {@code $toUpper : $name} that manifest as {@link org.bson.Document} when
  * passed on to the driver.
@@ -36,7 +34,7 @@ import java.util.function.Function;
  * @see org.springframework.data.mongodb.core.aggregation.DateOperators
  * @see org.springframework.data.mongodb.core.aggregation.ObjectOperators
  * @see org.springframework.data.mongodb.core.aggregation.SetOperators
- * @see org.springframework.data.mongodb.core.aggregation.StringOperators @
+ * @see org.springframework.data.mongodb.core.aggregation.StringOperators
  */
 @FunctionalInterface
 public interface MongoExpression {
@@ -49,38 +47,27 @@ public interface MongoExpression {
 	org.bson.Document toDocument();
 
 	/**
-	 * Convert this instance to another expression applying the given conversion {@link Function}.
+	 * Create a new {@link MongoExpression} from plain {@link String} (eg. {@code $toUpper : $name}). <br />
+	 * The given expression will be wrapped with <code>{ ... }</code> to match an actual MongoDB {@link org.bson.Document}
+	 * if necessary.
 	 *
-	 * @param function must not be {@literal null}.
-	 * @param <T>
-	 * @return never {@literal null}.
+	 * @param expression must not be {@literal null}.
+	 * @return new instance of {@link MongoExpression}.
 	 */
-	default <T extends MongoExpression> T as(Function<MongoExpression, T> function) {
-		return function.apply(this);
+	static MongoExpression create(String expression) {
+		return new BindableMongoExpression(expression, null);
 	}
 
 	/**
-	 * Create a new {@link MongoExpression} from plain String (eg. {@code $toUpper : $name}). <br />
-	 * The given source value will be wrapped with <code>{ }</code> to match an actual MongoDB {@link org.bson.Document}
+	 * Create a new {@link MongoExpression} from plain {@link String} containing placeholders (eg. {@code $toUpper : ?0})
+	 * that will be resolved on first call of {@link #toDocument()}. <br />
+	 * The given expression will be wrapped with <code>{ ... }</code> to match an actual MongoDB {@link org.bson.Document}
 	 * if necessary.
 	 *
-	 * @param json must not be {@literal null}.
+	 * @param expression must not be {@literal null}.
 	 * @return new instance of {@link MongoExpression}.
 	 */
-	static MongoExpression expressionFromString(String json) {
-		return new BindableMongoExpression(json, null);
-	}
-
-	/**
-	 * Create a new {@link MongoExpression} from plain String containing placeholders (eg. {@code $toUpper : ?0}) that
-	 * will be resolved on {@link #toDocument()}. <br />
-	 * The given source value will be wrapped with <code>{ }</code> to match an actual MongoDB {@link org.bson.Document}
-	 * if necessary.
-	 *
-	 * @param json must not be {@literal null}.
-	 * @return new instance of {@link MongoExpression}.
-	 */
-	static MongoExpression expressionFromString(String json, Object... args) {
-		return new BindableMongoExpression(json, args);
+	static MongoExpression create(String expression, Object... args) {
+		return new BindableMongoExpression(expression, args);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/MongoExpression.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb;
+
+import java.util.function.Function;
+
+/**
+ * Wrapper object for MongoDB expressions like {@code $toUpper : $name} that manifest as {@link org.bson.Document} when
+ * passed on to the driver.
+ * <p />
+ * A set of predefined {@link MongoExpression expressions}, including a
+ * {@link org.springframework.data.mongodb.core.aggregation.AggregationSpELExpression SpEL based variant} for method
+ * like expressions (eg. {@code toUpper(name)}) are available via the
+ * {@link org.springframework.data.mongodb.core.aggregation Aggregation API}.
+ *
+ * @author Christoph Strobl
+ * @since 3.2
+ * @see org.springframework.data.mongodb.core.aggregation.ArithmeticOperators
+ * @see org.springframework.data.mongodb.core.aggregation.ArrayOperators
+ * @see org.springframework.data.mongodb.core.aggregation.ComparisonOperators
+ * @see org.springframework.data.mongodb.core.aggregation.ConditionalOperators
+ * @see org.springframework.data.mongodb.core.aggregation.ConvertOperators
+ * @see org.springframework.data.mongodb.core.aggregation.DateOperators
+ * @see org.springframework.data.mongodb.core.aggregation.ObjectOperators
+ * @see org.springframework.data.mongodb.core.aggregation.SetOperators
+ * @see org.springframework.data.mongodb.core.aggregation.StringOperators @
+ */
+@FunctionalInterface
+public interface MongoExpression {
+
+	/**
+	 * Obtain the native {@link org.bson.Document} representation.
+	 *
+	 * @return never {@literal null}.
+	 */
+	org.bson.Document toDocument();
+
+	/**
+	 * Convert this instance to another expression applying the given conversion {@link Function}.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param <T>
+	 * @return never {@literal null}.
+	 */
+	default <T extends MongoExpression> T as(Function<MongoExpression, T> function) {
+		return function.apply(this);
+	}
+
+	/**
+	 * Create a new {@link MongoExpression} from plain String (eg. {@code $toUpper : $name}). <br />
+	 * The given source value will be wrapped with <code>{ }</code> to match an actual MongoDB {@link org.bson.Document}
+	 * if necessary.
+	 *
+	 * @param json must not be {@literal null}.
+	 * @return new instance of {@link MongoExpression}.
+	 */
+	static MongoExpression expressionFromString(String json) {
+		return new BindableMongoExpression(json, null);
+	}
+
+	/**
+	 * Create a new {@link MongoExpression} from plain String containing placeholders (eg. {@code $toUpper : ?0}) that
+	 * will be resolved on {@link #toDocument()}. <br />
+	 * The given source value will be wrapped with <code>{ }</code> to match an actual MongoDB {@link org.bson.Document}
+	 * if necessary.
+	 *
+	 * @param json must not be {@literal null}.
+	 * @return new instance of {@link MongoExpression}.
+	 */
+	static MongoExpression expressionFromString(String json, Object... args) {
+		return new BindableMongoExpression(json, args);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
@@ -300,8 +300,7 @@ class QueryOperations {
 					AggregationOperationContext ctx = entity == null ? Aggregation.DEFAULT_CONTEXT
 							: new RelaxedTypeBasedAggregationOperationContext(entity.getType(), mappingContext, queryMapper);
 
-					fields.put(entry.getKey(),
-							((MongoExpression) entry.getValue()).as(AggregationExpression::create).toDocument(ctx));
+					fields.put(entry.getKey(), AggregationExpression.from((MongoExpression) entry.getValue()).toDocument(ctx));
 				} else {
 					fields.put(entry.getKey(), entry.getValue());
 				}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpression.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.aggregation;
 
 import org.bson.Document;
+import org.springframework.data.mongodb.MongoExpression;
 
 /**
  * An {@link AggregationExpression} can be used with field expressions in aggregation pipeline stages like
@@ -25,7 +26,36 @@ import org.bson.Document;
  * @author Oliver Gierke
  * @author Christoph Strobl
  */
-public interface AggregationExpression {
+public interface AggregationExpression extends MongoExpression {
+
+	/**
+	 * Obtain the as is (unmapped) representation of the {@link AggregationExpression}. Use
+	 * {@link #toDocument(AggregationOperationContext)} with a matching {@link AggregationOperationContext context} to
+	 * engage domain type mapping including field name resolution.
+	 *
+	 * @see org.springframework.data.mongodb.MongoExpression#toDocument()
+	 */
+	@Override
+	default Document toDocument() {
+		return toDocument(Aggregation.DEFAULT_CONTEXT);
+	}
+
+	/**
+	 * Create an {@link AggregationExpression} out of a given {@link MongoExpression}. <br />
+	 * If the given expression is already an {@link AggregationExpression} return the very same instance.
+	 *
+	 * @param expression must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 3.2
+	 */
+	static AggregationExpression create(MongoExpression expression) {
+
+		if (expression instanceof AggregationExpression) {
+			return AggregationExpression.class.cast(expression);
+		}
+
+		return (context) -> context.getMappedObject(expression.toDocument());
+	}
 
 	/**
 	 * Turns the {@link AggregationExpression} into a {@link Document} within the given

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpression.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpression.java
@@ -41,14 +41,15 @@ public interface AggregationExpression extends MongoExpression {
 	}
 
 	/**
-	 * Create an {@link AggregationExpression} out of a given {@link MongoExpression}. <br />
-	 * If the given expression is already an {@link AggregationExpression} return the very same instance.
+	 * Create an {@link AggregationExpression} out of a given {@link MongoExpression} to ensure the resulting
+	 * {@link MongoExpression#toDocument() Document} is mapped against the {@link AggregationOperationContext}. <br />
+	 * If the given expression is already an {@link AggregationExpression} the very same instance is returned.
 	 *
 	 * @param expression must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 3.2
 	 */
-	static AggregationExpression create(MongoExpression expression) {
+	static AggregationExpression from(MongoExpression expression) {
 
 		if (expression instanceof AggregationExpression) {
 			return AggregationExpression.class.cast(expression);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -24,7 +24,6 @@ import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
-
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.domain.Example;
@@ -37,6 +36,7 @@ import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.mapping.context.InvalidPersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.MongoExpression;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter.NestedDocument;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -294,6 +294,10 @@ public class QueryMapper {
 
 		String key = field.getMappedKey();
 		Object value;
+
+		if (rawValue instanceof MongoExpression) {
+			return createMapEntry(key, getMappedObject(((MongoExpression) rawValue).toDocument(), field.getEntity()));
+		}
 
 		if (isNestedKeyword(rawValue) && !field.isIdField()) {
 			Keyword keyword = new Keyword((Document) rawValue);
@@ -934,6 +938,11 @@ public class QueryMapper {
 			return null;
 		}
 
+		@Nullable
+		MongoPersistentEntity<?> getEntity() {
+			return null;
+		}
+
 		/**
 		 * Returns whether the field represents an association.
 		 *
@@ -1084,6 +1093,12 @@ public class QueryMapper {
 		public MongoPersistentEntity<?> getPropertyEntity() {
 			MongoPersistentProperty property = getProperty();
 			return property == null ? null : mappingContext.getPersistentEntity(property);
+		}
+
+		@Nullable
+		@Override
+		public MongoPersistentEntity<?> getEntity() {
+			return entity;
 		}
 
 		/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateFieldProjectionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateFieldProjectionTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.MongoExpression;
+import org.springframework.data.mongodb.core.aggregation.AggregationSpELExpression;
+import org.springframework.data.mongodb.core.aggregation.StringOperators;
+import org.springframework.data.mongodb.core.mapping.Embedded;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.test.util.MongoTemplateExtension;
+import org.springframework.data.mongodb.test.util.MongoTestTemplate;
+import org.springframework.data.mongodb.test.util.Template;
+
+/**
+ * @author Christoph Strobl
+ */
+@ExtendWith(MongoTemplateExtension.class)
+class MongoTemplateFieldProjectionTests {
+
+	private static @Template MongoTestTemplate template;
+
+	private Person luke;
+
+	@BeforeEach
+	void beforeEach() {
+
+		luke = new Person();
+		luke.id = "luke";
+		luke.firstname = "luke";
+		luke.lastname = "skywalker";
+
+		template.save(luke);
+	}
+
+	@AfterEach
+	void afterEach() {
+		template.flush(Person.class, Wrapper.class);
+	}
+
+	@Test // GH-3583
+	void usesMongoExpressionAsIs() {
+
+		Person result = findLuke(fields -> {
+			fields.include("firstname").project(MongoExpression.expressionFromString("'$toUpper' : '$last_name'"))
+					.as("last_name");
+		});
+
+		assertThat(result).isEqualTo(luke.upperCaseLastnameClone());
+	}
+
+	@Test // GH-3583
+	void usesMongoExpressionWithPlaceholdersAsIs() {
+
+		Person result = findLuke(fields -> {
+			fields.include("firstname").project(MongoExpression.expressionFromString("'$toUpper' : '$?0'", "last_name"))
+					.as("last_name");
+		});
+
+		assertThat(result).isEqualTo(luke.upperCaseLastnameClone());
+	}
+
+	@Test // GH-3583
+	void mapsAggregationExpressionToDomainType() {
+
+		Person result = findLuke(fields -> {
+			fields.include("firstname").project(StringOperators.valueOf("lastname").toUpper()).as("last_name");
+		});
+
+		assertThat(result).isEqualTo(luke.upperCaseLastnameClone());
+	}
+
+	@Test // GH-3583
+	void mapsAggregationSpELExpressionToDomainType() {
+
+		Person result = findLuke(fields -> {
+			fields.include("firstname").project(AggregationSpELExpression.expressionOf("toUpper(lastname)")).as("last_name");
+		});
+
+		assertThat(result).isEqualTo(luke.upperCaseLastnameClone());
+	}
+
+	@Test // GH-3583
+	void mapsNestedPathAggregationExpressionToDomainType() {
+
+		Wrapper wrapper = new Wrapper();
+		wrapper.id = "wrapper";
+		wrapper.person = luke;
+
+		template.save(wrapper);
+
+		Query query = Query.query(Criteria.where("id").is(wrapper.id));
+		query.fields().include("person.firstname", "person.id")
+				.project(StringOperators.valueOf("person.lastname").toUpper()).as("person.last_name");
+
+		Wrapper result = template.findOne(query, Wrapper.class);
+		assertThat(result.person).isEqualTo(luke.upperCaseLastnameClone());
+	}
+
+	@Test // GH-3583
+	void mapsProjectionOnEmbedded() {
+
+		luke.address = new Address();
+		luke.address.planet = "tatoine";
+
+		template.save(luke);
+
+		Person result = findLuke(fields -> {
+			fields.project(StringOperators.valueOf("address.planet").toUpper()).as("planet");
+		});
+
+		assertThat(result.address.planet).isEqualTo("TATOINE");
+	}
+
+	private Person findLuke(Consumer<org.springframework.data.mongodb.core.query.Field> projection) {
+
+		Query query = Query.query(Criteria.where("id").is(luke.id));
+		projection.accept(query.fields());
+		return template.findOne(query, Person.class);
+	}
+
+	@EqualsAndHashCode
+	@ToString
+	static class Wrapper {
+		@Id String id;
+		Person person;
+	}
+
+	@EqualsAndHashCode
+	@ToString
+	static class Person {
+
+		@Id String id;
+		String firstname;
+
+		@Field("last_name") //
+		String lastname;
+
+		@Embedded.Nullable Address address;
+
+		Person toUpperCaseLastnameClone(Person source) {
+
+			Person target = new Person();
+			target.id = source.id;
+			target.firstname = source.firstname;
+			target.lastname = source.lastname.toUpperCase();
+			target.address = source.address;
+
+			return target;
+		}
+
+		Person upperCaseLastnameClone() {
+			return toUpperCaseLastnameClone(this);
+		}
+	}
+
+	@EqualsAndHashCode
+	@ToString
+	static class Address {
+		String planet;
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateFieldProjectionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateFieldProjectionTests.java
@@ -68,7 +68,7 @@ class MongoTemplateFieldProjectionTests {
 	void usesMongoExpressionAsIs() {
 
 		Person result = findLuke(fields -> {
-			fields.include("firstname").project(MongoExpression.expressionFromString("'$toUpper' : '$last_name'"))
+			fields.include("firstname").project(MongoExpression.create("'$toUpper' : '$last_name'"))
 					.as("last_name");
 		});
 
@@ -79,7 +79,7 @@ class MongoTemplateFieldProjectionTests {
 	void usesMongoExpressionWithPlaceholdersAsIs() {
 
 		Person result = findLuke(fields -> {
-			fields.include("firstname").project(MongoExpression.expressionFromString("'$toUpper' : '$?0'", "last_name"))
+			fields.include("firstname").project(MongoExpression.create("'$toUpper' : '$?0'", "last_name"))
 					.as("last_name");
 		});
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -1413,4 +1413,11 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 	void caseSensitiveInClauseIgnoresExpressions() {
 		assertThat(repository.findByFirstnameIn(".*")).isEmpty();
 	}
+
+	@Test // GH-23583
+	void annotatedQueryShouldAllowAggregationInProjection() {
+
+		Person target = repository.findWithAggregationInProjection(alicia.getId());
+		assertThat(target.getFirstname()).isEqualTo(alicia.getFirstname().toUpperCase());
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -366,6 +366,9 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	@Query(value = "{ 'id' : ?0 }", fields = "{ 'fans': { '$slice': [ ?1, ?2 ] } }")
 	Person findWithSliceInProjection(String id, int skip, int limit);
 
+	@Query(value = "{ 'id' : ?0 }", fields = "{ 'firstname': { '$toUpper': '$firstname' } }")
+	Person findWithAggregationInProjection(String id);
+
 	@Query(value = "{ 'shippingAddresses' : { '$elemMatch' : { 'city' : { '$eq' : 'lnz' } } } }",
 			fields = "{ 'shippingAddresses.$': ?0 }")
 	Person findWithArrayPositionInProjection(int position);

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1247,6 +1247,69 @@ The `Query` class has some additional methods that provide options for the query
 * `Query` *skip* `(int skip)` used to skip the provided number of documents in the results (used for paging)
 * `Query` *with* `(Sort sort)` used to provide sort definition for the results
 
+[[mongo-template.querying.field-selection]]
+==== Selecting fields
+
+MongoDB supports https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/[projecting fields] returned by a query.
+A projection can in- & exclude fields (the `_id` field is always included unless explicitly excluded) based on their name.
+
+.Selecting result fields
+====
+[source,java]
+----
+public class Person {
+
+    @Id String id;
+    String firstname;
+
+    @Field("last_name")
+    String lastname;
+
+    Address address;
+}
+
+query.fields().include("lastname"); <1>
+
+query.fields().exclude("id").include("lastname") <2>
+
+query.fields().include("address") <3>
+
+query.fields().include("address.city") <4>
+
+
+----
+<1> Result will contain both `_id` and `last_name` via `{ "last_name" : 1 }`.
+<2> Result will only contain the `last_name` via `{ "_id" : 0, "last_name" : 1 }`.
+<3> Result will contain the `_id` and entire `address` object via `{ "address" : 1 }`.
+<4> Result will contain the `_id` and and `address` object that only contains the `city` field via `{ "address.city" : 1 }`.
+====
+
+Starting with MongoDB 4.4 it is possible to use the aggregation expressions syntax for field projections as shown below.
+
+.Computing result fields with expressions
+====
+[source,java]
+----
+query.fields()
+  .project(MongoExpression.expressionFromString("'$toUpper' : '$last_name'")) <1>
+  .as("last_name"); <2>
+
+query.fields()
+  .project(StringOperators.valueOf("lastname").toUpper()) <3>
+  .as("last_name");
+
+query.fields()
+  .project(AggregationSpELExpression.expressionOf("toUpper(lastname)")) <4>
+  .as("last_name");
+----
+<1> Use a native expression. The used field names must refer to the ones of the document within the database.
+<2> Assign the field name that shall hold the expression result in the target document. The resulting field name will never be mapped against the domain model.
+<3> Use an `AggregationExpression`. Other than native `MongoExpression`, field names are mapped to the ones used in the domain model.
+<4> Use SpEL along with an `AggregationExpression` to invoke expression functions. Field names are mapped to the ones used in the domain model.
+====
+
+`@Query(fields='...')` allows usage of expression field projections at `Repository` level as described in <<mongodb.repositories.queries.json-based>>.
+
 [[mongo-template.querying]]
 === Methods for Querying for Documents
 

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -1291,7 +1291,7 @@ Starting with MongoDB 4.4 it is possible to use the aggregation expressions synt
 [source,java]
 ----
 query.fields()
-  .project(MongoExpression.expressionFromString("'$toUpper' : '$last_name'")) <1>
+  .project(MongoExpression.create("'$toUpper' : '$last_name'")) <1>
   .as("last_name"); <2>
 
 query.fields()


### PR DESCRIPTION
Starting with MongoDB 4.4 it is possible to use the aggregation expressions syntax for field projections as shown below.

```java
query.fields()
  // Use a native expression. The used field names must refer to the ones of the document within the database.
  .project(MongoExpression.expressionFromString("'$toUpper' : '$last_name'"))
  // Assign the field name that shall hold the expression result in the target document.
  .as("last_name"); 

query.fields()
  // AggregationExpression makes sure field names are mapped to the ones used in the domain model.
  .project(StringOperators.valueOf("lastname").toUpper()) 
  .as("last_name");

query.fields()
  // Use SpEL along with an AggregationExpression to invoke expression functions.
  .project(AggregationSpELExpression.expressionOf("toUpper(lastname)"))
  .as("last_name");
```
`@Query(fields='...')` allows usage of expression field projections at `Repository` level.

Closes: #3583 