### PR TITLE
Fix ShardKey lookup for nested paths.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-3590-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3590-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3590-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-3590-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
@@ -689,7 +689,8 @@ class QueryOperations {
 					: mappedDocument != null ? mappedDocument.getDocument() : getMappedUpdate(domainType);
 
 			Document filterWithShardKey = new Document(filter);
-			getMappedShardKeyFields(domainType).forEach(key -> filterWithShardKey.putIfAbsent(key, shardKeySource.get(key)));
+			getMappedShardKeyFields(domainType)
+					.forEach(key -> filterWithShardKey.putIfAbsent(key, BsonUtils.resolveValue(shardKeySource, key)));
 
 			return filterWithShardKey;
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -386,6 +386,41 @@ public class BsonUtils {
 	}
 
 	/**
+	 * Resolve a the value for a given key. If the given {@link Bson} value contains the key the value is immediately
+	 * returned. If not and the key contains a path using the dot ({@code .}) notation it will try to resolve the path by
+	 * inspecting the individual parts. If one of the intermediate ones is {@literal null} or cannot be inspected further
+	 * (wrong) type, {@literal null} is returned.
+	 * 
+	 * @param bson the source to inspect. Must not be {@literal null}.
+	 * @param key the key to lookup. Must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 */
+	@Nullable
+	public static Object resolveValue(Bson bson, String key) {
+
+		Map<String, Object> source = asMap(bson);
+
+		if (source.containsKey(key) || !key.contains(".")) {
+			return source.get(key);
+		}
+
+		String[] parts = key.split("\\.");
+
+		for (int i = 1; i < parts.length; i++) {
+
+			Object result = source.get(parts[i - 1]);
+
+			if (result == null || !(result instanceof Bson)) {
+				return null;
+			}
+
+			source = asMap((Bson) result);
+		}
+
+		return source.get(parts[parts.length - 1]);
+	}
+
+	/**
 	 * Returns given object as {@link Collection}. Will return the {@link Collection} as is if the source is a
 	 * {@link Collection} already, will convert an array into a {@link Collection} or simply create a single element
 	 * collection for everything else.

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -78,6 +78,7 @@ import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexCreator;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.Sharded;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertCallback;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveCallback;
@@ -1954,6 +1955,24 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		verify(findIterable, never()).first();
 	}
 
+	@Test // GH-3590
+	void shouldIncludeValueFromNestedShardKeyPath() {
+
+		WithShardKeyPoitingToNested source = new WithShardKeyPoitingToNested();
+		source.id = "id-1";
+		source.value = "v1";
+		source.nested = new WithNamedFields();
+		source.nested.customName = "cname";
+		source.nested.name = "name";
+
+		template.save(source);
+
+		ArgumentCaptor<Bson> filter = ArgumentCaptor.forClass(Bson.class);
+		verify(collection).replaceOne(filter.capture(), any(), any());
+
+		assertThat(filter.getValue()).isEqualTo(new Document("_id", "id-1").append("value", "v1").append("nested.custom-named-field", "cname"));
+	}
+
 	@Test // DATAMONGO-2341
 	void saveShouldProjectOnShardKeyWhenLoadingExistingDocument() {
 
@@ -2311,6 +2330,13 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	static class Sith {
 
 		@Field("firstname") String name;
+	}
+
+	@Sharded(shardKey = {"value", "nested.customName"})
+	static class WithShardKeyPoitingToNested {
+		String id;
+		String value;
+		WithNamedFields nested;
 	}
 
 	static class TypeImplementingIterator implements Iterator {


### PR DESCRIPTION
This PR fixes the lookup of shard key values for nested paths using the dot (`.`) notation.

Closes: #3590
