### PR TITLE
Return saved entity reference instead of original reference.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -50,6 +50,7 @@ import com.mongodb.client.result.DeleteResult;
  * @author Christoph Strobl
  * @author Ruben J Garcia
  * @author Jens Schauder
+ * @author Clément Petit
  * @since 2.0
  */
 public class SimpleReactiveMongoRepository<T, ID extends Serializable> implements ReactiveMongoRepository<T, ID> {
@@ -113,8 +114,8 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Assert.notNull(entityStream, "The given Publisher of entities must not be null!");
 
 		return Flux.from(entityStream).flatMap(entity -> entityInformation.isNew(entity) ? //
-				mongoOperations.insert(entity, entityInformation.getCollectionName()).then(Mono.just(entity)) : //
-				mongoOperations.save(entity, entityInformation.getCollectionName()).then(Mono.just(entity)));
+				mongoOperations.insert(entity, entityInformation.getCollectionName()) : //
+				mongoOperations.save(entity, entityInformation.getCollectionName()));
 	}
 
 	/*


### PR DESCRIPTION
Make `SimpleReactiveMongoRepository#saveAll(Publisher<S>)` return the saved entity references instead of the original references.

Closes #3609

This is my first pull request, so I am sorry if am missing anything. Please tell me if something is missing and I will add it gladly.

I added a `ReactiveImmutablePersonRepository` and `ImmutablePerson` classes in `SimpleReactiveMongoRepositoryTests` but it would probably be better to create a dedicated test class that validates that immutable uses cases (including this one) are working.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
