### PR TITLE
Handle nested Pattern in Criteria equals

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -997,8 +998,20 @@ public class Criteria implements CriteriaDefinition {
 			}
 			Document leftDocument = (Document) left;
 			Document rightDocument = (Document) right;
+			Iterator leftIterator = leftDocument.entrySet().iterator();
+			Iterator rightIterator = rightDocument.entrySet().iterator();
 
-			return isEqual(leftDocument.values(), rightDocument.values());
+			while (leftIterator.hasNext() && rightIterator.hasNext()) {
+				Map.Entry leftEntry = (Map.Entry)leftIterator.next();
+				Map.Entry rightEntry = (Map.Entry)rightIterator.next();
+				if (!isEqual(leftEntry.getKey(), rightEntry.getKey())) {
+					return false;
+				}
+				if (!isEqual(leftEntry.getValue(), rightEntry.getValue())) {
+					return false;
+				}
+			}
+			return !leftIterator.hasNext() && !rightIterator.hasNext();
 		}
 
 		if (Collection.class.isAssignableFrom(left.getClass())) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/CriteriaUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
  * @author Christoph Strobl
  * @author Andreas Zink
  * @author Ziemowit Stolarczyk
+ * @author Clément Petit
  */
 public class CriteriaUnitTests {
 
@@ -353,9 +354,33 @@ public class CriteriaUnitTests {
 	@Test // DATAMONGO-2002
 	public void shouldEqualForSamePattern() {
 
+		Criteria left = new Criteria("field").regex("foo");
+		Criteria right = new Criteria("field").regex("foo");
+
+		assertThat(left).isEqualTo(right);
+	}
+
+	@Test // DATAMONGO-2002
+	public void shouldEqualForSamePatternAndFlags() {
+
 		Criteria left = new Criteria("field").regex("foo", "iu");
 		Criteria right = new Criteria("field").regex("foo");
 
 		assertThat(left).isNotEqualTo(right);
+	}
+
+	@Test // GH-3414
+	public void shouldEqualForNestedPattern() {
+
+		Criteria left = new Criteria("a").orOperator(
+			new Criteria("foo").regex("value", "i"),
+			new Criteria("bar").regex("value")
+		);
+		Criteria right = new Criteria("a").orOperator(
+			new Criteria("foo").regex("value", "i"),
+			new Criteria("bar").regex("value")
+		);
+
+		assertThat(left).isEqualTo(right);
 	}
 }


### PR DESCRIPTION
The equals method of `Pattern` returns false if two `Patterns` are equal but are different instances. This is already handled in the `equals` method of `Criteria` and works well. However, sometimes a `Pattern` can be nested in a `BasicDBList` or in a `Document` or both, like in the case of a `$or` operator.

This PR fixes that: it enhances the `equals` method to manually compare  `BasicDBLists` and `Documents` using the custom `isEqual` method. I am not aware of any util that allow to compare 2 collections using a custom `isEqual` function so I had to implement it manually.

Closes #3414


