### PR TITLE
Fix bullet points in aggregations framework asciidoc

### DIFF
--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2444,9 +2444,8 @@ A `TypedAggregation`, just like an `Aggregation`, holds the instructions of the 
 At runtime, field references get checked against the given input type, considering potential `@Field` annotations.
 [NOTE]
 ====
-Changed in 3.2 referencing none-xistent properties does no longer raise errors. To restore the previous behaviour use the `strictMapping` option of `AggregationOptions`.
+Changed in 3.2 referencing non-existent properties does no longer raise errors. To restore the previous behaviour use the `strictMapping` option of `AggregationOptions`.
 ====
-+
 * `AggregationDefinition`
 +
 An `AggregationDefinition` represents a MongoDB aggregation pipeline operation and describes the processing that should be performed in this aggregation step. Although you could manually create an `AggregationDefinition`, we recommend using the static factory methods provided by the `Aggregate` class to construct an `AggregateOperation`.


### PR DESCRIPTION
There is a small issue in the reference documentation, in the aggregation framework support exactly: some bullet points are not well formatted (see screenshot below). Also there is a small typo (none-xistent instead non-existent).

This PR fixes those 2 smalls issues.

![spring-data-mongodb-asciidoc-bullet-list-issue](https://user-images.githubusercontent.com/5570149/115110068-bb781380-9f79-11eb-8d90-2596f6c8ed37.png)
