### PR TITLE
Fix $or / $nor keyword mapping in query mapper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3635-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3635-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -787,7 +787,6 @@ public class QueryMapper {
 	 */
 	static class Keyword {
 
-		private static final String N_OR_PATTERN = "\\$.*or";
 		private static final Set<String> NON_DBREF_CONVERTING_KEYWORDS = new HashSet<>(
 				Arrays.asList("$", "$size", "$slice", "$gt", "$lt"));
 
@@ -818,7 +817,7 @@ public class QueryMapper {
 		}
 
 		public boolean isOrOrNor() {
-			return key.matches(N_OR_PATTERN);
+			return key.equalsIgnoreCase("$or") || key.equalsIgnoreCase("$nor");
 		}
 
 		/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1257,6 +1257,14 @@ public class QueryMapperUnitTests {
 		assertThat(document).isEqualTo(new org.bson.Document("double_underscore.renamed", new org.bson.Document("$exists", true)));
 	}
 
+	@Test // GH-3635
+	void $floorKeywordDoesNotMatch$or$norPattern() {
+
+		Query query = new BasicQuery(" { $expr: { $gt: [ \"$spent\" , { $floor : \"$budget\" } ] } }");
+		assertThatNoException()
+				.isThrownBy(() -> mapper.getMappedObject(query.getQueryObject(), context.getPersistentEntity(Foo.class)));
+	}
+
 	class WithDeepArrayNesting {
 
 		List<WithNestedArray> level0;


### PR DESCRIPTION
This PR fixes an issue with the pattern used for detecting `$or` / `$nor` which also matched other keywords like `$floor`.

Closes: #3635