### PR TITLE
Fix NPE in QueryMapper when trying to apply target type on null value.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3633-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3633-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3633-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3633-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -751,12 +751,12 @@ public class QueryMapper {
 	 * converted one by one.
 	 *
 	 * @param documentField the field and its meta data
-	 * @param value the actual value
+	 * @param value the actual value. Can be {@literal null}.
 	 * @return the potentially converted target value.
 	 */
-	private Object applyFieldTargetTypeHintToValue(Field documentField, Object value) {
+	private Object applyFieldTargetTypeHintToValue(Field documentField, @Nullable Object value) {
 
-		if (documentField.getProperty() == null || !documentField.getProperty().hasExplicitWriteTarget()) {
+		if (value == null || documentField.getProperty() == null || !documentField.getProperty().hasExplicitWriteTarget()) {
 			return value;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.bson.BsonRegularExpression;
+import org.bson.BsonType;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.springframework.data.domain.Example;
@@ -185,6 +186,42 @@ public class Criteria implements CriteriaDefinition {
 		}
 
 		this.isValue = value;
+		return this;
+	}
+
+	/**
+	 * Creates a criterion using {@literal null} equality comparison which matches documents that either contain the item
+	 * field whose value is {@literal null} or that do not contain the item field.
+	 * <p />
+	 * Use {@link #isNullValue()} to only query for documents that contain the field whose value is equal to
+	 * {@link org.bson.BsonType#NULL}. <br />
+	 * Use {@link #exists(boolean)} to query for documents that do (not) contain the field.
+	 *
+	 * @return this.
+	 * @see <a href="https://docs.mongodb.com/manual/tutorial/query-for-null-fields/#equality-filter">Query for Null or
+	 *      Missing Fields: Equality Filter</a>
+	 * @since 3.3
+	 */
+	public Criteria isNull() {
+		return is(null);
+	}
+
+	/**
+	 * Creates a criterion using a {@link org.bson.BsonType} comparison which matches only documents that contain the item
+	 * field whose value is equal to {@link org.bson.BsonType#NULL}.
+	 * <p />
+	 * Use {@link #isNull()} to query for documents that contain the field with a {@literal null} value or do not contain the
+	 * field at all. <br />
+	 * Use {@link #exists(boolean)} to query for documents that do (not) contain the field.
+	 *
+	 * @return this.
+	 * @see <a href="https://docs.mongodb.com/manual/tutorial/query-for-null-fields/#type-check">Query for Null or Missing
+	 *      Fields: Type Check</a>
+	 * @since 3.3
+	 */
+	public Criteria isNullValue() {
+
+		criteria.put("$type", BsonType.NULL.getValue());
 		return this;
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1257,6 +1257,17 @@ public class QueryMapperUnitTests {
 		assertThat(document).isEqualTo(new org.bson.Document("double_underscore.renamed", new org.bson.Document("$exists", true)));
 	}
 
+	@Test // GH-3633
+	void mapsNullValueForFieldWithCustomTargetType() {
+
+		Query query = query(where("stringAsOid").is(null));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(NonIdFieldWithObjectIdTargetType.class));
+
+		assertThat(document).isEqualTo(new org.bson.Document("stringAsOid", null));
+	}
+
 	class WithDeepArrayNesting {
 
 		List<WithNestedArray> level0;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1260,12 +1260,23 @@ public class QueryMapperUnitTests {
 	@Test // GH-3633
 	void mapsNullValueForFieldWithCustomTargetType() {
 
-		Query query = query(where("stringAsOid").is(null));
+		Query query = query(where("stringAsOid").isNull());
 
 		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
 				context.getPersistentEntity(NonIdFieldWithObjectIdTargetType.class));
 
 		assertThat(document).isEqualTo(new org.bson.Document("stringAsOid", null));
+	}
+
+	@Test // GH-3633
+	void mapsNullBsonTypeForFieldWithCustomTargetType() {
+
+		Query query = query(where("stringAsOid").isNullValue());
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(NonIdFieldWithObjectIdTargetType.class));
+
+		assertThat(document).isEqualTo(new org.bson.Document("stringAsOid", new org.bson.Document("$type", 10)));
 	}
 
 	class WithDeepArrayNesting {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -60,7 +60,9 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.repository.Person.Sex;
 import org.springframework.data.mongodb.repository.SampleEvaluationContextExtension.SampleSecurityContextHolder;
 import org.springframework.data.mongodb.test.util.EnableIfMongoServerVersion;
@@ -1421,5 +1423,14 @@ public abstract class AbstractPersonRepositoryIntegrationTests {
 
 		Person target = repository.findWithAggregationInProjection(alicia.getId());
 		assertThat(target.getFirstname()).isEqualTo(alicia.getFirstname().toUpperCase());
+	}
+
+	@Test // GH-3633
+	void annotatedQueryWithNullEqualityCheckShouldWork() {
+
+		operations.updateFirst(Query.query(Criteria.where("id").is(dave.getId())), Update.update("age", null), Person.class);
+
+		Person byQueryWithNullEqualityCheck = repository.findByQueryWithNullEqualityCheck();
+		assertThat(byQueryWithNullEqualityCheck.getId()).isEqualTo(dave.getId());
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -410,4 +410,7 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	List<Person> findByUnwrappedUserUsername(String username);
 
 	List<Person> findByUnwrappedUser(User user);
+
+	@Query("{ 'age' : null }")
+	Person findByQueryWithNullEqualityCheck();
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -383,6 +383,13 @@ class ParameterBindingJsonReaderUnitTests {
 				.parse("{ 'stores.location' : { $geoWithin: { $centerSphere: [ [ 1.948516, 48.799029 ] , 0.004 ] } } }"));
 	}
 
+	@Test // GH-3633
+	void parsesNullValue() {
+
+		Document target = parse("{ 'parent' : null }");
+		assertThat(target).isEqualTo(new Document("parent", null));
+	}
+
 	private static Document parse(String json, Object... args) {
 
 		ParameterBindingJsonReader reader = new ParameterBindingJsonReader(json, args);


### PR DESCRIPTION
This PR fixes a NPE when a `Query` does a `null` value equality comparison on a field that has a custom target type defined.

```java
@Field(targetType = FieldType.OBJECT_ID) 
String parentId;

// ...

Query q = query(where("parentId").is(null));
template.find(q, ...
```

Further more we introduced additional methods (`isNull()`, `isNullValue()`) on `Criteria` that simplify query creation for `null` or missing fields.

Closes: #3633 