### PR TITLE
Fix query mapper path resolution for types considered simple ones.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3659-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3659-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3659-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3659-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -19,11 +19,14 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Reference;
@@ -68,6 +71,8 @@ import com.mongodb.DBRef;
  * @author Mark Paluch
  */
 public class QueryMapper {
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(QueryMapper.class);
 
 	private static final List<String> DEFAULT_ID_NAMES = Arrays.asList("id", "_id");
 	private static final Document META_TEXT_SCORE = new Document("$meta", "textScore");
@@ -673,7 +678,8 @@ public class QueryMapper {
 			return (DBRef) source;
 		}
 
-		if(property != null && (property.isDocumentReference() || (!property.isDbReference() && property.findAnnotation(Reference.class) != null))) {
+		if (property != null && (property.isDocumentReference()
+				|| (!property.isDbReference() && property.findAnnotation(Reference.class) != null))) {
 			return converter.toDocumentPointer(source, property).getPointer();
 		}
 
@@ -1174,8 +1180,8 @@ public class QueryMapper {
 					removePlaceholders(DOT_POSITIONAL_PATTERN, pathExpression));
 
 			if (sourceProperty != null && sourceProperty.getOwner().equals(entity)) {
-				return mappingContext
-						.getPersistentPropertyPath(PropertyPath.from(Pattern.quote(sourceProperty.getName()), entity.getTypeInformation()));
+				return mappingContext.getPersistentPropertyPath(
+						PropertyPath.from(Pattern.quote(sourceProperty.getName()), entity.getTypeInformation()));
 			}
 
 			PropertyPath path = forName(rawPath);
@@ -1183,29 +1189,46 @@ public class QueryMapper {
 				return null;
 			}
 
-			try {
+			PersistentPropertyPath<MongoPersistentProperty> propertyPath = tryToResolvePersistentPropertyPath(path);
 
-				PersistentPropertyPath<MongoPersistentProperty> propertyPath = mappingContext.getPersistentPropertyPath(path);
+			if (propertyPath == null) {
 
-				Iterator<MongoPersistentProperty> iterator = propertyPath.iterator();
-				boolean associationDetected = false;
+				if (QueryMapper.LOGGER.isInfoEnabled()) {
 
-				while (iterator.hasNext()) {
+					String types = StringUtils.collectionToDelimitedString(
+							path.stream().map(it -> it.getType().getSimpleName()).collect(Collectors.toList()), " -> ");
+					QueryMapper.LOGGER.info(
+							"Could not map '{}'. Maybe a fragment in '{}' is considered a simple type. Mapper continues with {}.",
+							path, types, pathExpression);
+				}
+				return null;
+			}
 
-					MongoPersistentProperty property = iterator.next();
+			Iterator<MongoPersistentProperty> iterator = propertyPath.iterator();
+			boolean associationDetected = false;
 
-					if (property.isAssociation()) {
-						associationDetected = true;
-						continue;
-					}
+			while (iterator.hasNext()) {
 
-					if (associationDetected && !property.isIdProperty()) {
-						throw new MappingException(String.format(INVALID_ASSOCIATION_REFERENCE, pathExpression));
-					}
+				MongoPersistentProperty property = iterator.next();
+
+				if (property.isAssociation()) {
+					associationDetected = true;
+					continue;
 				}
 
-				return propertyPath;
-			} catch (InvalidPersistentPropertyPath e) {
+				if (associationDetected && !property.isIdProperty()) {
+					throw new MappingException(String.format(INVALID_ASSOCIATION_REFERENCE, pathExpression));
+				}
+			}
+
+			return propertyPath;
+		}
+
+		private PersistentPropertyPath<MongoPersistentProperty> tryToResolvePersistentPropertyPath(PropertyPath path) {
+
+			try {
+				return mappingContext.getPersistentPropertyPath(path);
+			} catch (MappingException e) {
 				return null;
 			}
 		}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import lombok.Data;
 import org.bson.conversions.Bson;
 import org.bson.types.Code;
 import org.bson.types.ObjectId;
@@ -49,12 +48,10 @@ import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.geo.GeoJsonPolygon;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
-import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.mapping.TextScore;
 import org.springframework.data.mongodb.core.mapping.Unwrapped;
 import org.springframework.data.mongodb.core.query.BasicQuery;
@@ -75,7 +72,6 @@ import com.mongodb.client.model.Filters;
  * @author Christoph Strobl
  * @author Mark Paluch
  */
-@ExtendWith(MockitoExtension.class)
 public class QueryMapperUnitTests {
 
 	private QueryMapper mapper;
@@ -1417,18 +1413,18 @@ public class QueryMapperUnitTests {
 		@Field("geoJsonPointWithNameViaFieldAnnotation") GeoJsonPoint namedGeoJsonPoint;
 	}
 
-	static class SimpeEntityWithoutId {
+	static class SimpleEntityWithoutId {
 
 		String stringProperty;
 		Integer integerProperty;
 	}
 
 	static class EntityWithComplexValueTypeMap {
-		Map<Integer, SimpeEntityWithoutId> map;
+		Map<Integer, SimpleEntityWithoutId> map;
 	}
 
 	static class EntityWithComplexValueTypeList {
-		List<SimpeEntityWithoutId> list;
+		List<SimpleEntityWithoutId> list;
 	}
 
 	static class WithExplicitTargetTypes {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoTestTemplateConfiguration.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/MongoTestTemplateConfiguration.java
@@ -119,6 +119,9 @@ public class MongoTestTemplateConfiguration {
 			mappingContext = new MongoMappingContext();
 			mappingContext.setInitialEntitySet(mappingContextConfigurer.initialEntitySet());
 			mappingContext.setAutoIndexCreation(mappingContextConfigurer.autocreateIndex);
+			if(mongoConverterConfigurer.customConversions != null) {
+				mappingContext.setSimpleTypeHolder(mongoConverterConfigurer.customConversions.getSimpleTypeHolder());
+			}
 			mappingContext.afterPropertiesSet();
 		}
 


### PR DESCRIPTION
spring-projects/spring-data-commons#2293 changed how `PersistentPropertyPath` is resolved and considers potentially registered `Converter` for those, which made the path resolution fail in during the query mapping process.
This PR makes sure to capture the `Exception` and continue with the given user input.

Fixes: #3659