### PR TITLE
Add support for Wildcard Index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3225-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3225-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3225-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3225-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/IndexConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/IndexConverters.java
@@ -115,6 +115,10 @@ abstract class IndexConverters {
 				ops = ops.collation(fromDocument(indexOptions.get("collation", Document.class)));
 			}
 
+			if(indexOptions.containsKey("wildcardProjection")) {
+				ops.wildcardProjection(indexOptions.get("wildcardProjection", Document.class));
+			}
+
 			return ops;
 		};
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexField.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexField.java
@@ -29,7 +29,7 @@ import org.springframework.util.ObjectUtils;
 public final class IndexField {
 
 	enum Type {
-		GEO, TEXT, DEFAULT, HASH;
+		GEO, TEXT, DEFAULT, HASH, WILDCARD;
 	}
 
 	private final String key;
@@ -48,7 +48,7 @@ public final class IndexField {
 		if (Type.GEO.equals(type) || Type.TEXT.equals(type)) {
 			Assert.isNull(direction, "Geo/Text indexes must not have a direction!");
 		} else {
-			if (!Type.HASH.equals(type)) {
+			if (!(Type.HASH.equals(type) || Type.WILDCARD.equals(type))) {
 				Assert.notNull(direction, "Default indexes require a direction");
 			}
 		}
@@ -75,6 +75,17 @@ public final class IndexField {
 	 */
 	static IndexField hashed(String key) {
 		return new IndexField(key, null, Type.HASH);
+	}
+
+	/**
+	 * Creates a {@literal wildcard} {@link IndexField} for the given key.
+	 *
+	 * @param key must not be {@literal null} or empty.
+	 * @return new instance of {@link IndexField}.
+	 * @since 3.3
+	 */
+	static IndexField wildcard(String key) {
+		return new IndexField(key, null, Type.WILDCARD);
 	}
 
 	/**
@@ -140,6 +151,16 @@ public final class IndexField {
 	 */
 	public boolean isHashed() {
 		return Type.HASH.equals(type);
+	}
+
+	/**
+	 * Returns whether the {@link IndexField} is contains a {@literal wildcard} expression.
+	 *
+	 * @return {@literal true} if {@link IndexField} contains a wildcard {@literal $**}.
+	 * @since 3.3
+	 */
+	public boolean isWildcard() {
+		return Type.WILDCARD.equals(type);
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndex.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndex.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.bson.Document;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link WildcardIndex} is a specific {@link Index} that can be used to include all fields into an index based on the
+ * {@code $**" : 1} pattern on a root object (the one typically carrying the
+ * {@link org.springframework.data.mongodb.core.mapping.Document} annotation). On those it is possible to use
+ * {@link #wildcardProjectionInclude(String...)} and {@link #wildcardProjectionExclude(String...)} to define specific
+ * paths for in-/exclusion.
+ * <p />
+ * It can also be used to define an index on a specific field path and its subfields, e.g.
+ * {@code "path.to.field.$**" : 1}. <br />
+ * Note that {@literal wildcardProjections} are not allowed in this case.
+ * <p />
+ * <strong>LIMITATIONS</strong><br />
+ * <ul>
+ * <li>{@link #unique() Unique} and {@link #expire(long) ttl} options are not supported.</li>
+ * <li>Keys used for sharding must not be included</li>
+ * <li>Cannot be used to generate any type of geo index.</li>
+ * </ul>
+ *
+ * @author Christoph Strobl
+ * @see <a href= "https://docs.mongodb.com/manual/core/index-wildcard/">MongoDB Reference Documentation: Wildcard
+ *      Indexes/</a>
+ * @since 3.3
+ */
+public class WildcardIndex extends Index {
+
+	private @Nullable String fieldName;
+	private Map<String, Object> wildcardProjection = new LinkedHashMap<>();
+
+	/**
+	 * Create a new instance of {@link WildcardIndex} using {@code $**}.
+	 */
+	public WildcardIndex() {}
+
+	/**
+	 * Create a new instance of {@link WildcardIndex} for the given {@literal path}. If no {@literal path} is provided the
+	 * index will be considered a root one using {@code $**}. <br />
+	 * <strong>NOTE</strong> {@link #wildcardProjectionInclude(String...)}, {@link #wildcardProjectionExclude(String...)}
+	 * can only be used for top level index definitions having an {@literal empty} or {@literal null} path.
+	 *
+	 * @param path can be {@literal null}. If {@literal null} all fields will be indexed.
+	 */
+	public WildcardIndex(@Nullable String path) {
+		this.fieldName = path;
+	}
+
+	/**
+	 * Include the {@code _id} field in {@literal wildcardProjection}.
+	 *
+	 * @return this.
+	 */
+	public WildcardIndex includeId() {
+
+		wildcardProjection.put("_id", 1);
+		return this;
+	}
+
+	/**
+	 * Set the index name to use.
+	 *
+	 * @param name
+	 * @return this.
+	 */
+	@Override
+	public WildcardIndex named(String name) {
+
+		super.named(name);
+		return this;
+	}
+
+	/**
+	 * Unique option is not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	public Index unique() {
+		throw new UnsupportedOperationException("Wildcard Index does not support 'unique'.");
+	}
+
+	/**
+	 * ttl option is not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	public Index expire(long seconds) {
+		throw new UnsupportedOperationException("Wildcard Index does not support 'ttl'.");
+	}
+
+	/**
+	 * ttl option is not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	public Index expire(long value, TimeUnit timeUnit) {
+		throw new UnsupportedOperationException("Wildcard Index does not support 'ttl'.");
+	}
+
+	/**
+	 * ttl option is not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	public Index expire(Duration duration) {
+		throw new UnsupportedOperationException("Wildcard Index does not support 'ttl'.");
+	}
+
+	/**
+	 * Add fields to be included from indexing via {@code wildcardProjection}. <br />
+	 * This option is only allowed on {@link WildcardIndex#WildcardIndex() top level} wildcard indexes.
+	 *
+	 * @param paths must not be {@literal null}.
+	 * @return this.
+	 */
+	public WildcardIndex wildcardProjectionInclude(String... paths) {
+
+		for (String path : paths) {
+			wildcardProjection.put(path, 1);
+		}
+		return this;
+	}
+
+	/**
+	 * Add fields to be excluded from indexing via {@code wildcardProjection}. <br />
+	 * This option is only allowed on {@link WildcardIndex#WildcardIndex() top level} wildcard indexes.
+	 *
+	 * @param paths must not be {@literal null}.
+	 * @return this.
+	 */
+	public WildcardIndex wildcardProjectionExclude(String... paths) {
+
+		for (String path : paths) {
+			wildcardProjection.put(path, 0);
+		}
+		return this;
+	}
+
+	/**
+	 * Set the fields to be in-/excluded from indexing via {@code wildcardProjection}. <br />
+	 * This option is only allowed on {@link WildcardIndex#WildcardIndex() top level} wildcard indexes.
+	 *
+	 * @param includeExclude must not be {@literal null}.
+	 * @return this.
+	 */
+	public WildcardIndex wildcardProjection(Map<String, Object> includeExclude) {
+
+		wildcardProjection.putAll(includeExclude);
+		return this;
+	}
+
+	private String getTargetFieldName() {
+		return StringUtils.hasText(fieldName) ? (fieldName + ".$**") : "$**";
+	}
+
+	@Override
+	public Document getIndexKeys() {
+		return new Document(getTargetFieldName(), 1);
+	}
+
+	@Override
+	public Document getIndexOptions() {
+
+		Document options = new Document(super.getIndexOptions());
+		if (!CollectionUtils.isEmpty(wildcardProjection)) {
+			options.put("wildcardProjection", new Document(wildcardProjection));
+		}
+		return options;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndexed.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.index;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for an entity or property that should be used as key for a
+ * <a href="https://docs.mongodb.com/manual/core/index-wildcard/">Wildcard Index</a>. <br />
+ * If placed on a {@link ElementType#TYPE type} that is a root level domain entity (one having an
+ * {@link org.springframework.data.mongodb.core.mapping.Document} annotation) will advise the index creator to create a
+ * wildcard index for it.
+ *
+ * <pre class="code">
+ *
+ * &#64;Document
+ * &#64;WildcardIndexed
+ * public class Product {
+ *     ...
+ * }
+ *
+ * db.product.createIndex({ "$**" : 1 } , {})
+ * </pre>
+ * 
+ * {@literal wildcardProjection} can be used to specify keys to in-/exclude in the index.
+ *
+ * <pre class="code">
+ *
+ * &#64;Document
+ * &#64;WildcardIndexed(wildcardProjection = "{ 'userMetadata.age' : 0 }")
+ * public class User {
+ *     private &#64;Id String id;
+ *     private UserMetadata userMetadata;
+ * }
+ *
+ *
+ * db.user.createIndex(
+ *   { "$**" : 1 },
+ *   { "wildcardProjection" :
+ *     { "userMetadata.age" : 0 }
+ *   }
+ * )
+ * </pre>
+ *
+ * Wildcard indexes can also be expressed by adding the annotation directly to the field. Please note that
+ * {@literal wildcardProjection} is not allowed on nested paths.
+ *
+ * <pre class="code">
+ * &#64;Document
+ * public class User {
+ * 
+ *     private &#64;Id String id;
+ *
+ *     &#64;WildcardIndexed
+ *     private UserMetadata userMetadata;
+ * }
+ *
+ *
+ * db.user.createIndex({ "userMetadata.$**" : 1 }, {})
+ * </pre>
+ *
+ * @author Christoph Strobl
+ * @since 3.3
+ */
+@Documented
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WildcardIndexed {
+
+	/**
+	 * Index name either as plain value or as {@link org.springframework.expression.spel.standard.SpelExpression template
+	 * expression}. <br />
+	 * <br />
+	 * The name will only be applied as is when defined on root level. For usage on nested or embedded structures the
+	 * provided name will be prefixed with the path leading to the entity. <br />
+	 * 
+	 * @return
+	 */
+	String name() default "";
+
+	/**
+	 * If set to {@literal true} then MongoDB will ignore the given index name and instead generate a new name. Defaults
+	 * to {@literal false}.
+	 *
+	 * @return {@literal false} by default.
+	 */
+	boolean useGeneratedName() default false;
+
+	/**
+	 * Only index the documents in a collection that meet a specified {@link IndexFilter filter expression}. <br />
+	 *
+	 * @return empty by default.
+	 * @see <a href=
+	 *      "https://docs.mongodb.com/manual/core/index-partial/">https://docs.mongodb.com/manual/core/index-partial/</a>
+	 */
+	String partialFilter() default "";
+
+	/**
+	 * Explicitly specify sub fields to be in-/excluded as a {@link org.bson.Document#parse(String) prasable} String.
+	 * <br />
+	 * <strong>NOTE: </strong>Can only be done on root level documents.
+	 * 
+	 * @return empty by default.
+	 */
+	String wildcardProjection() default "";
+
+	/**
+	 * Defines the collation to apply.
+	 *
+	 * @return an empty {@link String} by default.
+	 */
+	String collation() default "";
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
@@ -36,6 +36,7 @@ public class IndexInfoUnitTests {
 	static final String INDEX_WITH_PARTIAL_FILTER = "{ \"v\" : 2, \"key\" : { \"k3y\" : 1 }, \"name\" : \"partial-filter-index\", \"ns\" : \"db.collection\", \"partialFilterExpression\" : { \"quantity\" : { \"$gte\" : 10 } } }";
 	static final String INDEX_WITH_EXPIRATION_TIME = "{ \"v\" : 2, \"key\" : { \"lastModifiedDate\" : 1 },\"name\" : \"expire-after-last-modified\", \"ns\" : \"db.collectio\", \"expireAfterSeconds\" : 3600 }";
 	static final String HASHED_INDEX = "{ \"v\" : 2, \"key\" : { \"score\" : \"hashed\" }, \"name\" : \"score_hashed\", \"ns\" : \"db.collection\" }";
+	static final String WILDCARD_INDEX = "{ \"v\" : 2, \"key\" : { \"$**\" : 1 }, \"name\" : \"$**_1\", \"wildcardProjection\" : { \"fieldA\" : 0, \"fieldB.fieldC\" : 0 } }";
 
 	@Test
 	public void isIndexForFieldsCorrectly() {
@@ -77,6 +78,16 @@ public class IndexInfoUnitTests {
 	@Test // DATAMONGO-1183
 	public void hashedIndexIsMarkedAsSuch() {
 		assertThat(getIndexInfo(HASHED_INDEX).isHashed()).isTrue();
+	}
+
+	@Test // GH-3225
+	public void identifiesWildcardIndexCorrectly() {
+		assertThat(getIndexInfo(WILDCARD_INDEX).isWildcard()).isTrue();
+	}
+
+	@Test // GH-3225
+	public void readsWildcardIndexProjectionCorrectly() {
+		assertThat(getIndexInfo(WILDCARD_INDEX).getWildcardProjection()).contains(new Document("fieldA", 0).append("fieldB.fieldC", 0));
 	}
 
 	private static IndexInfo getIndexInfo(String documentJson) {

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -760,6 +760,94 @@ mongoOperations.indexOpsFor(Jedi.class)
 ----
 ====
 
+[[mapping-usage-indexes.wildcard-index]]
+=== Wildcard Indexes
+
+A `WildcardIndex` is an index that can be used to include all fields or specific ones based a given (wildcard) pattern.
+For details, refer to the https://docs.mongodb.com/manual/core/index-wildcard/[MongoDB Documentation].
+
+The index can be set up programmatically using `WildcardIndex` via `IndexOperations`.
+
+.Programmatic WildcardIndex setup
+====
+[source,java]
+----
+mongoOperations
+    .indexOps(User.class)
+    .ensureIndex(new WildcardIndex("userMetadata"));
+----
+[source,javascript]
+----
+db.user.createIndex({ "userMetadata.$**" : 1 }, {})
+----
+====
+
+The `@WildcardIndex` annotation allows a declarative index setup an can be added on either a type or property.
+
+If placed on a type that is a root level domain entity (one having an `@Document` annotation) will advise the index creator to create a
+wildcard index for it.
+
+.Wildcard index on domain type
+====
+[source,java]
+----
+@Document
+@WildcardIndexed
+public class Product {
+    ...
+}
+----
+[source,javascript]
+----
+db.product.createIndex({ "$**" : 1 },{})
+----
+====
+
+The `wildcardProjection` can be used to specify keys to in-/exclude in the index.
+
+.Wildcard index with `wildcardProjection`
+====
+[source,java]
+----
+@Document
+@WildcardIndexed(wildcardProjection = "{ 'userMetadata.age' : 0 }")
+public class User {
+    private @Id String id;
+    private UserMetadata userMetadata;
+}
+----
+[source,javascript]
+----
+db.user.createIndex(
+  { "$**" : 1 },
+  { "wildcardProjection" :
+    { "userMetadata.age" : 0 }
+  }
+)
+----
+====
+
+Wildcard indexes can also be expressed by adding the annotation directly to the field.
+Please note that `wildcardProjection` is not allowed on nested paths.
+
+.Wildcard index on property
+====
+[source,java]
+----
+@Document
+public class User {
+    private @Id String id;
+
+    @WildcardIndexed
+    private UserMetadata userMetadata;
+}
+----
+[source,javascript]
+----
+db.user.createIndex({ "userMetadata.$**" : 1 }, {})
+----
+====
+
 [[mapping-usage-indexes.text-index]]
 === Text Indexes
 


### PR DESCRIPTION
A `WildcardIndex` is an index that can be used to include all fields or specific ones based a given (wildcard) pattern.

The index can be set up programmatically using `WildcardIndex` via `IndexOperations`.

```java
mongoOperations
    .indexOps(User.class)
    .ensureIndex(new WildcardIndex("userMetadata"));
```
```javascript
db.user.createIndex({ "userMetadata.$**" : 1 }, {})
```

The `@WildcardIndex` annotation allows a declarative index setup and can be added on either a type or property.

If placed on a type that is a root level domain entity (one having an `@Document` annotation) will advise the index creator to create a wildcard index for it.

```java
@Document
@WildcardIndexed
public class Product {
    ...
}
```
```javascript
db.product.createIndex({ "$**" : 1 },{})
```

The `wildcardProjection` can be used to specify keys to in-/exclude in the index.

```java
@Document
@WildcardIndexed(wildcardProjection = "{ 'userMetadata.age' : 0 }")
public class User {
    private @Id String id;
    private UserMetadata userMetadata;
}
```javascript
db.user.createIndex(
  { "$**" : 1 },
  { "wildcardProjection" :
    { "userMetadata.age" : 0 }
  }
)
```

Wildcard indexes can also be expressed by adding the annotation directly to the field.
Please note that `wildcardProjection` is not allowed on nested paths.

```java
@Document
public class User {
    private @Id String id;

    @WildcardIndexed
    private UserMetadata userMetadata;
}
```
```javascript
db.user.createIndex({ "userMetadata.$**" : 1 }, {})
```

Closes: #3225 