### PR TITLE
Fix field projection value conversion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3668-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3668-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3668-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3668-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -195,19 +195,7 @@ public class QueryMapper {
 			return new Document();
 		}
 
-		sortObject = filterUnwrappedObjects(sortObject, entity);
-
-		Document mappedSort = new Document();
-		for (Map.Entry<String, Object> entry : BsonUtils.asMap(sortObject).entrySet()) {
-
-			Field field = createPropertyField(entity, entry.getKey(), mappingContext);
-			if (field.getProperty() != null && field.getProperty().isUnwrapped()) {
-				continue;
-			}
-
-			mappedSort.put(field.getMappedKey(), entry.getValue());
-		}
-
+		Document mappedSort = mapFieldsToPropertyNames(sortObject, entity);
 		mapMetaAttributes(mappedSort, entity, MetaMapping.WHEN_PRESENT);
 		return mappedSort;
 	}
@@ -225,11 +213,28 @@ public class QueryMapper {
 
 		Assert.notNull(fieldsObject, "FieldsObject must not be null!");
 
-		fieldsObject = filterUnwrappedObjects(fieldsObject, entity);
-
-		Document mappedFields = getMappedObject(fieldsObject, entity);
+		Document mappedFields = mapFieldsToPropertyNames(fieldsObject, entity);
 		mapMetaAttributes(mappedFields, entity, MetaMapping.FORCE);
 		return mappedFields;
+	}
+
+	private Document mapFieldsToPropertyNames(Document fields, @Nullable MongoPersistentEntity<?> entity) {
+
+		if(fields.isEmpty()) {
+			return new Document();
+
+		}
+		Document target = new Document();
+		for (Map.Entry<String, Object> entry : BsonUtils.asMap(filterUnwrappedObjects(fields, entity)).entrySet()) {
+
+			Field field = createPropertyField(entity, entry.getKey(), mappingContext);
+			if (field.getProperty() != null && field.getProperty().isUnwrapped()) {
+				continue;
+			}
+
+			target.put(field.getMappedKey(), entry.getValue());
+		}
+		return target;
 	}
 
 	private void mapMetaAttributes(Document source, @Nullable MongoPersistentEntity<?> entity, MetaMapping metaMapping) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -50,6 +50,7 @@ import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
+import org.springframework.data.mongodb.core.mapping.MongoId;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.TextScore;
@@ -1304,6 +1305,13 @@ public class QueryMapperUnitTests {
 		assertThat(mapper.getMappedSort(query.getQueryObject(), context.getPersistentEntity(Customer.class))).isEqualTo(new org.bson.Document("address.street", "1007 Mountain Drive"));
 	}
 
+	@Test // GH-3668
+	void mapStringIdFieldProjection() {
+
+		org.bson.Document mappedFields = mapper.getMappedFields(new org.bson.Document("id", 1), context.getPersistentEntity(WithStringId.class));
+		assertThat(mappedFields).containsEntry("_id", 1);
+	}
+
 	class WithDeepArrayNesting {
 
 		List<WithNestedArray> level0;
@@ -1365,6 +1373,12 @@ public class QueryMapperUnitTests {
 	class Sample {
 
 		@Id private String foo;
+	}
+
+	class WithStringId {
+
+		@MongoId String id;
+		String name;
 	}
 
 	class BigIntegerId {


### PR DESCRIPTION
The field projection conversion should actually only map field names and avoid value conversion. In the `@MongoId` case a numeric inclusion parameter `1` was unintentionally converted into its `String` representation `"1"` which causes trouble on Mongo 4.4 servers.

Fixes: #3668
