### PR TITLE
Fix Regression in generating queries with nested maps with numeric keys

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -69,6 +69,7 @@ import com.mongodb.DBRef;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author David Julia
  */
 public class QueryMapper {
 
@@ -1367,11 +1368,17 @@ public class QueryMapper {
 		static class KeyMapper {
 
 			private final Iterator<String> iterator;
+			private int currentIndex;
+			private String currentPropertyRoot;
+			private final List<String> pathParts;
 
 			public KeyMapper(String key,
 					MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
-				this.iterator = Arrays.asList(key.split("\\.")).iterator();
+				this.pathParts = Arrays.asList(key.split("\\."));
+				this.currentPropertyRoot = pathParts.get(0);
+				this.currentIndex = 0;
+				this.iterator = pathParts.iterator();
 				this.iterator.next();
 			}
 
@@ -1389,16 +1396,25 @@ public class QueryMapper {
 				while (inspect) {
 
 					String partial = iterator.next();
+					currentIndex++;
 
-					boolean isPositional = isPositionalParameter(partial) && property.isCollectionLike();
+					boolean isPositional = isPositionalParameter(partial) && property.isCollectionLike() ;
+					if(property.isMap() && currentPropertyRoot.equals(partial) && iterator.hasNext()){
+						partial = iterator.next();
+						currentIndex++;
+					}
 
-					if (isPositional || property.isMap()) {
+					if (isPositional || property.isMap() && !currentPropertyRoot.equals(partial)) {
 						mappedName.append(".").append(partial);
 					}
 
 					inspect = isPositional && iterator.hasNext();
 				}
 
+				if(currentIndex + 1 < pathParts.size()) {
+					currentIndex++;
+					currentPropertyRoot = pathParts.get(currentIndex);
+				}
 				return mappedName.toString();
 			}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -72,6 +72,7 @@ import com.mongodb.client.model.Filters;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author David Julia
  */
 public class QueryMapperUnitTests {
 
@@ -728,6 +729,28 @@ public class QueryMapperUnitTests {
 				context.getPersistentEntity(EntityWithComplexValueTypeMap.class));
 
 		assertThat(document).containsKey("map.1.stringProperty");
+	}
+
+	@Test // GH-3688
+	void mappingShouldRetainNestedNumericMapKeys() {
+
+		Query query = query(where("outerMap.1.map.2.stringProperty").is("ba'alzamon"));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(EntityWithIntKeyedMapOfMap.class));
+
+		assertThat(document).containsKey("outerMap.1.map.2.stringProperty");
+	}
+
+	@Test // GH-3688
+	void mappingShouldAllowSettingEntireNestedNumericKeyedMapValue() {
+
+		Query query = query(where("outerMap.1.map").is(null)); //newEntityWithComplexValueTypeMap()
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(EntityWithIntKeyedMapOfMap.class));
+
+		assertThat(document).containsKey("outerMap.1.map");
 	}
 
 	@Test // DATAMONGO-1269
@@ -1465,6 +1488,10 @@ public class QueryMapperUnitTests {
 
 	static class EntityWithComplexValueTypeMap {
 		Map<Integer, SimpleEntityWithoutId> map;
+	}
+
+	static class EntityWithIntKeyedMapOfMap{
+		Map<Integer, EntityWithComplexValueTypeMap> outerMap;
 	}
 
 	static class EntityWithComplexValueTypeList {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -67,6 +67,7 @@ import com.mongodb.DBRef;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Pavel Vodrazka
+ * @author David Julia
  */
 @ExtendWith(MockitoExtension.class)
 class UpdateMapperUnitTests {
@@ -1179,6 +1180,16 @@ class UpdateMapperUnitTests {
 		assertThat(mappedUpdate).isEqualTo("{\"$set\": {\"map.601218778970110001827396.value\": \"testing\"}}");
 	}
 
+	@Test // GH-3688
+	void multipleNumericKeysInNestedPath() {
+
+		Update update = new Update().set("intKeyedMap.12345.map.0", "testing");
+		Document mappedUpdate = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(EntityWithIntKeyedMap.class));
+
+		assertThat(mappedUpdate).isEqualTo("{\"$set\": {\"intKeyedMap.12345.map.0\": \"testing\"}}");
+	}
+
 	@Test // GH-3566
 	void mapsObjectClassPropertyFieldInMapValueTypeAsKey() {
 
@@ -1423,6 +1434,10 @@ class UpdateMapperUnitTests {
 
 		Map<Object, Object> map;
 		Map<Object, NestedDocument> concreteMap;
+	}
+
+	static class EntityWithIntKeyedMap{
+		Map<Integer, EntityWithObjectMap> intKeyedMap;
 	}
 
 	static class ClassWithEnum {


### PR DESCRIPTION
While maps that have numeric keys work if there is only one map with an integer key, when there are multiple maps with numeric keys in a given query, it fails.

Take the following example for a map called outer with numeric keys holding reference to another object with a map called inner with numeric keys: Updates that are meant to generate {"$set": {"outerMap.1234.inner.5678": "hello"}} are instead generating {"$set": {"outerMap.1234.inner.inner": "hello"}}, repeating the later map property name instead of using the integer key value.

This commit adds unit tests both for the UpdateMapper and QueryMapper, which check multiple consecutive maps with numeric keys, and adds a fix in the KeyMapper. Because we cannot easily change the path parsing to somehow parse path parts corresponding to map keys differently, we address the issue in the KeyMapper. We keep track of the partial path corresponding to the current property and use it to skip adding the duplicated property name for the map to the query, and instead add the key.

This is a bit redundant in that we now have both an iterator and an index-based way of accessing the path parts, but it gets the tests passing and fixes the issue without making a large change to the current approach. There certainly is room to refactor this according to the maintainers' preference. I'm happy to take a pass at refactoring it to use just the index-based access to DRY things up a bit as long as the overall approach looks good. Or if it's quicker/easier for the maintainers to do the refactoring, no problem.. whatever gets this fix in quickest 😀. 

Signed-off-by: David Julia <dajulia3@gmail.com>

This should fix https://github.com/spring-projects/spring-data-mongodb/issues/3688

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
