### PR TITLE
Add Criteria infix functions for `maxDistance` and `minDistance`

### DIFF
--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/TypedCriteriaExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/TypedCriteriaExtensions.kt
@@ -365,6 +365,28 @@ infix fun KProperty<GeoJson<*>>.minDistance(d: Double): Criteria =
 		Criteria(asString(this)).minDistance(d)
 
 /**
+ * Creates a geo-spatial criterion using a $maxDistance operation, for use with $near
+ *
+ * See [MongoDB Query operator:
+ * $maxDistance](https://docs.mongodb.com/manual/reference/operator/query/maxDistance/)
+ * @author Sangyong Choi
+ * @since 3.2
+ * @see Criteria.maxDistance
+ */
+infix fun Criteria.maxDistance(d: Double): Criteria =
+		this.maxDistance(d)
+
+/**
+ * Creates a geospatial criterion using a $minDistance operation, for use with $near or
+ * $nearSphere.
+ * @author Sangyong Choi
+ * @since 3.2
+ * @see Criteria.minDistance
+ */
+infix fun Criteria.minDistance(d: Double): Criteria =
+		this.minDistance(d)
+
+/**
  * Creates a criterion using the $elemMatch operator
  *
  * See [MongoDB Query operator:

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/TypedCriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/TypedCriteriaExtensionsTests.kt
@@ -318,6 +318,54 @@ class TypedCriteriaExtensionsTests {
 	}
 
 	@Test
+	fun `maxDistance() should equal expected criteria with nearSphere`() {
+		val point = Point(0.0, 0.0)
+
+		val typed = Building::location nearSphere point maxDistance 3.0
+		val expected = Criteria("location")
+			.nearSphere(point)
+			.maxDistance(3.0)
+
+		assertThat(typed).isEqualTo(expected)
+	}
+
+	@Test
+	fun `minDistance() should equal expected criteria with nearSphere`() {
+		val point = Point(0.0, 0.0)
+
+		val typed = Building::location nearSphere point minDistance 3.0
+		val expected = Criteria("location")
+			.nearSphere(point)
+			.minDistance(3.0)
+
+		assertThat(typed).isEqualTo(expected)
+	}
+
+	@Test
+	fun `maxDistance() should equal expected criteria with near`() {
+		val point = Point(0.0, 0.0)
+
+		val typed = Building::location near point maxDistance 3.0
+		val expected = Criteria("location")
+			.near(point)
+			.maxDistance(3.0)
+
+		assertThat(typed).isEqualTo(expected)
+	}
+
+	@Test
+	fun `minDistance() should equal expected criteria with near`() {
+		val point = Point(0.0, 0.0)
+
+		val typed = Building::location near point minDistance 3.0
+		val expected = Criteria("location")
+			.near(point)
+			.minDistance(3.0)
+
+		assertThat(typed).isEqualTo(expected)
+	}
+
+	@Test
 	fun `elemMatch() should equal expected criteria`() {
 
 		val value = Criteria("price").lt(950)


### PR DESCRIPTION
add Criteria infix func 
- maxDistance
- minDistance

Because to use minDistance and maxDistance, near and nearSphere must exist.
But currently using infix fun to use minDistance, maxDistance throws an error.
Because we're adding it to the new Criteria.

[A repository where you can check for errors](https://github.com/sangyongchoi/mongodb-error)

I think good if criteria with Near Sphere and NearSphere added min Distance and Max Distance could be easily added. so I will send you a PR.


