### PR TITLE
Relax requirement for `GeoJsonMultiPoint` construction allowing creation using a single point

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJsonMultiPoint.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJsonMultiPoint.java
@@ -28,6 +28,7 @@ import org.springframework.util.ObjectUtils;
  * {@link GeoJsonMultiPoint} is defined as list of {@link Point}s.
  *
  * @author Christoph Strobl
+ * @author Ivan Volzhev
  * @since 1.7
  * @see <a href="https://geojson.org/geojson-spec.html#multipoint">https://geojson.org/geojson-spec.html#multipoint</a>
  */
@@ -40,12 +41,12 @@ public class GeoJsonMultiPoint implements GeoJson<Iterable<Point>> {
 	/**
 	 * Creates a new {@link GeoJsonMultiPoint} for the given {@link Point}s.
 	 *
-	 * @param points points must not be {@literal null} and have at least 2 entries.
+	 * @param points points must not be {@literal null} and have at least 1 entry.
 	 */
 	public GeoJsonMultiPoint(List<Point> points) {
 
 		Assert.notNull(points, "Points must not be null.");
-		Assert.isTrue(points.size() >= 2, "Minimum of 2 Points required.");
+		Assert.isTrue(points.size() >= 1, "Minimum of 1 Point required.");
 
 		this.points = new ArrayList<Point>(points);
 	}
@@ -67,6 +68,19 @@ public class GeoJsonMultiPoint implements GeoJson<Iterable<Point>> {
 		this.points.add(first);
 		this.points.add(second);
 		this.points.addAll(Arrays.asList(others));
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonMultiPoint} for the given {@link Point}.
+	 *
+	 * @param point must not be {@literal null}.
+	 */
+	public GeoJsonMultiPoint(Point point) {
+
+		Assert.notNull(point, "First point must not be null!");
+
+		this.points = new ArrayList<Point>();
+		this.points.add(point);
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoJsonTests.java
@@ -63,6 +63,7 @@ import com.mongodb.client.MongoCollection;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Ivan Volzhev
  */
 @ExtendWith({ MongoClientExtension.class, SpringExtension.class })
 @ContextConfiguration
@@ -320,6 +321,21 @@ public class GeoJsonTests {
 		DocumentWithPropertyUsingGeoJsonType obj = new DocumentWithPropertyUsingGeoJsonType();
 		obj.id = "geoJsonMultiPoint";
 		obj.geoJsonMultiPoint = new GeoJsonMultiPoint(Arrays.asList(new Point(0, 0), new Point(0, 1), new Point(1, 1)));
+
+		template.save(obj);
+
+		DocumentWithPropertyUsingGeoJsonType result = template.findOne(query(where("id").is(obj.id)),
+				DocumentWithPropertyUsingGeoJsonType.class);
+
+		assertThat(result.geoJsonMultiPoint).isEqualTo(obj.geoJsonMultiPoint);
+	}
+
+	@Test // DATAMONGO-3776
+	public void shouldSaveAndRetrieveDocumentWithGeoJsonMultiPointTypeWithOnePointCorrectly() {
+
+		DocumentWithPropertyUsingGeoJsonType obj = new DocumentWithPropertyUsingGeoJsonType();
+		obj.id = "geoJsonMultiPoint";
+		obj.geoJsonMultiPoint = new GeoJsonMultiPoint(new Point(0, 0));
 
 		template.save(obj);
 


### PR DESCRIPTION
Only 1 point is required per GeoJson RFC and Mongo works just fine with 1 point as well.

Closes #3776

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
