### PR TITLE
Fix id field target type conversion for document references. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3782-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3782-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3782-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3782-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentPointerFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentPointerFactory.java
@@ -83,7 +83,16 @@ class DocumentPointerFactory {
 				.getRequiredPersistentEntity(property.getAssociationTargetType());
 
 		if (usesDefaultLookup(property)) {
-			return () -> persistentEntity.getIdentifierAccessor(value).getIdentifier();
+
+			MongoPersistentProperty idProperty = persistentEntity.getIdProperty();
+			Object idValue = persistentEntity.getIdentifierAccessor(value).getIdentifier();
+
+			if (idProperty.hasExplicitWriteTarget()
+					&& conversionService.canConvert(idValue.getClass(), idProperty.getFieldType())) {
+				return () -> conversionService.convert(idValue, idProperty.getFieldType());
+			}
+
+			return () -> idValue;
 		}
 
 		MongoPersistentEntity<?> valueEntity = mappingContext.getPersistentEntity(value.getClass());


### PR DESCRIPTION
This PR fixes an issue where a defined custom target type conversion for the `id` field was not properly considered when writing a document reference.  Previously an eg. `String `was not being converted into an `ObjectId` correctly causing lookup queries to return empty results.
Converting the `id` property value on write solves the issue.

Includes a minor polish in the mapping centralizing pointer creation within the `DocumentPointerFactory`.

Closes: #3782