### PR TITLE
Allow OneToMany style lookups with via DocumentReference.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3798-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3798-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3798-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3798-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultReferenceResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultReferenceResolver.java
@@ -108,6 +108,6 @@ public class DefaultReferenceResolver implements ReferenceResolver {
 			ReferenceLookupDelegate referenceLookupDelegate, LookupFunction lookupFunction, MongoEntityReader entityReader) {
 		return proxyFactory.createLazyLoadingProxy(property, it -> {
 			return referenceLookupDelegate.readReference(it, source, lookupFunction, entityReader);
-		}, source);
+		}, source instanceof DocumentReferenceSource ? ((DocumentReferenceSource)source).getTargetSource() : source);
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentReferenceSource.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentReferenceSource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * The source object to resolve document references upon. Encapsulates the actual source and the reference specific
+ * values.
+ *
+ * @author Christoph Strobl
+ * @since 3.3
+ */
+public class DocumentReferenceSource {
+
+	private final Object self;
+
+	@Nullable private final Object targetSource;
+
+	/**
+	 * Create a new instance of {@link DocumentReferenceSource}.
+	 * 
+	 * @param self the entire wrapper object holding references. Must not be {@literal null}.
+	 * @param targetSource the reference value source.
+	 */
+	DocumentReferenceSource(Object self, @Nullable Object targetSource) {
+
+		this.self = self;
+		this.targetSource = targetSource;
+	}
+
+	/**
+	 * Get the outer document.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public Object getSelf() {
+		return self;
+	}
+
+	/**
+	 * Get the actual (property specific) reference value.
+	 *
+	 * @return can be {@literal null}.
+	 */
+	@Nullable
+	public Object getTargetSource() {
+		return targetSource;
+	}
+}

--- a/src/main/asciidoc/reference/document-references.adoc
+++ b/src/main/asciidoc/reference/document-references.adoc
@@ -262,6 +262,62 @@ class Publisher {
 <2> The field value placeholders of the lookup query (like `acc`) is used to form the reference document.
 ====
 
+It is also possible to model relational style _One-To-Many_ references using a combination of `@ReadonlyProperty` and `@DocumentReference`.
+This approach allows to link types without explicitly storing the linking values within the document itself as shown in the snipped below.
+
+====
+[source,java]
+----
+@Document
+class Book {
+
+  @Id
+  ObjectId id;
+  String title;
+  List<String> author;
+
+  ObjectId publisherId;                                        <1>
+}
+
+@Document
+class Publisher {
+
+  @Id
+  ObjectId id;
+  String acronym;
+  String name;
+
+  @ReadOnlyProperty                                            <2>
+  @DocumentReference(lookup="{'publisherId':?#{#self._id} }")  <3>
+  List<Book> books;
+}
+----
+
+.`Book` document
+[source,json]
+----
+{
+  "_id" : 9a48e32,
+  "title" : "The Warded Man",
+  "author" : ["Peter V. Brett"],
+  "publisherId" : 8cfb002
+}
+----
+
+.`Publisher` document
+[source,json]
+----
+{
+  "_id" : 8cfb002,
+  "acronym" : "DR",
+  "name" : "Del Rey"
+}
+----
+<1> Set up the link from `Book` to `Publisher` by storing the `Publisher.id` within the `Book` document.
+<2> Mark the property holding the references to be read only. This prevents storing references to individual ``Book``s with the `Publisher` document.
+<3> Use the `#self` variable to access values within the `Publisher` document and in this retrieve `Books` with matching `publisherId`.
+====
+
 With all the above in place it is possible to model all kind of associations between entities.
 Have a look at the non-exhaustive list of samples below to get feeling for what is possible.
 


### PR DESCRIPTION
This PR adds support for relational style _One-To-Many_ references using a combination of `@ReadonlyProperty` and `@DocumentReference`.
It allows to link types without explicitly storing the linking values within the document itself.


```java
@Document
class Book {

  @Id
  ObjectId id;
  String title;
  List<String> author;

  ObjectId publisherId;
}

@Document
class Publisher {

  @Id
  ObjectId id;
  String acronym;
  String name;

  @ReadOnlyProperty
  @DocumentReference(lookup="{'publisherId':?#{#self._id} }")
  List<Book> books;
}
```

**Book**
```json
{
  "_id" : "9a48e32",
  "title" : "The Warded Man",
  "author" : ["Peter V. Brett"],
  "publisherId" : "8cfb002"
}
```

**Publisher**
```json
{
  "_id" : "8cfb002",
  "acronym" : "DR",
  "name" : "Del Rey"
}
```

Closes: #3798