### PR TITLE
Properly detect all supported identifier annotations as explicitly annotated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,11 +141,11 @@
 			<id>sonatype-libs-snapshot</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
-        <enabled>false</enabled>
-      </releases>
+				<enabled>false</enabled>
+			</releases>
 			<snapshots>
-        <enabled>true</enabled>
-      </snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -317,6 +317,15 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- jMolecules -->
+
+		<dependency>
+			<groupId>org.jmolecules</groupId>
+			<artifactId>jmolecules-ddd</artifactId>
+			<version>${jmolecules}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
@@ -115,7 +114,7 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 	 */
 	@Override
 	public boolean isExplicitIdProperty() {
-		return isAnnotationPresent(Id.class);
+		return super.isIdProperty();
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
@@ -28,9 +28,9 @@ import java.util.Locale;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.jmolecules.ddd.annotation.Identity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.MappingException;
@@ -241,6 +241,15 @@ public class BasicMongoPersistentPropertyUnitTests {
 		assertThat(property.getFieldType()).isEqualTo(Document.class);
 	}
 
+	@Test
+	void considersJMoleculesIdentityExplicitlyAnnotatedIdentifier() {
+
+		MongoPersistentProperty property = getPropertyFor(WithJMoleculesIdentity.class, "identifier");
+
+		assertThat(property.isIdProperty()).isTrue();
+		assertThat(property.isExplicitIdProperty()).isTrue();
+	}
+
 	private MongoPersistentProperty getPropertyFor(Field field) {
 		return getPropertyFor(entity, field);
 	}
@@ -368,5 +377,9 @@ public class BasicMongoPersistentPropertyUnitTests {
 	static class WithComplexId {
 
 		@Id @org.springframework.data.mongodb.core.mapping.Field ComplexId id;
+	}
+
+	static class WithJMoleculesIdentity {
+		@Identity ObjectId identifier;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentPropertyUnitTests.java
@@ -356,8 +356,7 @@ public class BasicMongoPersistentPropertyUnitTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.FIELD)
 	@Id
-	static @interface ComposedIdAnnotation {
-	}
+	static @interface ComposedIdAnnotation {}
 
 	static class WithStringMongoId {
 


### PR DESCRIPTION
We now simply delegate to `AnnotationBasedPersistentProperty.isIdProperty()` for the detection of annotated identifiers. The previous, manual identifier check was preventing additional identifier annotations, supported by ABP, to be considered, too.