### PR TITLE
Fix parse error when collecting SpEL extensions for queries computed entirely via expression.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3871-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3871-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3871-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.3.0-GH-3871-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingDocumentCodec.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingDocumentCodec.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.util.json;
 import static java.util.Arrays.*;
 import static org.bson.assertions.Assertions.*;
 import static org.bson.codecs.configuration.CodecRegistries.*;
+import static org.springframework.data.mongodb.util.json.ParameterBindingJsonReader.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -217,6 +218,9 @@ public class ParameterBindingDocumentCodec implements CollectibleCodec<Document>
 			if (bindingReader.currentValue instanceof org.bson.Document) {
 				return (Document) bindingReader.currentValue;
 			}
+			if(ObjectUtils.nullSafeEquals(bindingReader.currentValue, PLACEHOLDER)) {
+				return new Document();
+			}
 		}
 
 		Document document = new Document();
@@ -376,8 +380,6 @@ public class ParameterBindingDocumentCodec implements CollectibleCodec<Document>
 	 * @since 3.1
 	 */
 	static class DependencyCapturingExpressionEvaluator implements SpELExpressionEvaluator {
-
-		private static final Object PLACEHOLDER = new Object();
 
 		private final ExpressionParser expressionParser;
 		private final List<ExpressionDependencies> dependencies = new ArrayList<>();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -358,6 +358,15 @@ class ParameterBindingJsonReaderUnitTests {
 						new Document("user.supervisor", "wonderwoman"))));
 	}
 
+	@Test // GH-3871
+	public void capturingExpressionDependenciesShouldNotThrowParseErrorForSpelOnlyJson() {
+
+		Object[] args = new Object[] { "1", "2" };
+		String json = "?#{ true ? { 'name': #name } : { 'name' : #name + 'trouble' } }";
+
+		new ParameterBindingDocumentCodec().captureExpressionDependencies(json, (index) -> args[index], new SpelExpressionParser());
+	}
+
 	@Test // DATAMONGO-2571
 	void shouldParseRegexCorrectly() {
 


### PR DESCRIPTION
This PR makes sure the extension collector returns a marker object to indicate no further json parsing is required.

Fixes: #3871   