### PR TITLE
Fix pagination using the reactive fluent Querydsl API

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveSpringDataMongodbQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveSpringDataMongodbQuery.java
@@ -96,7 +96,8 @@ class ReactiveSpringDataMongodbQuery<K> extends SpringDataMongodbQuerySupport<Re
 	 */
 	Mono<Page<K>> fetchPage(Pageable pageable) {
 
-		Mono<List<K>> content = createQuery().flatMapMany(it -> find.matching(it).all()).collectList();
+		Mono<List<K>> content = createQuery().map(it -> it.with(pageable))
+						     .flatMapMany(it -> find.matching(it).all()).collectList();
 
 		return content.flatMap(it -> ReactivePageableExecutionUtils.getPage(it, pageable, fetchCount()));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
@@ -400,6 +400,7 @@ public class ReactiveQuerydslMongoPredicateExecutorTests {
 				.as(StepVerifier::create) //
 				.assertNext(it -> {
 
+					assertThat(it.getContent().size()).isEqualTo(1);
 					assertThat(it.getTotalElements()).isEqualTo(2);
 					assertThat(it.getContent()).contains(dave);
 				}).verifyComplete();
@@ -409,6 +410,7 @@ public class ReactiveQuerydslMongoPredicateExecutorTests {
 				.as(StepVerifier::create) //
 				.assertNext(it -> {
 
+					assertThat(it.getContent().size()).isEqualTo(1);
 					assertThat(it.getTotalElements()).isEqualTo(2);
 					assertThat(it.getContent()).contains(oliver);
 				}).verifyComplete();


### PR DESCRIPTION
Pageable object was not passed to Query, so fetchPage retrieved erroneously the whole dataset as Page content.