### PR TITLE
Add support for direct and nested projections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-2860-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>
@@ -26,7 +26,7 @@
 	<properties>
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
-		<springdata.commons>2.7.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.7.0-GH-2420-SNAPSHOT</springdata.commons>
 		<mongo>4.4.0</mongo>
 		<mongo.reactivestreams>${mongo}</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-2860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-2860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-2860-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -28,6 +28,7 @@ import org.springframework.data.mapping.IdentifierAccessor;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
@@ -244,7 +245,7 @@ class EntityOperations {
 		return UntypedOperations.instance();
 	}
 
-	public <M, D> EntityProjectionIntrospector.EntityProjection<M, D> introspectProjection(Class<M> resultType,
+	public <M, D> EntityProjection<M, D> introspectProjection(Class<M> resultType,
 			Class<D> entityType) {
 		return introspector.introspect(resultType, entityType);
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -23,13 +23,16 @@ import java.util.Optional;
 import org.bson.Document;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.mapping.IdentifierAccessor;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mongodb.core.CollectionOptions.TimeSeriesOptions;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoWriter;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -39,6 +42,7 @@ import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.timeseries.Granularity;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -63,8 +67,19 @@ class EntityOperations {
 
 	private final MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> context;
 
-	EntityOperations(MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> context) {
+	private final EntityProjectionIntrospector introspector;
+
+	EntityOperations(MongoConverter converter) {
+		this(converter.getMappingContext(), converter.getCustomConversions(), converter.getProjectionFactory());
+	}
+
+	EntityOperations(MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> context,
+			CustomConversions conversions, ProjectionFactory projectionFactory) {
 		this.context = context;
+		this.introspector = EntityProjectionIntrospector.create(projectionFactory,
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and(((target, underlyingType) -> !conversions.isSimpleType(target))),
+				context);
 	}
 
 	/**
@@ -227,6 +242,11 @@ class EntityOperations {
 
 		}
 		return UntypedOperations.instance();
+	}
+
+	public <M, D> EntityProjectionIntrospector.EntityProjection<M, D> introspectProjection(Class<M> resultType,
+			Class<D> entityType) {
+		return introspector.introspect(resultType, entityType);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -49,6 +49,7 @@ import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.callback.EntityCallbacks;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoDatabaseUtils;
@@ -102,7 +103,6 @@ import org.springframework.data.mongodb.core.query.UpdateDefinition.ArrayFilter;
 import org.springframework.data.mongodb.core.timeseries.Granularity;
 import org.springframework.data.mongodb.core.validation.Validator;
 import org.springframework.data.mongodb.util.BsonUtils;
-import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.data.util.Optionals;
 import org.springframework.lang.Nullable;
@@ -173,7 +173,6 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	private final QueryMapper queryMapper;
 	private final UpdateMapper updateMapper;
 	private final JsonSchemaMapper schemaMapper;
-	private final SpelAwareProxyProjectionFactory projectionFactory;
 	private final EntityOperations operations;
 	private final PropertyOperations propertyOperations;
 	private final QueryOperations queryOperations;
@@ -225,9 +224,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		this.queryMapper = new QueryMapper(this.mongoConverter);
 		this.updateMapper = new UpdateMapper(this.mongoConverter);
 		this.schemaMapper = new MongoJsonSchemaMapper(this.mongoConverter);
-		this.projectionFactory = new SpelAwareProxyProjectionFactory();
-		this.operations = new EntityOperations(this.mongoConverter.getMappingContext());
-		this.propertyOperations = new PropertyOperations(this.mongoConverter.getMappingContext());
+		this.operations = new EntityOperations(this.mongoConverter);
+		this.propertyOperations = new PropertyOperations();
 		this.queryOperations = new QueryOperations(queryMapper, updateMapper, operations, propertyOperations,
 				mongoDbFactory);
 
@@ -264,7 +262,6 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		this.queryMapper = that.queryMapper;
 		this.updateMapper = that.updateMapper;
 		this.schemaMapper = that.schemaMapper;
-		this.projectionFactory = that.projectionFactory;
 		this.mappingContext = that.mappingContext;
 		this.operations = that.operations;
 		this.propertyOperations = that.propertyOperations;
@@ -330,9 +327,6 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		}
 
 		resourceLoader = applicationContext;
-
-		projectionFactory.setBeanFactory(applicationContext);
-		projectionFactory.setBeanClassLoader(applicationContext.getClassLoader());
 	}
 
 	/**
@@ -416,15 +410,17 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			MongoPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(entityType);
 
 			QueryContext queryContext = queryOperations.createQueryContext(query);
+			EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
+					entityType);
 
 			Document mappedQuery = queryContext.getMappedQuery(persistentEntity);
-			Document mappedFields = queryContext.getMappedFields(persistentEntity, returnType, projectionFactory);
+			Document mappedFields = queryContext.getMappedFields(persistentEntity, projection);
 
 			FindIterable<Document> cursor = new QueryCursorPreparer(query, entityType).initiateFind(collection,
 					col -> col.find(mappedQuery, Document.class).projection(mappedFields));
 
 			return new CloseableIterableCursorAdapter<>(cursor, exceptionTranslator,
-					new ProjectingReadCallback<>(mongoConverter, entityType, returnType, collectionName));
+					new ProjectingReadCallback<>(mongoConverter, projection, collectionName));
 		});
 	}
 
@@ -964,9 +960,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
 
 		AggregationResults<Document> results = aggregate($geoNear, collection, Document.class);
+		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
+				domainType);
 
 		DocumentCallback<GeoResult<T>> callback = new GeoNearResultDocumentCallback<>(distanceField,
-				new ProjectingReadCallback<>(mongoConverter, domainType, returnType, collection), near.getMetric());
+				new ProjectingReadCallback<>(mongoConverter, projection, collection), near.getMetric());
 
 		List<GeoResult<T>> result = new ArrayList<>();
 
@@ -1050,8 +1048,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityType);
 		QueryContext queryContext = queryOperations.createQueryContext(query);
 
+		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(resultType,
+				entityType);
 		Document mappedQuery = queryContext.getMappedQuery(entity);
-		Document mappedFields = queryContext.getMappedFields(entity, resultType, projectionFactory);
+		Document mappedFields = queryContext.getMappedFields(entity, projection);
 		Document mappedSort = queryContext.getMappedSort(entity);
 
 		replacement = maybeCallBeforeConvert(replacement, collectionName);
@@ -1061,7 +1061,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		maybeCallBeforeSave(replacement, mappedReplacement, collectionName);
 
 		T saved = doFindAndReplace(collectionName, mappedQuery, mappedFields, mappedSort,
-				queryContext.getCollation(entityType).orElse(null), entityType, mappedReplacement, options, resultType);
+				queryContext.getCollation(entityType).orElse(null), entityType, mappedReplacement, options, resultType,
+				projection);
 
 		if (saved != null) {
 			maybeEmitEvent(new AfterSaveEvent<>(saved, mappedReplacement, collectionName));
@@ -2499,7 +2500,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityClass);
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
-		Document mappedFields = queryContext.getMappedFields(entity, entityClass, projectionFactory);
+		Document mappedFields = queryContext.getMappedFields(entity,
+				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2551,7 +2553,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityClass);
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
-		Document mappedFields = queryContext.getMappedFields(entity, entityClass, projectionFactory);
+		Document mappedFields = queryContext.getMappedFields(entity,
+				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2573,9 +2576,11 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Class<T> targetClass, CursorPreparer preparer) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(sourceClass);
+		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(targetClass,
+				sourceClass);
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
-		Document mappedFields = queryContext.getMappedFields(entity, targetClass, projectionFactory);
+		Document mappedFields = queryContext.getMappedFields(entity, projection);
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2584,8 +2589,9 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		}
 
 		return executeFindMultiInternal(new FindCallback(mappedQuery, mappedFields, null), preparer,
-				new ProjectingReadCallback<>(mongoConverter, sourceClass, targetClass, collectionName), collectionName);
+				new ProjectingReadCallback<>(mongoConverter, projection, collectionName), collectionName);
 	}
+
 
 	/**
 	 * Convert given {@link CollectionOptions} to a document and take the domain type information into account when
@@ -2746,6 +2752,43 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Document replacement, FindAndReplaceOptions options, Class<T> resultType) {
 
 		if (LOGGER.isDebugEnabled()) {
+			LOGGER
+					.debug(String.format(
+							"findAndReplace using query: %s fields: %s sort: %s for class: %s and replacement: %s "
+									+ "in collection: %s",
+							serializeToJsonSafely(mappedQuery), serializeToJsonSafely(mappedFields),
+							serializeToJsonSafely(mappedSort), entityType, serializeToJsonSafely(replacement), collectionName));
+		}
+		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(resultType,
+				entityType);
+
+		return executeFindOneInternal(
+				new FindAndReplaceCallback(mappedQuery, mappedFields, mappedSort, replacement, collation, options),
+				new ProjectingReadCallback<>(mongoConverter, projection, collectionName), collectionName);
+	}
+
+	/**
+	 * Customize this part for findAndReplace.
+	 *
+	 * @param collectionName The name of the collection to perform the operation in.
+	 * @param mappedQuery the query to look up documents.
+	 * @param mappedFields the fields to project the result to.
+	 * @param mappedSort the sort to be applied when executing the query.
+	 * @param collation collation settings for the query. Can be {@literal null}.
+	 * @param entityType the source domain type.
+	 * @param replacement the replacement {@link Document}.
+	 * @param options applicable options.
+	 * @param resultType the target domain type.
+	 * @return {@literal null} if object does not exist, {@link FindAndReplaceOptions#isReturnNew() return new} is
+	 *         {@literal false} and {@link FindAndReplaceOptions#isUpsert() upsert} is {@literal false}.
+	 */
+	@Nullable
+	private <T> T doFindAndReplace(String collectionName, Document mappedQuery, Document mappedFields,
+			Document mappedSort, @Nullable com.mongodb.client.model.Collation collation, Class<?> entityType,
+			Document replacement, FindAndReplaceOptions options, Class<T> resultType,
+			EntityProjectionIntrospector.EntityProjection<T, ?> projection) {
+
+		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format(
 					"findAndReplace using query: %s fields: %s sort: %s for class: %s and replacement: %s " + "in collection: %s",
 					serializeToJsonSafely(mappedQuery), serializeToJsonSafely(mappedFields), serializeToJsonSafely(mappedSort),
@@ -2754,7 +2797,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		return executeFindOneInternal(
 				new FindAndReplaceCallback(mappedQuery, mappedFields, mappedSort, replacement, collation, options),
-				new ProjectingReadCallback<>(mongoConverter, entityType, resultType, collectionName), collectionName);
+				new ProjectingReadCallback<>(mongoConverter, projection, collectionName), collectionName);
 	}
 
 	/**
@@ -3205,17 +3248,15 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 */
 	private class ProjectingReadCallback<S, T> implements DocumentCallback<T> {
 
-		private final EntityReader<Object, Bson> reader;
-		private final Class<S> entityType;
-		private final Class<T> targetType;
+		private final MongoConverter reader;
+		private final EntityProjectionIntrospector.EntityProjection<T, S> projection;
 		private final String collectionName;
 
-		ProjectingReadCallback(EntityReader<Object, Bson> reader, Class<S> entityType, Class<T> targetType,
+		ProjectingReadCallback(MongoConverter reader, EntityProjectionIntrospector.EntityProjection<T, S> projection,
 				String collectionName) {
 
 			this.reader = reader;
-			this.entityType = entityType;
-			this.targetType = targetType;
+			this.projection = projection;
 			this.collectionName = collectionName;
 		}
 
@@ -3230,21 +3271,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				return null;
 			}
 
-			Class<?> typeToRead = targetType.isInterface() || targetType.isAssignableFrom(entityType) ? entityType
-					: targetType;
+			maybeEmitEvent(new AfterLoadEvent<>(document, projection.getMappedType().getType(), collectionName));
 
-			maybeEmitEvent(new AfterLoadEvent<>(document, targetType, collectionName));
-
-			Object entity = reader.read(typeToRead, document);
+			Object entity = reader.project(projection, document);
 
 			if (entity == null) {
 				throw new MappingException(String.format("EntityReader %s returned null", reader));
 			}
 
-			Object result = targetType.isInterface() ? projectionFactory.createProjection(targetType, entity) : entity;
-
-			maybeEmitEvent(new AfterConvertEvent<>(document, result, collectionName));
-			return (T) maybeCallAfterConvert(result, document, collectionName);
+			maybeEmitEvent(new AfterConvertEvent<>(document, entity, collectionName));
+			return (T) maybeCallAfterConvert(entity, document, collectionName);
 		}
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -49,7 +49,7 @@ import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.callback.EntityCallbacks;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoDatabaseUtils;
@@ -410,7 +410,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			MongoPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(entityType);
 
 			QueryContext queryContext = queryOperations.createQueryContext(query);
-			EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
+			EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
 					entityType);
 
 			Document mappedQuery = queryContext.getMappedQuery(persistentEntity);
@@ -960,7 +960,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				.withOptions(AggregationOptions.builder().collation(near.getCollation()).build());
 
 		AggregationResults<Document> results = aggregate($geoNear, collection, Document.class);
-		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
+		EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
 				domainType);
 
 		DocumentCallback<GeoResult<T>> callback = new GeoNearResultDocumentCallback<>(distanceField,
@@ -1048,7 +1048,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityType);
 		QueryContext queryContext = queryOperations.createQueryContext(query);
 
-		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(resultType,
+		EntityProjection<T, S> projection = operations.introspectProjection(resultType,
 				entityType);
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 		Document mappedFields = queryContext.getMappedFields(entity, projection);
@@ -2501,7 +2501,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
 		Document mappedFields = queryContext.getMappedFields(entity,
-				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
+				EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2554,7 +2554,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
 		Document mappedFields = queryContext.getMappedFields(entity,
-				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
+				EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2576,7 +2576,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Class<T> targetClass, CursorPreparer preparer) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(sourceClass);
-		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(targetClass,
+		EntityProjection<T, S> projection = operations.introspectProjection(targetClass,
 				sourceClass);
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
@@ -2751,7 +2751,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Document mappedSort, @Nullable com.mongodb.client.model.Collation collation, Class<?> entityType,
 			Document replacement, FindAndReplaceOptions options, Class<T> resultType) {
 
-		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(resultType,
+		EntityProjection<T, ?> projection = operations.introspectProjection(resultType,
 				entityType);
 
 		return doFindAndReplace(collectionName, mappedQuery, mappedFields, mappedSort, collation, entityType, replacement,
@@ -2778,7 +2778,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	private <T> T doFindAndReplace(String collectionName, Document mappedQuery, Document mappedFields,
 			Document mappedSort, @Nullable com.mongodb.client.model.Collation collation, Class<?> entityType,
 			Document replacement, FindAndReplaceOptions options,
-			EntityProjectionIntrospector.EntityProjection<T, ?> projection) {
+			EntityProjection<T, ?> projection) {
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format(
@@ -3241,10 +3241,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	private class ProjectingReadCallback<S, T> implements DocumentCallback<T> {
 
 		private final MongoConverter reader;
-		private final EntityProjectionIntrospector.EntityProjection<T, S> projection;
+		private final EntityProjection<T, S> projection;
 		private final String collectionName;
 
-		ProjectingReadCallback(MongoConverter reader, EntityProjectionIntrospector.EntityProjection<T, S> projection,
+		ProjectingReadCallback(MongoConverter reader, EntityProjection<T, S> projection,
 				String collectionName) {
 
 			this.reader = reader;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2772,7 +2772,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	 * @param projection the projection descriptor.
 	 * @return {@literal null} if object does not exist, {@link FindAndReplaceOptions#isReturnNew() return new} is
 	 *         {@literal false} and {@link FindAndReplaceOptions#isUpsert() upsert} is {@literal false}.
-	 * @since 2.7
+	 * @since 3.4
 	 */
 	@Nullable
 	private <T> T doFindAndReplace(String collectionName, Document mappedQuery, Document mappedFields,

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/PropertyOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/PropertyOperations.java
@@ -58,7 +58,6 @@ class PropertyOperations {
 		Document projectedFields = new Document();
 
 		if (projection.getMappedType().getType().isInterface()) {
-
 			projection.forEach(propertyPath -> projectedFields.put(propertyPath.getSegment(), 1));
 		} else {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/PropertyOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/PropertyOperations.java
@@ -17,7 +17,7 @@ package org.springframework.data.mongodb.core;
 
 import org.bson.Document;
 
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -48,7 +48,7 @@ class PropertyOperations {
 	 * @param fields must not be {@literal null}.
 	 * @return {@link Document} with fields to be included.
 	 */
-	Document computeMappedFieldsForProjection(EntityProjectionIntrospector.EntityProjection<?, ?> projection,
+	Document computeMappedFieldsForProjection(EntityProjection<?, ?> projection,
 			Document fields) {
 
 		if (!projection.isProjection() || !projection.isClosedProjection()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
@@ -31,7 +31,7 @@ import org.bson.codecs.Codec;
 
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.CodecRegistryProvider;
 import org.springframework.data.mongodb.MongoExpression;
@@ -289,7 +289,7 @@ class QueryOperations {
 		}
 
 		Document getMappedFields(@Nullable MongoPersistentEntity<?> entity,
-				EntityProjectionIntrospector.EntityProjection<?, ?> projection) {
+				EntityProjection<?, ?> projection) {
 
 			Document fields = evaluateFields(entity);
 
@@ -402,7 +402,7 @@ class QueryOperations {
 
 		@Override
 		Document getMappedFields(@Nullable MongoPersistentEntity<?> entity,
-				EntityProjectionIntrospector.EntityProjection<?, ?> projection) {
+				EntityProjection<?, ?> projection) {
 			return getMappedFields(entity);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2617,7 +2617,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 * @param projection the projection descriptor.
 	 * @return {@link Mono#empty()} if object does not exist, {@link FindAndReplaceOptions#isReturnNew() return new} is
 	 *         {@literal false} and {@link FindAndReplaceOptions#isUpsert() upsert} is {@literal false}.
-	 * @since 2.7
+	 * @since 3.4
 	 */
 	private <T> Mono<T> doFindAndReplace(String collectionName, Document mappedQuery, Document mappedFields,
 			Document mappedSort, com.mongodb.client.model.Collation collation, Class<?> entityType, Document replacement,

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -63,7 +63,7 @@ import org.springframework.data.geo.Metric;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.context.MappingContextEvent;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
@@ -1052,7 +1052,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		String collection = StringUtils.hasText(collectionName) ? collectionName : getCollectionName(entityClass);
 		String distanceField = operations.nearQueryDistanceFieldName(entityClass);
-		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
+		EntityProjection<T, ?> projection = operations.introspectProjection(returnType,
 				entityClass);
 
 		GeoNearResultDocumentCallback<T> callback = new GeoNearResultDocumentCallback<>(distanceField,
@@ -1135,7 +1135,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityType);
 		QueryContext queryContext = queryOperations.createQueryContext(query);
-		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(resultType,
+		EntityProjection<T, S> projection = operations.introspectProjection(resultType,
 				entityType);
 
 		Document mappedQuery = queryContext.getMappedQuery(entity);
@@ -2373,7 +2373,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		QueryContext queryContext = queryOperations
 				.createQueryContext(new BasicQuery(query, fields != null ? fields : new Document()));
 		Document mappedFields = queryContext.getMappedFields(entity,
-				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
+				EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2426,7 +2426,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
 		Document mappedFields = queryContext.getMappedFields(entity,
-				EntityProjectionIntrospector.EntityProjection.nonProjecting(entityClass));
+				EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
 
 		if (LOGGER.isDebugEnabled()) {
@@ -2448,7 +2448,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			Class<T> targetClass, FindPublisherPreparer preparer) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(sourceClass);
-		EntityProjectionIntrospector.EntityProjection<T, S> projection = operations.introspectProjection(targetClass,
+		EntityProjection<T, S> projection = operations.introspectProjection(targetClass,
 				sourceClass);
 
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
@@ -2596,7 +2596,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			Document mappedSort, com.mongodb.client.model.Collation collation, Class<?> entityType, Document replacement,
 			FindAndReplaceOptions options, Class<T> resultType) {
 
-		EntityProjectionIntrospector.EntityProjection<T, ?> projection = operations.introspectProjection(resultType,
+		EntityProjection<T, ?> projection = operations.introspectProjection(resultType,
 					entityType);
 
 		return doFindAndReplace(collectionName, mappedQuery, mappedFields, mappedSort, collation, entityType, replacement,
@@ -2622,7 +2622,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	private <T> Mono<T> doFindAndReplace(String collectionName, Document mappedQuery, Document mappedFields,
 			Document mappedSort, com.mongodb.client.model.Collation collation, Class<?> entityType, Document replacement,
 			FindAndReplaceOptions options,
-			EntityProjectionIntrospector.EntityProjection<T, ?> projection) {
+			EntityProjection<T, ?> projection) {
 
 		return Mono.defer(() -> {
 
@@ -3218,10 +3218,10 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	private class ProjectingReadCallback<S, T> implements DocumentCallback<T> {
 
 		private final MongoConverter reader;
-		private final EntityProjectionIntrospector.EntityProjection<T, S> projection;
+		private final EntityProjection<T, S> projection;
 		private final String collectionName;
 
-		ProjectingReadCallback(MongoConverter reader, EntityProjectionIntrospector.EntityProjection<T, S> projection,
+		ProjectingReadCallback(MongoConverter reader, EntityProjection<T, S> projection,
 				String collectionName) {
 			this.reader = reader;
 			this.projection = projection;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -91,7 +91,7 @@ class DocumentAccessor {
 	public void put(MongoPersistentProperty prop, @Nullable Object value) {
 
 		Assert.notNull(prop, "MongoPersistentProperty must not be null!");
-		String fieldName = prop.getFieldName();
+		String fieldName = getFieldName(prop);
 
 		if (!fieldName.contains(".")) {
 			BsonUtils.addToMap(document, fieldName, value);
@@ -123,7 +123,7 @@ class DocumentAccessor {
 	 */
 	@Nullable
 	public Object get(MongoPersistentProperty property) {
-		return BsonUtils.resolveValue(document, property.getFieldName());
+		return BsonUtils.resolveValue(document, getFieldName(property));
 	}
 
 	/**
@@ -150,7 +150,11 @@ class DocumentAccessor {
 
 		Assert.notNull(property, "Property must not be null!");
 
-		return BsonUtils.hasValue(document, property.getFieldName());
+		return BsonUtils.hasValue(document, getFieldName(property));
+	}
+
+	String getFieldName(MongoPersistentProperty prop) {
+		return prop.getFieldName();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -59,7 +59,7 @@ import org.springframework.data.mapping.PersistentPropertyPathAccessor;
 import org.springframework.data.mapping.PreferredConstructor;
 import org.springframework.data.mapping.PreferredConstructor.Parameter;
 import org.springframework.data.mapping.callback.EntityCallbacks;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mapping.model.DefaultSpELExpressionEvaluator;
@@ -300,7 +300,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	}
 
 	@Override
-	public <R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> projection, Bson bson) {
+	public <R> R project(EntityProjection<R, ?> projection, Bson bson) {
 
 		if (!projection.isProjection()) { // backed by real object
 			return read(projection.getMappedType(), bson);
@@ -315,7 +315,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 	@SuppressWarnings("unchecked")
 	private <R> R doReadProjection(ConversionContext context, Bson bson,
-			EntityProjectionIntrospector.EntityProjection<R, ?> projection) {
+			EntityProjection<R, ?> projection) {
 
 		MongoPersistentEntity<?> entity = getMappingContext().getRequiredPersistentEntity(projection.getActualDomainType());
 		TypeInformation<?> mappedType = projection.getActualMappedType();
@@ -377,7 +377,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	}
 
 	private Object doReadOrProject(ConversionContext context, Bson source, TypeInformation<?> typeHint,
-			EntityProjectionIntrospector.EntityProjection<?, ?> typeDescriptor) {
+			EntityProjection<?, ?> typeDescriptor) {
 
 		if (typeDescriptor.isProjection()) {
 			return doReadProjection(context, BsonUtils.asDocument(source), typeDescriptor);
@@ -388,12 +388,12 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 	class ProjectingConversionContext extends ConversionContext {
 
-		private final EntityProjectionIntrospector.EntityProjection<?, ?> returnedTypeDescriptor;
+		private final EntityProjection<?, ?> returnedTypeDescriptor;
 
 		ProjectingConversionContext(CustomConversions customConversions, ObjectPath path,
 				ContainerValueConverter<Collection<?>> collectionConverter, ContainerValueConverter<Bson> mapConverter,
 				ContainerValueConverter<DBRef> dbRefConverter, ValueConverter<Object> elementConverter,
-				EntityProjectionIntrospector.EntityProjection<?, ?> projection) {
+				EntityProjection<?, ?> projection) {
 			super(customConversions, path,
 					(context, source, typeHint) -> doReadOrProject(context, source, typeHint, projection),
 
@@ -404,7 +404,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		@Override
 		public ConversionContext forProperty(String name) {
 
-			EntityProjectionIntrospector.EntityProjection<?, ?> property = returnedTypeDescriptor.findProperty(name);
+			EntityProjection<?, ?> property = returnedTypeDescriptor.findProperty(name);
 			if (property == null) {
 				return super.forProperty(name);
 			}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -20,12 +20,15 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.springframework.core.convert.ConversionException;
+import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.convert.EntityReader;
 import org.springframework.data.convert.TypeMapper;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.util.BsonUtils;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -53,6 +56,30 @@ public interface MongoConverter
 	 * @return will never be {@literal null}.
 	 */
 	MongoTypeMapper getTypeMapper();
+
+	/**
+	 * Returns the {@link ProjectionFactory} for this converter.
+	 *
+	 * @return
+	 */
+	ProjectionFactory getProjectionFactory();
+
+	/**
+	 * Returns the {@link CustomConversions} for this converter.
+	 *
+	 * @return
+	 */
+	CustomConversions getCustomConversions();
+
+	/**
+	 * Apply a projection to {@link Bson} and return the projection return type {@code  R}.
+	 *
+	 * @param descriptor
+	 * @param bson
+	 * @param <R>
+	 * @return
+	 */
+	<R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson);
 
 	/**
 	 * Mapping function capable of converting values into a desired target type by eg. extracting the actual java type
@@ -154,4 +181,5 @@ public interface MongoConverter
 			return convertToMongoType(id,(TypeInformation<?>)  null);
 		}
 	}
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -19,12 +19,13 @@ import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
+
 import org.springframework.core.convert.ConversionException;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.convert.EntityReader;
 import org.springframework.data.convert.TypeMapper;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.util.BsonUtils;
@@ -75,8 +76,8 @@ public interface MongoConverter
 
 	/**
 	 * Apply a projection to {@link Bson} and return the projection return type {@code R}.
-	 * {@link EntityProjectionIntrospector.EntityProjection#isProjection() Non-projecting} descriptors fall back to
-	 * {@link #read(Class, Object) regular object materialization}.
+	 * {@link EntityProjection#isProjection() Non-projecting} descriptors fall back to {@link #read(Class, Object) regular
+	 * object materialization}.
 	 *
 	 * @param descriptor the projection descriptor, must not be {@literal null}.
 	 * @param bson must not be {@literal null}.
@@ -84,7 +85,7 @@ public interface MongoConverter
 	 * @return a new instance of the projection return type {@code R}.
 	 * @since 2.7
 	 */
-	<R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson);
+	<R> R project(EntityProjection<R, ?> descriptor, Bson bson);
 
 	/**
 	 * Mapping function capable of converting values into a desired target type by eg. extracting the actual java type

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -60,24 +60,29 @@ public interface MongoConverter
 	/**
 	 * Returns the {@link ProjectionFactory} for this converter.
 	 *
-	 * @return
+	 * @return will never be {@literal null}.
+	 * @since 2.7
 	 */
 	ProjectionFactory getProjectionFactory();
 
 	/**
 	 * Returns the {@link CustomConversions} for this converter.
 	 *
-	 * @return
+	 * @return will never be {@literal null}.
+	 * @since 2.7
 	 */
 	CustomConversions getCustomConversions();
 
 	/**
-	 * Apply a projection to {@link Bson} and return the projection return type {@code  R}.
+	 * Apply a projection to {@link Bson} and return the projection return type {@code R}.
+	 * {@link EntityProjectionIntrospector.EntityProjection#isProjection() Non-projecting} descriptors fall back to
+	 * {@link #read(Class, Object) regular object materialization}.
 	 *
-	 * @param descriptor
-	 * @param bson
+	 * @param descriptor the projection descriptor, must not be {@literal null}.
+	 * @param bson must not be {@literal null}.
 	 * @param <R>
-	 * @return
+	 * @return a new instance of the projection return type {@code R}.
+	 * @since 2.7
 	 */
 	<R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson);
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -62,7 +62,7 @@ public interface MongoConverter
 	 * Returns the {@link ProjectionFactory} for this converter.
 	 *
 	 * @return will never be {@literal null}.
-	 * @since 2.7
+	 * @since 3.4
 	 */
 	ProjectionFactory getProjectionFactory();
 
@@ -70,7 +70,7 @@ public interface MongoConverter
 	 * Returns the {@link CustomConversions} for this converter.
 	 *
 	 * @return will never be {@literal null}.
-	 * @since 2.7
+	 * @since 3.4
 	 */
 	CustomConversions getCustomConversions();
 
@@ -83,7 +83,7 @@ public interface MongoConverter
 	 * @param bson must not be {@literal null}.
 	 * @param <R>
 	 * @return a new instance of the projection return type {@code R}.
-	 * @since 2.7
+	 * @since 3.4
 	 */
 	<R> R project(EntityProjection<R, ?> descriptor, Bson bson);
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -223,8 +223,8 @@ public class QueryMapper {
 
 		if (fields.isEmpty()) {
 			return BsonUtils.EMPTY_DOCUMENT;
-
 		}
+
 		Document target = new Document();
 
 		BsonUtils.asMap(filterUnwrappedObjects(fields, entity)).forEach((k, v) -> {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
@@ -201,7 +201,7 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 	 *         {@link org.springframework.data.mongodb.core.mapping.Field#value()} present.
 	 * @since 1.7
 	 */
-	protected boolean hasExplicitFieldName() {
+	public boolean hasExplicitFieldName() {
 		return StringUtils.hasText(getAnnotatedFieldName());
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoPersistentProperty.java
@@ -42,6 +42,13 @@ public interface MongoPersistentProperty extends PersistentProperty<MongoPersist
 	String getFieldName();
 
 	/**
+	 * Returns whether the property uses an annotated field name through {@link Field}.
+	 *
+	 * @return
+	 */
+	boolean hasExplicitFieldName();
+
+	/**
 	 * Returns the {@link Class Java FieldType} of the field a property is persisted to.
 	 *
 	 * @return

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/PersistentPropertyTranslator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/PersistentPropertyTranslator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.util.function.Predicate;
+
+import org.springframework.data.util.Predicates;
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility to translate a {@link MongoPersistentProperty} into a corresponding property from a different
+ * {@link MongoPersistentEntity} by looking it up by name.
+ * <p>
+ * Mainly used within the framework.
+ *
+ * @author Mark Paluch
+ * @since 2.7
+ */
+public class PersistentPropertyTranslator {
+
+	/**
+	 * Translate a {@link MongoPersistentProperty} into a corresponding property from a different
+	 * {@link MongoPersistentEntity}.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return the translated property. Can be the original {@code property}.
+	 */
+	public MongoPersistentProperty translate(MongoPersistentProperty property) {
+		return property;
+	}
+
+	/**
+	 * Create a new {@link PersistentPropertyTranslator}.
+	 *
+	 * @param targetEntity must not be {@literal null}.
+	 * @return the property translator to use.
+	 */
+	public static PersistentPropertyTranslator create(@Nullable MongoPersistentEntity<?> targetEntity) {
+		return create(targetEntity, Predicates.isTrue());
+	}
+
+	/**
+	 * Create a new {@link PersistentPropertyTranslator} accepting a {@link Predicate filter predicate} whether the
+	 * translation should happen at all.
+	 *
+	 * @param targetEntity must not be {@literal null}.
+	 * @param translationFilter must not be {@literal null}.
+	 * @return the property translator to use.
+	 */
+	public static PersistentPropertyTranslator create(@Nullable MongoPersistentEntity<?> targetEntity,
+			Predicate<MongoPersistentProperty> translationFilter) {
+		return targetEntity != null ? new EntityPropertyTranslator(targetEntity, translationFilter)
+				: new PersistentPropertyTranslator();
+	}
+
+	private static class EntityPropertyTranslator extends PersistentPropertyTranslator {
+
+		private final MongoPersistentEntity<?> targetEntity;
+		private final Predicate<MongoPersistentProperty> translationFilter;
+
+		EntityPropertyTranslator(MongoPersistentEntity<?> targetEntity,
+				Predicate<MongoPersistentProperty> translationFilter) {
+			this.targetEntity = targetEntity;
+			this.translationFilter = translationFilter;
+		}
+
+		@Override
+		public MongoPersistentProperty translate(MongoPersistentProperty property) {
+
+			if (!translationFilter.test(property)) {
+				return property;
+			}
+
+			MongoPersistentProperty targetProperty = targetEntity.getPersistentProperty(property.getName());
+			return targetProperty != null ? targetProperty : property;
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/PersistentPropertyTranslator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/PersistentPropertyTranslator.java
@@ -27,7 +27,7 @@ import org.springframework.lang.Nullable;
  * Mainly used within the framework.
  *
  * @author Mark Paluch
- * @since 2.7
+ * @since 3.4
  */
 public class PersistentPropertyTranslator {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/UnwrappedMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/UnwrappedMongoPersistentProperty.java
@@ -57,6 +57,12 @@ class UnwrappedMongoPersistentProperty implements MongoPersistentProperty {
 	}
 
 	@Override
+	public boolean hasExplicitFieldName() {
+		return delegate.hasExplicitFieldName()
+				|| !ObjectUtils.isEmpty(context.getProperty().findAnnotation(Unwrapped.class).prefix());
+	}
+
+	@Override
 	public Class<?> getFieldType() {
 		return delegate.getFieldType();
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactory.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -74,6 +75,11 @@ public class MongoRepositoryFactory extends RepositoryFactorySupport {
 
 		this.operations = mongoOperations;
 		this.mappingContext = mongoOperations.getConverter().getMappingContext();
+	}
+
+	@Override
+	protected ProjectionFactory getProjectionFactory(ClassLoader classLoader, BeanFactory beanFactory) {
+		return this.operations.getConverter().getProjectionFactory();
 	}
 
 	/*

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveMongoRepositoryFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveMongoRepositoryFactory.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
@@ -76,6 +77,11 @@ public class ReactiveMongoRepositoryFactory extends ReactiveRepositoryFactorySup
 		this.operations = mongoOperations;
 		this.mappingContext = mongoOperations.getConverter().getMappingContext();
 		setEvaluationContextProvider(ReactiveQueryMethodEvaluationContextProvider.DEFAULT);
+	}
+
+	@Override
+	protected ProjectionFactory getProjectionFactory(ClassLoader classLoader, BeanFactory beanFactory) {
+		return this.operations.getConverter().getProjectionFactory();
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationUnitTests.java
@@ -24,6 +24,8 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.EntityOperations.AdaptibleEntity;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
 /**
@@ -37,7 +39,7 @@ public class EntityOperationUnitTests {
 
 	@BeforeEach
 	public void setUp() {
-		ops = new EntityOperations(mappingContext);
+		ops = new EntityOperations(new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, mappingContext));
 	}
 
 	@Test // DATAMONGO-2293

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/EntityOperationsUnitTests.java
@@ -22,7 +22,8 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.mapping.TimeSeries;
 import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
 
@@ -33,7 +34,8 @@ import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
  */
 class EntityOperationsUnitTests {
 
-	EntityOperations operations = new EntityOperations(MongoTestMappingContext.newTestContext());
+	EntityOperations operations = new EntityOperations(
+			new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, MongoTestMappingContext.newTestContext()));
 
 	@Test // GH-3731
 	void shouldReportInvalidTimeField() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableFindOperationSupportTests.java
@@ -21,7 +21,9 @@ import static org.springframework.data.mongodb.core.query.Query.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 import java.util.stream.Stream;
@@ -32,6 +34,7 @@ import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -569,6 +572,8 @@ class ExecutableFindOperationSupportTests {
 		String getName();
 	}
 
+	@Getter
+	@Setter // TODO: Without getters/setters, not identified as projection/properties
 	static class PersonDtoProjection {
 
 		@Field("firstname") String name;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.bson.BsonString;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.annotation.Id;
@@ -132,10 +133,11 @@ class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
+	@Disabled("TODO")
 	void updateWithDifferentDomainClassAndCollection() {
 
 		UpdateResult result = template.update(Jedi.class).inCollection(STAR_WARS)
-				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).all();
+				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("firstname", "Han")).all();
 
 		assertThat(result.getModifiedCount()).isEqualTo(1L);
 		assertThat(result.getUpsertedId()).isNull();
@@ -166,12 +168,13 @@ class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
+	@Disabled("TODO")
 	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		Optional<Jedi> result = template.update(Jedi.class).inCollection(STAR_WARS)
-				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).findAndModify();
+				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("firstname", "Han")).findAndModify();
 
-		assertThat(result.get()).hasFieldOrPropertyWithValue("name", "han");
+		assertThat(result.get()).hasFieldOrPropertyWithValue("firstname", "han");
 		assertThat(template.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
 				"Han");
 	}
@@ -257,7 +260,7 @@ class ExecutableUpdateOperationSupportTests {
 		Jedi result = template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class)
 				.findAndReplaceValue();
 
-		assertThat(result.getName()).isEqualTo(han.firstname);
+		assertThat(result.getFirstname()).isEqualTo(han.firstname);
 	}
 
 	private Query queryHan() {
@@ -268,6 +271,7 @@ class ExecutableUpdateOperationSupportTests {
 	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS)
 	static class Person {
 		@Id String id;
+		@Field("name")
 		String firstname;
 	}
 
@@ -278,7 +282,6 @@ class ExecutableUpdateOperationSupportTests {
 
 	@Data
 	static class Jedi {
-
-		@Field("firstname") String name;
+		String firstname;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableUpdateOperationSupportTests.java
@@ -25,9 +25,9 @@ import java.util.Optional;
 
 import org.bson.BsonString;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Query;
@@ -133,11 +133,10 @@ class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	@Disabled("TODO")
 	void updateWithDifferentDomainClassAndCollection() {
 
 		UpdateResult result = template.update(Jedi.class).inCollection(STAR_WARS)
-				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("firstname", "Han")).all();
+				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).all();
 
 		assertThat(result.getModifiedCount()).isEqualTo(1L);
 		assertThat(result.getUpsertedId()).isNull();
@@ -168,13 +167,12 @@ class ExecutableUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1563
-	@Disabled("TODO")
 	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		Optional<Jedi> result = template.update(Jedi.class).inCollection(STAR_WARS)
-				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("firstname", "Han")).findAndModify();
+				.matching(query(where("_id").is(han.getId()))).apply(new Update().set("name", "Han")).findAndModify();
 
-		assertThat(result.get()).hasFieldOrPropertyWithValue("firstname", "han");
+		assertThat(result.get()).hasFieldOrPropertyWithValue("name", "han");
 		assertThat(template.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
 				"Han");
 	}
@@ -260,7 +258,7 @@ class ExecutableUpdateOperationSupportTests {
 		Jedi result = template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class)
 				.findAndReplaceValue();
 
-		assertThat(result.getFirstname()).isEqualTo(han.firstname);
+		assertThat(result.getName()).isEqualTo(han.firstname);
 	}
 
 	private Query queryHan() {
@@ -271,7 +269,6 @@ class ExecutableUpdateOperationSupportTests {
 	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS)
 	static class Person {
 		@Id String id;
-		@Field("name")
 		String firstname;
 	}
 
@@ -282,6 +279,6 @@ class ExecutableUpdateOperationSupportTests {
 
 	@Data
 	static class Jedi {
-		String firstname;
+		@Field("firstname") String name;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOperationsUnitTests.java
@@ -27,11 +27,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.AbstractMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -107,7 +108,7 @@ public abstract class MongoOperationsUnitTests {
 			}
 
 			@Override
-			public <R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson) {
+			public <R> R project(EntityProjection<R, ?> descriptor, Bson bson) {
 				return null;
 			}
 		};

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoOperationsUnitTests.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.AbstractMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -37,6 +39,7 @@ import org.springframework.data.mongodb.core.convert.MongoTypeMapper;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.NearQuery;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.util.TypeInformation;
 
 import com.mongodb.DBRef;
@@ -90,6 +93,21 @@ public abstract class MongoOperationsUnitTests {
 
 			@Override
 			public MongoTypeMapper getTypeMapper() {
+				return null;
+			}
+
+			@Override
+			public ProjectionFactory getProjectionFactory() {
+				return null;
+			}
+
+			@Override
+			public CustomConversions getCustomConversions() {
+				return null;
+			}
+
+			@Override
+			public <R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson) {
 				return null;
 			}
 		};

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -1080,7 +1080,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	@Test // DATAMONGO-1733, DATAMONGO-2041
 	void appliesFieldsToDtoProjection() {
 
-		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonDtoProjection.class,
+		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class,
 				CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("firstname", 1)));
@@ -2359,12 +2359,6 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	static class Jedi {
 
 		@Field("firstname") String name;
-	}
-
-	@Data
-	static class PersonDtoProjection {
-
-		String firstname;
 	}
 
 	class Wrapper {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -102,6 +102,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.timeseries.Granularity;
 import org.springframework.data.mongodb.util.BsonUtils;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.CollectionUtils;
@@ -410,6 +411,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		when(cursor.next()).thenReturn(new org.bson.Document("_id", Integer.valueOf(0)));
 		MappingMongoConverter converter = mock(MappingMongoConverter.class);
 		when(converter.getMappingContext()).thenReturn((MappingContext) mappingContext);
+		when(converter.getProjectionFactory()).thenReturn(new SpelAwareProxyProjectionFactory());
 		template = new MongoTemplate(factory, converter);
 
 		assertThatExceptionOfType(MappingException.class).isThrownBy(() -> template.findAll(Person.class))
@@ -1078,7 +1080,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	@Test // DATAMONGO-1733, DATAMONGO-2041
 	void appliesFieldsToDtoProjection() {
 
-		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class,
+		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonDtoProjection.class,
 				CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("firstname", 1)));
@@ -2357,6 +2359,12 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	static class Jedi {
 
 		@Field("firstname") String name;
+	}
+
+	@Data
+	static class PersonDtoProjection {
+
+		String firstname;
 	}
 
 	class Wrapper {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -90,6 +90,7 @@ import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.timeseries.Granularity;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.CollectionUtils;
@@ -408,7 +409,7 @@ public class ReactiveMongoTemplateUnitTests {
 	@Test // DATAMONGO-1719, DATAMONGO-2041
 	void appliesFieldsToDtoProjection() {
 
-		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class,
+		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonDtoProjection.class,
 				FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("firstname", 1)));
@@ -1151,6 +1152,7 @@ public class ReactiveMongoTemplateUnitTests {
 
 		MappingMongoConverter converter = mock(MappingMongoConverter.class);
 		when(converter.getMappingContext()).thenReturn((MappingContext) mappingContext);
+		when(converter.getProjectionFactory()).thenReturn(new SpelAwareProxyProjectionFactory());
 		template = new ReactiveMongoTemplate(factory, converter);
 
 		when(collection.find(Document.class)).thenReturn(findPublisher);
@@ -1500,6 +1502,12 @@ public class ReactiveMongoTemplateUnitTests {
 	static class Jedi {
 
 		@Field("firstname") String name;
+	}
+
+	@Data
+	static class PersonDtoProjection {
+
+		String firstname;
 	}
 
 	@org.springframework.data.mongodb.core.mapping.Document(collation = "de_AT")

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -409,7 +409,7 @@ public class ReactiveMongoTemplateUnitTests {
 	@Test // DATAMONGO-1719, DATAMONGO-2041
 	void appliesFieldsToDtoProjection() {
 
-		template.doFind("star-wars", new Document(), new Document(), Person.class, PersonDtoProjection.class,
+		template.doFind("star-wars", new Document(), new Document(), Person.class, Jedi.class,
 				FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("firstname", 1)));
@@ -1482,7 +1482,6 @@ public class ReactiveMongoTemplateUnitTests {
 
 		AutogenerateableId foo;
 	}
-
 	static class PersonExtended extends Person {
 
 		String lastname;
@@ -1502,12 +1501,6 @@ public class ReactiveMongoTemplateUnitTests {
 	static class Jedi {
 
 		@Field("firstname") String name;
-	}
-
-	@Data
-	static class PersonDtoProjection {
-
-		String firstname;
 	}
 
 	@org.springframework.data.mongodb.core.mapping.Document(collation = "de_AT")

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -24,8 +24,10 @@ import reactor.test.StepVerifier;
 
 import org.bson.BsonString;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Query;
@@ -164,11 +166,12 @@ class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
+	@Disabled("TODO")
 	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		template.update(Jedi.class).inCollection(STAR_WARS).matching(query(where("_id").is(han.getId())))
 				.apply(new Update().set("name", "Han")).findAndModify().as(StepVerifier::create)
-				.consumeNextWith(actual -> assertThat(actual.getName()).isEqualTo("han")).verifyComplete();
+				.consumeNextWith(actual -> assertThat(actual.getFirstname()).isEqualTo("han")).verifyComplete();
 
 		assertThat(blocking.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
 				"Han");
@@ -220,7 +223,7 @@ class ReactiveUpdateOperationSupportTests {
 
 		template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class).findAndReplace() //
 				.as(StepVerifier::create).consumeNextWith(it -> {
-					assertThat(it.getName()).isEqualTo(han.firstname);
+					assertThat(it.getFirstname()).isEqualTo(han.firstname);
 				}).verifyComplete();
 	}
 
@@ -262,6 +265,7 @@ class ReactiveUpdateOperationSupportTests {
 	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS)
 	static class Person {
 		@Id String id;
+		@Field("name")
 		String firstname;
 	}
 
@@ -273,6 +277,6 @@ class ReactiveUpdateOperationSupportTests {
 	@Data
 	static class Jedi {
 
-		@Field("firstname") String name;
+		String firstname;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveUpdateOperationSupportTests.java
@@ -24,10 +24,8 @@ import reactor.test.StepVerifier;
 
 import org.bson.BsonString;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Query;
@@ -166,12 +164,11 @@ class ReactiveUpdateOperationSupportTests {
 	}
 
 	@Test // DATAMONGO-1719
-	@Disabled("TODO")
 	void findAndModifyWithDifferentDomainTypeAndCollection() {
 
 		template.update(Jedi.class).inCollection(STAR_WARS).matching(query(where("_id").is(han.getId())))
 				.apply(new Update().set("name", "Han")).findAndModify().as(StepVerifier::create)
-				.consumeNextWith(actual -> assertThat(actual.getFirstname()).isEqualTo("han")).verifyComplete();
+				.consumeNextWith(actual -> assertThat(actual.getName()).isEqualTo("han")).verifyComplete();
 
 		assertThat(blocking.findOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
 				"Han");
@@ -223,7 +220,7 @@ class ReactiveUpdateOperationSupportTests {
 
 		template.update(Person.class).matching(queryHan()).replaceWith(luke).as(Jedi.class).findAndReplace() //
 				.as(StepVerifier::create).consumeNextWith(it -> {
-					assertThat(it.getFirstname()).isEqualTo(han.firstname);
+					assertThat(it.getName()).isEqualTo(han.firstname);
 				}).verifyComplete();
 	}
 
@@ -265,7 +262,6 @@ class ReactiveUpdateOperationSupportTests {
 	@org.springframework.data.mongodb.core.mapping.Document(collection = STAR_WARS)
 	static class Person {
 		@Id String id;
-		@Field("name")
 		String firstname;
 	}
 
@@ -277,6 +273,6 @@ class ReactiveUpdateOperationSupportTests {
 	@Data
 	static class Jedi {
 
-		String firstname;
+		@Field("firstname") String name;
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
@@ -48,8 +48,8 @@ class UpdateOperationsUnitTests {
 	MongoConverter mongoConverter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, mappingContext);
 	QueryMapper queryMapper = new QueryMapper(mongoConverter);
 	UpdateMapper updateMapper = new UpdateMapper(mongoConverter);
-	EntityOperations entityOperations = new EntityOperations(mappingContext);
-	PropertyOperations propertyOperations = new PropertyOperations(mappingContext);
+	EntityOperations entityOperations = new EntityOperations(mongoConverter);
+	PropertyOperations propertyOperations = new PropertyOperations();
 
 	ExtendedQueryOperations queryOperations = new ExtendedQueryOperations(queryMapper, updateMapper, entityOperations, propertyOperations,
 			MongoClientSettings::getDefaultCodecRegistry);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/UpdateOperationsUnitTests.java
@@ -49,7 +49,7 @@ class UpdateOperationsUnitTests {
 	QueryMapper queryMapper = new QueryMapper(mongoConverter);
 	UpdateMapper updateMapper = new UpdateMapper(mongoConverter);
 	EntityOperations entityOperations = new EntityOperations(mongoConverter);
-	PropertyOperations propertyOperations = new PropertyOperations();
+	PropertyOperations propertyOperations = new PropertyOperations(mongoConverter.getMappingContext());
 
 	ExtendedQueryOperations queryOperations = new ExtendedQueryOperations(queryMapper, updateMapper, entityOperations, propertyOperations,
 			MongoClientSettings::getDefaultCodecRegistry);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverterUnitTests.java
@@ -21,11 +21,14 @@ import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.convert.CustomConversions;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.MongoConverters.ObjectIdToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToObjectIdConverter;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.util.TypeInformation;
 
 import com.mongodb.DBRef;
@@ -57,6 +60,21 @@ public class AbstractMongoConverterUnitTests {
 		@Override
 		public MongoTypeMapper getTypeMapper() {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProjectionFactory getProjectionFactory() {
+			return null;
+		}
+
+		@Override
+		public CustomConversions getCustomConversions() {
+			return null;
+		}
+
+		@Override
+		public <R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson) {
+			return null;
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/AbstractMongoConverterUnitTests.java
@@ -19,10 +19,11 @@ import static org.mockito.Mockito.*;
 
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.convert.CustomConversions;
-import org.springframework.data.mapping.context.EntityProjectionIntrospector;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.MongoConverters.ObjectIdToStringConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverters.StringToObjectIdConverter;
@@ -73,7 +74,7 @@ public class AbstractMongoConverterUnitTests {
 		}
 
 		@Override
-		public <R> R project(EntityProjectionIntrospector.EntityProjection<R, ?> descriptor, Bson bson) {
+		public <R> R project(EntityProjection<R, ?> descriptor, Bson bson) {
 			return null;
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -67,6 +67,7 @@ import org.springframework.data.geo.Polygon;
 import org.springframework.data.geo.Shape;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.callback.EntityCallbacks;
+import org.springframework.data.mapping.context.EntityProjection;
 import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.model.MappingInstantiationException;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
@@ -2650,7 +2651,7 @@ class MappingMongoConverterUnitTests {
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
 
-		EntityProjectionIntrospector.EntityProjection<PersonProjection, Person> projection = discoverer
+		EntityProjection<PersonProjection, Person> projection = discoverer
 				.introspect(PersonProjection.class, Person.class);
 		PersonProjection person = converter.project(projection, source);
 
@@ -2669,7 +2670,7 @@ class MappingMongoConverterUnitTests {
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
 
-		EntityProjectionIntrospector.EntityProjection<PersonDto, Person> projection = introspector
+		EntityProjection<PersonDto, Person> projection = introspector
 				.introspect(PersonDto.class, Person.class);
 		PersonDto person = converter.project(projection, source);
 
@@ -2688,7 +2689,7 @@ class MappingMongoConverterUnitTests {
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
 
-		EntityProjectionIntrospector.EntityProjection<WithNestedProjection, Person> projection = introspector
+		EntityProjection<WithNestedProjection, Person> projection = introspector
 				.introspect(WithNestedProjection.class, Person.class);
 		WithNestedProjection person = converter.project(projection, source);
 
@@ -2706,7 +2707,7 @@ class MappingMongoConverterUnitTests {
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
 
-		EntityProjectionIntrospector.EntityProjection<ProjectionWithNestedEntity, Person> projection = introspector
+		EntityProjection<ProjectionWithNestedEntity, Person> projection = introspector
 				.introspect(ProjectionWithNestedEntity.class, Person.class);
 		ProjectionWithNestedEntity person = converter.project(projection, source);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.data.mongodb.core.DocumentTestUtils.*;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
@@ -66,6 +67,7 @@ import org.springframework.data.geo.Polygon;
 import org.springframework.data.geo.Shape;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.callback.EntityCallbacks;
+import org.springframework.data.mapping.context.EntityProjectionIntrospector;
 import org.springframework.data.mapping.model.MappingInstantiationException;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
 import org.springframework.data.mongodb.core.convert.DocumentAccessorUnitTests.NestedType;
@@ -138,7 +140,7 @@ class MappingMongoConverterUnitTests {
 		converter.write(address, document);
 
 		assertThat(document.get("city").toString()).isEqualTo("New York");
-		assertThat(document.get("street").toString()).isEqualTo("Broadway");
+		assertThat(document.get("s").toString()).isEqualTo("Broadway");
 	}
 
 	@Test
@@ -2191,7 +2193,8 @@ class MappingMongoConverterUnitTests {
 	@Test // GH-3546
 	void readFlattensNestedDocumentToStringIfNecessary() {
 
-		org.bson.Document source = new org.bson.Document("street", new org.bson.Document("json", "string").append("_id", UUID.randomUUID()));
+		org.bson.Document source = new org.bson.Document("s",
+				new org.bson.Document("json", "string").append("_id", UUID.randomUUID()));
 
 		Address target = converter.read(Address.class, source);
 		assertThat(target.street).isNotNull();
@@ -2355,7 +2358,7 @@ class MappingMongoConverterUnitTests {
 	void readUnwrappedTypeWithComplexValue() {
 
 		org.bson.Document source = new org.bson.Document("_id", "id-1").append("address",
-				new org.bson.Document("street", "1007 Mountain Drive").append("city", "Gotham"));
+				new org.bson.Document("s", "1007 Mountain Drive").append("city", "Gotham"));
 
 		WithNullableUnwrapped target = converter.read(WithNullableUnwrapped.class, source);
 
@@ -2381,9 +2384,9 @@ class MappingMongoConverterUnitTests {
 		converter.write(source, target);
 
 		assertThat(target) //
-				.containsEntry("address", new org.bson.Document("street", "1007 Mountain Drive").append("city", "Gotham")) //
+				.containsEntry("address", new org.bson.Document("s", "1007 Mountain Drive").append("city", "Gotham")) //
 				.doesNotContainKey("street") //
-				.doesNotContainKey("address.street") //
+				.doesNotContainKey("address.s") //
 				.doesNotContainKey("city") //
 				.doesNotContainKey("address.city");
 	}
@@ -2636,6 +2639,80 @@ class MappingMongoConverterUnitTests {
 		assertThat(accessor.getDocument()).isEqualTo(new org.bson.Document("pName", new org.bson.Document("_id", id.toString())));
 	}
 
+	@Test // GH-2860
+	void projectShouldReadSimpleInterfaceProjection() {
+
+		org.bson.Document source = new org.bson.Document("birthDate", new LocalDate(1999, 12, 1).toDate()).append("foo",
+				"Walter");
+
+		EntityProjectionIntrospector discoverer = EntityProjectionIntrospector.create(converter.getFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjectionIntrospector.EntityProjection<PersonProjection, Person> projection = discoverer
+				.introspect(PersonProjection.class, Person.class);
+		PersonProjection person = converter.project(projection, source);
+
+		assertThat(person.getBirthDate()).isEqualTo(new LocalDate(1999, 12, 1));
+		assertThat(person.getFirstname()).isEqualTo("Walter");
+	}
+
+	@Test // GH-2860
+	void projectShouldReadSimpleDtoProjection() {
+
+		org.bson.Document source = new org.bson.Document("birthDate", new LocalDate(1999, 12, 1).toDate()).append("foo",
+				"Walter");
+
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjectionIntrospector.EntityProjection<PersonDto, Person> projection = introspector
+				.introspect(PersonDto.class, Person.class);
+		PersonDto person = converter.project(projection, source);
+
+		assertThat(person.getBirthDate()).isEqualTo(new LocalDate(1999, 12, 1));
+		assertThat(person.getFirstname()).isEqualTo("Walter");
+	}
+
+	@Test // GH-2860
+	void projectShouldReadNestedProjection() {
+
+		org.bson.Document source = new org.bson.Document("addresses",
+				Collections.singletonList(new org.bson.Document("s", "hwy")));
+
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjectionIntrospector.EntityProjection<WithNestedProjection, Person> projection = introspector
+				.introspect(WithNestedProjection.class, Person.class);
+		WithNestedProjection person = converter.project(projection, source);
+
+		assertThat(person.getAddresses()).extracting(AddressProjection::getStreet).hasSize(1).containsOnly("hwy");
+	}
+
+	@Test // GH-2860
+	void projectShouldReadProjectionWithNestedEntity() {
+
+		org.bson.Document source = new org.bson.Document("addresses",
+				Collections.singletonList(new org.bson.Document("s", "hwy")));
+
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjectionIntrospector.EntityProjection<ProjectionWithNestedEntity, Person> projection = introspector
+				.introspect(ProjectionWithNestedEntity.class, Person.class);
+		ProjectionWithNestedEntity person = converter.project(projection, source);
+
+		assertThat(person.getAddresses()).extracting(Address::getStreet).hasSize(1).containsOnly("hwy");
+	}
+
 	static class GenericType<T> {
 		T content;
 	}
@@ -2666,7 +2743,9 @@ class MappingMongoConverterUnitTests {
 	}
 
 	@EqualsAndHashCode
+	@Getter
 	static class Address implements InterfaceType {
+		@Field("s")
 		String street;
 		String city;
 	}
@@ -2693,6 +2772,54 @@ class MappingMongoConverterUnitTests {
 		@PersistenceConstructor
 		public Person(Set<Address> addresses) {
 			this.addresses = addresses;
+		}
+	}
+
+	interface PersonProjection {
+
+		LocalDate getBirthDate();
+
+		String getFirstname();
+	}
+
+	interface WithNestedProjection {
+
+		Set<AddressProjection> getAddresses();
+	}
+
+	interface ProjectionWithNestedEntity {
+
+		Set<Address> getAddresses();
+	}
+
+	interface AddressProjection {
+
+		String getStreet();
+	}
+
+	static class PersonDto {
+
+		LocalDate birthDate;
+
+		@Field("foo") String firstname;
+		String lastname;
+
+		public PersonDto(LocalDate birthDate, String firstname, String lastname) {
+			this.birthDate = birthDate;
+			this.firstname = firstname;
+			this.lastname = lastname;
+		}
+
+		public LocalDate getBirthDate() {
+			return birthDate;
+		}
+
+		public String getFirstname() {
+			return firstname;
+		}
+
+		public String getLastname() {
+			return lastname;
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2645,7 +2645,7 @@ class MappingMongoConverterUnitTests {
 		org.bson.Document source = new org.bson.Document("birthDate", new LocalDate(1999, 12, 1).toDate()).append("foo",
 				"Walter");
 
-		EntityProjectionIntrospector discoverer = EntityProjectionIntrospector.create(converter.getFactory(),
+		EntityProjectionIntrospector discoverer = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
 				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
@@ -2664,7 +2664,7 @@ class MappingMongoConverterUnitTests {
 		org.bson.Document source = new org.bson.Document("birthDate", new LocalDate(1999, 12, 1).toDate()).append("foo",
 				"Walter");
 
-		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
 				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
@@ -2683,7 +2683,7 @@ class MappingMongoConverterUnitTests {
 		org.bson.Document source = new org.bson.Document("addresses",
 				Collections.singletonList(new org.bson.Document("s", "hwy")));
 
-		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
 				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);
@@ -2701,7 +2701,7 @@ class MappingMongoConverterUnitTests {
 		org.bson.Document source = new org.bson.Document("addresses",
 				Collections.singletonList(new org.bson.Document("s", "hwy")));
 
-		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getFactory(),
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
 				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
 						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
 				mappingContext);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactoryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/MongoRepositoryFactoryUnitTests.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -32,6 +34,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.repository.Person;
 import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.Repository;
 
 /**
@@ -40,6 +43,7 @@ import org.springframework.data.repository.Repository;
  * @author Oliver Gierke
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class MongoRepositoryFactoryUnitTests {
 
 	@Mock MongoTemplate template;
@@ -55,6 +59,7 @@ public class MongoRepositoryFactoryUnitTests {
 	public void setUp() {
 		when(template.getConverter()).thenReturn(converter);
 		when(converter.getMappingContext()).thenReturn(mappingContext);
+		when(converter.getProjectionFactory()).thenReturn(new SpelAwareProxyProjectionFactory());
 	}
 
 	@Test


### PR DESCRIPTION
`MappingMongoConverter` now is able to materialize projections without creating intermediate entities. That allows bypassing nullability restrictions of entities when e.g. using Kotlin. Interface projections are always backed by a `Map`, DTO projections use the target class to merge its metadata with the domain type metadata to e.g. allow overrides of field names.

Depends on spring-projects/spring-data-commons#2420