### PR TITLE
Retain sort order when using text search sort by score.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3896-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3896-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3896-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3896-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/TextQueryUnitTests.java
@@ -17,8 +17,9 @@ package org.springframework.data.mongodb.core.query;
 
 import static org.springframework.data.mongodb.test.util.Assertions.*;
 
-import org.junit.jupiter.api.Test;
+import java.util.Map.Entry;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
@@ -92,6 +93,30 @@ public class TextQueryUnitTests {
 		assertThat(query.getQueryObject()).containsEntry("$text.$search", QUERY);
 		assertThat(query.getFieldsObject()).containsKeys("customFieldForScore");
 		assertThat(query.getSortObject()).containsKey("customFieldForScore");
+	}
+
+	@Test // GH-3896
+	public void retainsSortOrderWhenUsingScore() {
+
+		TextQuery query = new TextQuery(QUERY);
+		query.with(Sort.by(Direction.DESC, "one"));
+		query.sortByScore();
+		query.with(Sort.by(Direction.DESC, "two"));
+
+		assertThat(query.getSortObject().entrySet().stream().map(Entry::getKey)).containsExactly("one", "score", "two");
+
+		query = new TextQuery(QUERY);
+		query.with(Sort.by(Direction.DESC, "one"));
+		query.sortByScore();
+
+		assertThat(query.getSortObject().entrySet().stream().map(Entry::getKey)).containsExactly("one", "score");
+
+		query = new TextQuery(QUERY);
+		query.sortByScore();
+		query.with(Sort.by(Direction.DESC, "one"));
+		query.with(Sort.by(Direction.DESC, "two"));
+
+		assertThat(query.getSortObject().entrySet().stream().map(Entry::getKey)).containsExactly("score", "one", "two");
 	}
 
 }


### PR DESCRIPTION
We now make sure to capture the position to apply sort by score.