### PR TITLE
Handling collections and map types before running an element converter

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -2032,10 +2032,6 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			Assert.notNull(source, "Source must not be null");
 			Assert.notNull(typeHint, "TypeInformation must not be null");
 
-			if (conversions.hasCustomReadTarget(source.getClass(), typeHint.getType())) {
-				return (S) elementConverter.convert(source, typeHint);
-			}
-
 			if (source instanceof Collection) {
 
 				Class<?> rawType = typeHint.getType();
@@ -2063,6 +2059,10 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 				throw new IllegalArgumentException(
 						String.format("Expected map like structure but found %s", source.getClass()));
+			}
+
+			if (conversions.hasCustomReadTarget(source.getClass(), typeHint.getType())) {
+				return (S) elementConverter.convert(source, typeHint);
 			}
 
 			if (source instanceof DBRef) {


### PR DESCRIPTION
When the custom conversions are checked before collection and map converters, it is not possible to use custom converters for lists and maps.
If a custom converter for a list or a map is defined, it is executed here and not from within the `collectionConverter` where it should be executed.
So I think collections and maps should be handled beforehand.
Maybe lines 2064-2066 might not be needed ad all as this case is covered with line 2081.