### PR TITLE
Avoid creating invalid index definitions for `Map`-like properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3914-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3914-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3914-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3914-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexResolver.java
@@ -25,6 +25,15 @@ import org.springframework.util.Assert;
 
 /**
  * {@link IndexResolver} finds those {@link IndexDefinition}s to be created for a given class.
+ * <p>
+ * The {@link IndexResolver} considers index annotations like {@link Indexed}, {@link GeoSpatialIndexed},
+ * {@link HashIndexed}, {@link TextIndexed} and {@link WildcardIndexed} on properties as well as {@link CompoundIndex}
+ * and {@link WildcardIndexed} on types.
+ * <p>
+ * Unless specified otherwise the index name will be created out of the keys/path involved in the index. <br />
+ * {@link TextIndexed} properties are collected into a single index that covers the detected fields. <br />
+ * {@link java.util.Map} like structures, unless annotated with {@link WildcardIndexed}, are skipped because the
+ * {@link java.util.Map.Entry#getKey() map key}, which cannot be resolved from static metadata, needs to be part of the index.
  *
  * @author Christoph Strobl
  * @author Thomas Darimont

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
@@ -158,6 +158,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 			List<IndexDefinitionHolder> indexes, CycleGuard guard) {
 
 		try {
+			if (isMapWithoutWildcardIndex(persistentProperty)) {
+				return;
+			}
+
 			if (persistentProperty.isEntity()) {
 				indexes.addAll(resolveIndexForEntity(mappingContext.getPersistentEntity(persistentProperty),
 						persistentProperty.isUnwrapped() ? "" : persistentProperty.getFieldName(), Path.of(persistentProperty),
@@ -219,6 +223,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 
 		Path propertyPath = path.append(persistentProperty);
 		guard.protect(persistentProperty, propertyPath);
+
+		if (isMapWithoutWildcardIndex(persistentProperty)) {
+			return;
+		}
 
 		if (persistentProperty.isEntity()) {
 			try {
@@ -347,6 +355,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 
 				if (persistentProperty.isExplicitLanguageProperty() && dotPath.isEmpty()) {
 					indexDefinitionBuilder.withLanguageOverride(persistentProperty.getFieldName());
+				}
+
+				if(persistentProperty.isMap()) {
+					return;
 				}
 
 				TextIndexed indexed = persistentProperty.findAnnotation(TextIndexed.class);
@@ -799,6 +811,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 		}
 
 		return expression.getValue(evaluationContext, Object.class);
+	}
+
+	private static boolean isMapWithoutWildcardIndex(MongoPersistentProperty property) {
+		return property.isMap() && !property.isAnnotationPresent(WildcardIndexed.class);
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
@@ -1393,6 +1393,15 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 			});
 		}
 
+		@Test // GH-3914
+		public void shouldSkipMapStructuresUnlessAnnotatedWithWildcardIndex() {
+
+			List<IndexDefinitionHolder> indexDefinitions = prepareMappingContextAndResolveIndexForType(
+					WithMapStructures.class);
+
+			assertThat(indexDefinitions).hasSize(1);
+		}
+
 		@Document
 		class MixedIndexRoot {
 
@@ -1624,6 +1633,17 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 
 		class GenericEntityWrapper<T> {
 			T entity;
+		}
+
+		@Document
+		class WithMapStructures {
+			Map<String, ValueObject> rootMap;
+			NestedInMapWithStructures nested;
+			ValueObject plainValue;
+		}
+
+		class NestedInMapWithStructures {
+			Map<String, ValueObject> nestedMap;
 		}
 
 		@Document

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -402,11 +402,16 @@ Indexes are automatically created for the initial entity set on application star
 
 We generally recommend explicit index creation for application-based control of indexes as Spring Data cannot automatically create indexes for collections that were recreated while the application was running.
 
-`IndexResolver` provides an abstraction for programmatic index definition creation if you want to make use of `@Indexed` annotations such as `@GeoSpatialIndexed`, `@TextIndexed`, `@CompoundIndex`.
+`IndexResolver` provides an abstraction for programmatic index definition creation if you want to make use of `@Indexed` annotations such as `@GeoSpatialIndexed`, `@TextIndexed`, `@CompoundIndex` and `@WildcardIndexed`.
 You can use index definitions with `IndexOperations` to create indexes.
 A good point in time for index creation is on application startup, specifically after the application context was refreshed, triggered by observing `ContextRefreshedEvent`.
 This event guarantees that the context is fully initialized.
 Note that at this time other components, especially bean factories might have access to the MongoDB database.
+
+[WARNING]
+===
+`Map` like structures, unless annotated with `@WildcardIndexed`, are skipped by the `IndexResolver` because the _map key_, which cannot be resolved from static metadata, needs to be part of the index definition.
+===
 
 .Programmatic Index Creation for a single Domain Type
 ====


### PR DESCRIPTION
This commit makes sure to exclude `Map` like structures from index inspection unless annotated with `@WilcardIndexed`.

Resolves: #3914, #3901