### PR TITLE
Avoid schema keyId uuid representation errors. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3929-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3929-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3929-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3929-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/encryption/EncryptionUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/encryption/EncryptionUtils.java
@@ -26,6 +26,7 @@ import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.Base64Utils;
 
 /**
  * Internal utility class for dealing with encryption related matters.
@@ -65,7 +66,8 @@ public final class EncryptionUtils {
 			return new Binary(BsonBinarySubType.UUID_STANDARD,
 					new BsonBinary(UUID.fromString(potentialKeyId.toString())).getData());
 		} catch (IllegalArgumentException e) {
-			return new Binary(BsonBinarySubType.UUID_STANDARD, org.bson.internal.Base64.decode(potentialKeyId.toString()));
+
+			return new Binary(BsonBinarySubType.UUID_STANDARD, Base64Utils.decodeFromString(potentialKeyId.toString()));
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/encryption/EncryptionUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/encryption/EncryptionUtils.java
@@ -35,8 +35,7 @@ public final class EncryptionUtils {
 	/**
 	 * Resolve a given plain {@link String} value into the store native {@literal keyId} format, considering potential
 	 * {@link Expression expressions}. <br />
-	 * The potential keyId is probed against an {@link UUID#fromString(String) UUID value} and the {@literal base64}
-	 * encoded {@code $binary} representation.
+	 * The potential keyId is converted to the  {@literal base64} encoded {@code $binary} representation.
 	 *
 	 * @param value the source value to resolve the keyId for. Must not be {@literal null}.
 	 * @param evaluationContext a {@link Supplier} used to provide the {@link EvaluationContext} in case an
@@ -57,11 +56,8 @@ public final class EncryptionUtils {
 				return potentialKeyId;
 			}
 		}
-		try {
-			return UUID.fromString(potentialKeyId.toString());
-		} catch (IllegalArgumentException e) {
-			return org.bson.Document.parse("{ val : { $binary : { base64 : '" + potentialKeyId + "', subType : '04'} } }")
+
+		return org.bson.Document.parse("{ val : { $binary : { base64 : '" + potentialKeyId + "', subType : '04'} } }")
 					.get("val");
-		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,7 +108,7 @@ public class MappingMongoJsonSchemaCreatorUnitTests {
 				.createSchemaFor(Patient.class);
 
 		Document targetSchema = schema.schemaDocument();
-		assertThat(targetSchema).isEqualTo(Document.parse(PATIENT));
+		assertThat(targetSchema.toBsonDocument()).isEqualTo(BsonDocument.parse(PATIENT));
 	}
 
 	@Test // GH-3800
@@ -136,7 +137,7 @@ public class MappingMongoJsonSchemaCreatorUnitTests {
 				.filter(MongoJsonSchemaCreator.encryptedOnly()) //
 				.createSchemaFor(EncryptionMetadataFromProperty.class);
 
-		assertThat(schema.schemaDocument()).isEqualTo(Document.parse(ENC_FROM_PROPERTY_SCHEMA));
+		assertThat(schema.schemaDocument().toBsonDocument()).isEqualTo(BsonDocument.parse(ENC_FROM_PROPERTY_SCHEMA));
 	}
 
 	@Test // GH-3800
@@ -154,7 +155,7 @@ public class MappingMongoJsonSchemaCreatorUnitTests {
 				.filter(MongoJsonSchemaCreator.encryptedOnly()) //
 				.createSchemaFor(EncryptionMetadataFromMethod.class);
 
-		assertThat(schema.schemaDocument()).isEqualTo(Document.parse(ENC_FROM_METHOD_SCHEMA));
+		assertThat(schema.schemaDocument().toBsonDocument()).isEqualTo(BsonDocument.parse(ENC_FROM_METHOD_SCHEMA));
 	}
 
 	// --> TYPES AND JSON

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
@@ -393,7 +393,7 @@ public class MappingMongoJsonSchemaCreatorUnitTests {
 	}
 
 	static final String ENC_FROM_PROPERTY_ENTITY_KEY = "C5a5aMB7Ttq4wSJTFeRn8g==";
-	static final String ENC_FROM_PROPERTY_PROPOERTY_KEY = "Mw6mdTVPQfm4quqSCLVB3g=";
+	static final String ENC_FROM_PROPERTY_PROPOERTY_KEY = "Mw6mdTVPQfm4quqSCLVB3g==";
 	static final String ENC_FROM_PROPERTY_SCHEMA = "{" + //
 			"  'encryptMetadata': {" + //
 			"    'keyId': [" + //


### PR DESCRIPTION
To avoid driver configuration specific `UUID` representation format errors (binary subtype 3 vs. subtype 4) we now directly convert the given key into its subtype 4 format.