### PR TITLE
prevent duplicated queries for external references

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultReferenceResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DefaultReferenceResolver.java
@@ -42,11 +42,10 @@ public class DefaultReferenceResolver implements ReferenceResolver {
 	private final LazyLoadingProxyFactory proxyFactory;
 
 	private final LookupFunction collectionLookupFunction = (filter, ctx) -> getReferenceLoader().fetchMany(filter, ctx);
-	private final LookupFunction singleValueLookupFunction = (filter, ctx) -> {
-		Document target = getReferenceLoader().fetchOne(filter, ctx);
-		return target == null ? Collections.emptyList() : Collections.singleton(target);
+	private final ReferenceLookupDelegate.LookupFunction singleValueLookupFunction = (filter, ctx) -> {
+        	Document target = getReferenceLoader().fetchOne(filter, ctx);
+	        return target == null ? Collections.emptyList() : Collections.singleton(target);
 	};
-
 	/**
 	 * Create a new instance of {@link DefaultReferenceResolver}.
 	 *


### PR DESCRIPTION
When loading an entity with an external reference, the reference is fetched twice.
Previous implementation call 'getReferenceLoader().fetchOne(filter, ctx)'  twice

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
