### PR TITLE
Update list of supported query method keywords.

### DIFF
--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -283,8 +283,8 @@ lower / upper bounds (`$gt` / `$gte` & `$lt` / `$lte`) according to `Range`
 | `{"location" : {"$exists" : exists }}`
 
 | `IgnoreCase`
-| `findByFirstnameIgnoreCase(String firstname)`
-| `{"firstname" : {"$strcasecmp" : firstname }}`
+| `findByUsernameIgnoreCase(String username)`
+| `{"username" : {"$strcasecmp" : username }}`
 |===
 
 NOTE: If the property criterion compares a document, the order of the fields and exact equality in the document matters.

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -281,6 +281,10 @@ lower / upper bounds (`$gt` / `$gte` & `$lt` / `$lte`) according to `Range`
 | `Exists`
 | `findByLocationExists(boolean exists)`
 | `{"location" : {"$exists" : exists }}`
+
+| `IgnoreCase`
+| `findByFirstnameIgnoreCase(String firstname)`
+| `{"firstname" : {"$strcasecmp" : firstname }}`
 |===
 
 NOTE: If the property criterion compares a document, the order of the fields and exact equality in the document matters.

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -284,7 +284,7 @@ lower / upper bounds (`$gt` / `$gte` & `$lt` / `$lte`) according to `Range`
 
 | `IgnoreCase`
 | `findByUsernameIgnoreCase(String username)`
-| `{"username" : {"$strcasecmp" : username }}`
+| `{"username" : {"$regex" : "^username$", "$options" : "i" }}`
 |===
 
 NOTE: If the property criterion compares a document, the order of the fields and exact equality in the document matters.


### PR DESCRIPTION
Fix for #3916.
- included `@IgnoreCase` to mongodb.repositories.queries query table documentation.