### PR TITLE
Allow to estimate document count. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3522-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3522-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3522-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-3522-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -1179,8 +1179,11 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *          {@literal null}.
 	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
 	 * @return the count of matching documents.
+	 * @since 3.4
 	 */
-	long count(Query query, Class<?> entityClass);
+	default long preciseCount(Query query, Class<?> entityClass) {
+		return preciseCount(query, entityClass, getCollectionName(entityClass));
+	}
 
 	/**
 	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
@@ -1196,6 +1199,71 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * aggregation execution} even for empty {@link Query queries} which may have an impact on performance, but guarantees
 	 * shard, session and transaction compliance. In case an inaccurate count satisfies the applications needs use
 	 * {@link #estimatedCount(String)} for empty queries instead.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents.
+	 * @param collectionName must not be {@literal null} or empty.
+	 * @return the count of matching documents.
+	 * @see #count(Query, Class, String)
+	 * @since 3.4
+	 */
+	default long preciseCount(Query query, String collectionName) {
+		return preciseCount(query, null, collectionName);
+	}
+
+	/**
+	 * Returns the number of documents for the given {@link Query} by querying the given collection using the given entity
+	 * class to map the given {@link Query}. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method uses an
+	 * {@link com.mongodb.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} even for empty {@link Query queries} which may have an impact on performance, but guarantees
+	 * shard, session and transaction compliance. In case an inaccurate count satisfies the applications needs use
+	 * {@link #estimatedCount(String)} for empty queries instead.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
+	 *          {@literal null}.
+	 * @param entityClass the parametrized type. Can be {@literal null}.
+	 * @param collectionName must not be {@literal null} or empty.
+	 * @return the count of matching documents.
+	 * @since 3.4
+	 */
+	long preciseCount(Query query, @Nullable Class<?> entityClass, String collectionName);
+
+	/**
+	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.
+	 * <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
+	 * {@link com.mongodb.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} which may have an impact on performance.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
+	 *          {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @return the count of matching documents.
+	 */
+	long count(Query query, Class<?> entityClass);
+
+	/**
+	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
+	 * must solely consist of document field references as we lack type information to map potential property references
+	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
+	 * {@link com.mongodb.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} which may have an impact on performance.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents.
 	 * @param collectionName must not be {@literal null} or empty.
@@ -1241,11 +1309,9 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
 	 * count all matches.
 	 * <br />
-	 * This method uses an
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
 	 * {@link com.mongodb.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
-	 * aggregation execution} even for empty {@link Query queries} which may have an impact on performance, but guarantees
-	 * shard, session and transaction compliance. In case an inaccurate count satisfies the applications needs use
-	 * {@link #estimatedCount(String)} for empty queries instead.
+	 * aggregation execution} which may have an impact on performance.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -1181,8 +1181,8 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * @return the count of matching documents.
 	 * @since 3.4
 	 */
-	default long preciseCount(Query query, Class<?> entityClass) {
-		return preciseCount(query, entityClass, getCollectionName(entityClass));
+	default long exactCount(Query query, Class<?> entityClass) {
+		return exactCount(query, entityClass, getCollectionName(entityClass));
 	}
 
 	/**
@@ -1206,8 +1206,8 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * @see #count(Query, Class, String)
 	 * @since 3.4
 	 */
-	default long preciseCount(Query query, String collectionName) {
-		return preciseCount(query, null, collectionName);
+	default long exactCount(Query query, String collectionName) {
+		return exactCount(query, null, collectionName);
 	}
 
 	/**
@@ -1231,7 +1231,7 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * @return the count of matching documents.
 	 * @since 3.4
 	 */
-	long preciseCount(Query query, @Nullable Class<?> entityClass, String collectionName);
+	long exactCount(Query query, @Nullable Class<?> entityClass, String collectionName);
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -953,8 +953,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * @return the count of matching documents.
 	 * @since 3.4
 	 */
-	default Mono<Long> preciseCount(Query query, Class<?> entityClass) {
-		return preciseCount(query, entityClass, getCollectionName(entityClass));
+	default Mono<Long> exactCount(Query query, Class<?> entityClass) {
+		return exactCount(query, entityClass, getCollectionName(entityClass));
 	}
 
 	/**
@@ -978,8 +978,8 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * @see #count(Query, Class, String)
 	 * @since 3.4
 	 */
-	default Mono<Long> preciseCount(Query query, String collectionName) {
-		return preciseCount(query, null, collectionName);
+	default Mono<Long> exactCount(Query query, String collectionName) {
+		return exactCount(query, null, collectionName);
 	}
 
 	/**
@@ -1003,7 +1003,7 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * @return the count of matching documents.
 	 * @since 3.4
 	 */
-	Mono<Long> preciseCount(Query query, @Nullable Class<?> entityClass, String collectionName);
+	Mono<Long> exactCount(Query query, @Nullable Class<?> entityClass, String collectionName);
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -951,8 +951,11 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 *          {@literal null}.
 	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
 	 * @return the count of matching documents.
+	 * @since 3.4
 	 */
-	Mono<Long> count(Query query, Class<?> entityClass);
+	default Mono<Long> preciseCount(Query query, Class<?> entityClass) {
+		return preciseCount(query, entityClass, getCollectionName(entityClass));
+	}
 
 	/**
 	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
@@ -973,8 +976,11 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * @param collectionName must not be {@literal null} or empty.
 	 * @return the count of matching documents.
 	 * @see #count(Query, Class, String)
+	 * @since 3.4
 	 */
-	Mono<Long> count(Query query, String collectionName);
+	default Mono<Long> preciseCount(Query query, String collectionName) {
+		return preciseCount(query, null, collectionName);
+	}
 
 	/**
 	 * Returns the number of documents for the given {@link Query} by querying the given collection using the given entity
@@ -989,6 +995,66 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 * aggregation execution} even for empty {@link Query queries} which may have an impact on performance, but guarantees
 	 * shard, session and transaction compliance. In case an inaccurate count satisfies the applications needs use
 	 * {@link #estimatedCount(String)} for empty queries instead.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
+	 *          {@literal null}.
+	 * @param entityClass the parametrized type. Can be {@literal null}.
+	 * @param collectionName must not be {@literal null} or empty.
+	 * @return the count of matching documents.
+	 * @since 3.4
+	 */
+	Mono<Long> preciseCount(Query query, @Nullable Class<?> entityClass, String collectionName);
+
+	/**
+	 * Returns the number of documents for the given {@link Query} by querying the collection of the given entity class.
+	 * <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
+	 * {@link com.mongodb.reactivestreams.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} which may have an impact on performance.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
+	 *          {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @return the count of matching documents.
+	 */
+	Mono<Long> count(Query query, Class<?> entityClass);
+
+	/**
+	 * Returns the number of documents for the given {@link Query} querying the given collection. The given {@link Query}
+	 * must solely consist of document field references as we lack type information to map potential property references
+	 * onto document fields. Use {@link #count(Query, Class, String)} to get full type specific support. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
+	 * {@link com.mongodb.reactivestreams.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} which may have an impact on performance.
+	 *
+	 * @param query the {@link Query} class that specifies the criteria used to find documents.
+	 * @param collectionName must not be {@literal null} or empty.
+	 * @return the count of matching documents.
+	 * @see #count(Query, Class, String)
+	 */
+	Mono<Long> count(Query query, String collectionName);
+
+	/**
+	 * Returns the number of documents for the given {@link Query} by querying the given collection using the given entity
+	 * class to map the given {@link Query}. <br />
+	 * <strong>NOTE:</strong> Query {@link Query#getSkip() offset} and {@link Query#getLimit() limit} can have direct
+	 * influence on the resulting number of documents found as those values are passed on to the server and potentially
+	 * limit the range and order within which the server performs the count operation. Use an {@literal unpaged} query to
+	 * count all matches.
+	 * <br />
+	 * This method may choose to use {@link #estimatedCount(Class)} for empty queries instead of running an
+	 * {@link com.mongodb.reactivestreams.client.MongoCollection#countDocuments(org.bson.conversions.Bson, com.mongodb.client.model.CountOptions)
+	 * aggregation execution} which may have an impact on performance.
 	 *
 	 * @param query the {@link Query} class that specifies the criteria used to find documents. Must not be
 	 *          {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -189,6 +190,8 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	private @Nullable ReactiveMongoPersistentEntityIndexCreator indexCreator;
 
 	private SessionSynchronization sessionSynchronization = SessionSynchronization.ON_ACTUAL_TRANSACTION;
+
+	private CountExecution countExecution = this::doPreciseCount;
 
 	/**
 	 * Constructor used for a basic template configuration.
@@ -367,6 +370,49 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 
 		Assert.notNull(entityCallbacks, "EntityCallbacks must not be null!");
 		this.entityCallbacks = entityCallbacks;
+	}
+
+	/**
+	 * En-/Disable usage of estimated count.
+	 *
+	 * @param enabled if {@literal true} {@link com.mongodb.client.MongoCollection#estimatedDocumentCount()} ()} will we used for unpaged,
+	 *          empty {@link Query queries}.
+	 * @since 3.4
+	 */
+	public void useEstimatedCount(boolean enabled) {
+		useEstimatedCount(enabled, this::countCanBeEstimated);
+	}
+
+	/**
+	 * En-/Disable usage of estimated count based on the given {@link BiPredicate estimationFilter}.
+	 *
+	 * @param enabled if {@literal true} {@link com.mongodb.client.MongoCollection#estimatedDocumentCount()} will we used for {@link Document
+	 *          filter queries} that pass the given {@link BiPredicate estimationFilter}.
+	 * @param estimationFilter the {@link BiPredicate filter}.
+	 * @since 3.4
+	 */
+	public void useEstimatedCount(boolean enabled, BiFunction<Document, CountOptions, Mono<Boolean>> estimationFilter) {
+
+		if (enabled) {
+
+			this.countExecution = (collectionName, filter, options) -> {
+
+				return estimationFilter.apply(filter, options).flatMap(canEstimate -> {
+					if (!canEstimate) {
+						return doPreciseCount(collectionName, filter, options);
+					}
+
+					EstimatedDocumentCountOptions estimatedDocumentCountOptions = new EstimatedDocumentCountOptions();
+					if (options.getMaxTime(TimeUnit.MILLISECONDS) > 0) {
+						estimatedDocumentCountOptions.maxTime(options.getMaxTime(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+					}
+
+					return doEstimatedCount(collectionName, estimatedDocumentCountOptions);
+				});
+			};
+		} else {
+			this.countExecution = this::doPreciseCount;
+		}
 	}
 
 	/**
@@ -1189,6 +1235,17 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 				entityClass);
 	}
 
+	@Override
+	public Mono<Long> preciseCount(Query query, @Nullable Class<?> entityClass, String collectionName) {
+
+		CountContext countContext = queryOperations.countQueryContext(query);
+
+		CountOptions options = countContext.getCountOptions(entityClass);
+		Document mappedQuery = countContext.getMappedQuery(entityClass, mappingContext::getPersistentEntity);
+
+		return doPreciseCount(collectionName, mappedQuery, options);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mongodb.core.ReactiveMongoOperations#count(org.springframework.data.mongodb.core.query.Query, java.lang.Class)
@@ -1252,13 +1309,34 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	 */
 	protected Mono<Long> doCount(String collectionName, Document filter, CountOptions options) {
 
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER
+					.debug(String.format("Executing count: %s in collection: %s", serializeToJsonSafely(filter), collectionName));
+		}
+
+		return countExecution.countDocuments(collectionName, filter, options);
+	}
+
+	protected Mono<Long> doPreciseCount(String collectionName, Document filter, CountOptions options) {
+
 		return createMono(collectionName,
 				collection -> collection.countDocuments(CountQuery.of(filter).toQueryDocument(), options));
 	}
 
 	protected Mono<Long> doEstimatedCount(String collectionName, EstimatedDocumentCountOptions options) {
-
 		return createMono(collectionName, collection -> collection.estimatedDocumentCount(options));
+	}
+
+	protected Mono<Boolean> countCanBeEstimated(Document filter, CountOptions options) {
+
+		if(!filter.isEmpty() || !isEmptyOptions(options)) {
+			return Mono.just(false);
+		}
+		return ReactiveMongoDatabaseUtils.isTransactionActive(getMongoDatabaseFactory()).map(it -> !it);
+	}
+
+	private boolean isEmptyOptions(CountOptions options) {
+		return options.getLimit() <= 0 && options.getSkip() <= 0;
 	}
 
 	/*
@@ -3444,6 +3522,11 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			// native MongoDB objects that offer methods with ClientSession must not be proxied.
 			return delegate.getMongoDatabase();
 		}
+
+		@Override
+		protected Mono<Boolean> countCanBeEstimated(Document filter, CountOptions options) {
+			return Mono.just(false);
+		}
 	}
 
 	class IndexCreatorEventListener implements ApplicationListener<MappingContextEvent<?, ?>> {
@@ -3520,5 +3603,10 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 		String getCollection() {
 			return collection;
 		}
+	}
+
+	@FunctionalInterface
+	interface CountExecution {
+		Mono<Long> countDocuments(String collection, Document filter, CountOptions options);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -2289,6 +2289,34 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 						.granularity(TimeSeriesGranularity.HOURS).toString());
 	}
 
+	@Test // GH-3522
+	void usedCountDocumentsForEmptyQueryByDefault() {
+
+		template.count(new Query(), Human.class);
+
+		verify(collection).countDocuments(any(Document.class), any());
+	}
+
+	@Test // GH-3522
+	void delegatesToEstimatedCountForEmptyQueryIfEnabled() {
+
+		template.useEstimatedCount(true);
+
+		template.count(new Query(), Human.class);
+
+		verify(collection).estimatedDocumentCount(any());
+	}
+
+	@Test // GH-3522
+	void stillUsesCountDocumentsForNonEmptyQueryEvenIfEstimationEnabled() {
+
+		template.useEstimatedCount(true);
+
+		template.count(new BasicQuery("{ 'spring' : 'data-mongodb' }"), Human.class);
+
+		verify(collection).countDocuments(any(Document.class), any());
+	}
+
 	class AutogenerateableId {
 
 		@Id BigInteger id;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -1424,6 +1424,34 @@ public class ReactiveMongoTemplateUnitTests {
 		verify(collection).estimatedDocumentCount(any());
 	}
 
+	@Test // GH-3522
+	void usedCountDocumentsForEmptyQueryByDefault() {
+
+		template.count(new Query(), Person.class).subscribe();
+
+		verify(collection).countDocuments(any(Document.class), any());
+	}
+
+	@Test // GH-3522
+	void delegatesToEstimatedCountForEmptyQueryIfEnabled() {
+
+		template.useEstimatedCount(true);
+
+		template.count(new Query(), Person.class).subscribe();
+
+		verify(collection).estimatedDocumentCount(any());
+	}
+
+	@Test // GH-3522
+	void stillUsesCountDocumentsForNonEmptyQueryEvenIfEstimationEnabled() {
+
+		template.useEstimatedCount(true);
+
+		template.count(new BasicQuery("{ 'spring' : 'data-mongodb' }"), Person.class).subscribe();
+
+		verify(collection).countDocuments(any(Document.class), any());
+	}
+
 	@Test // GH-2911
 	void insertErrorsOnPublisher() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
@@ -220,9 +220,18 @@ public class ReactiveSessionBoundMongoTemplateUnitTests {
 		verify(database).listCollectionNames(eq(clientSession));
 	}
 
-	@Test // DATAMONGO-1880
+	@Test // DATAMONGO-1880, GH-3522
 	public void countShouldUseProxiedCollection() {
 
+		template.count(new Query(), Person.class).subscribe();
+
+		verify(collection).countDocuments(eq(clientSession), any(), any(CountOptions.class));
+	}
+
+	@Test // GH-3522
+	public void countShouldDelegateToPreciseCountNoMatterWhat() {
+
+		template.useEstimatedCount(true);
 		template.count(new Query(), Person.class).subscribe();
 
 		verify(collection).countDocuments(eq(clientSession), any(), any(CountOptions.class));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveSessionBoundMongoTemplateUnitTests.java
@@ -229,7 +229,7 @@ public class ReactiveSessionBoundMongoTemplateUnitTests {
 	}
 
 	@Test // GH-3522
-	public void countShouldDelegateToPreciseCountNoMatterWhat() {
+	public void countShouldDelegateToExactCountNoMatterWhat() {
 
 		template.useEstimatedCount(true);
 		template.count(new Query(), Person.class).subscribe();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
@@ -220,9 +220,18 @@ public class SessionBoundMongoTemplateUnitTests {
 		verify(database).listCollectionNames(eq(clientSession));
 	}
 
-	@Test // DATAMONGO-1880
+	@Test // DATAMONGO-1880, GH-3522
 	public void countShouldUseProxiedCollection() {
 
+		template.count(new Query(), Person.class);
+
+		verify(collection).countDocuments(eq(clientSession), any(), any(CountOptions.class));
+	}
+
+	@Test // DATAMONGO-1880, GH-3522
+	public void countShouldDelegateToPreciseCountNoMatterWhat() {
+
+		template.useEstimatedCount(true);
 		template.count(new Query(), Person.class);
 
 		verify(collection).countDocuments(eq(clientSession), any(), any(CountOptions.class));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/SessionBoundMongoTemplateUnitTests.java
@@ -229,7 +229,7 @@ public class SessionBoundMongoTemplateUnitTests {
 	}
 
 	@Test // DATAMONGO-1880, GH-3522
-	public void countShouldDelegateToPreciseCountNoMatterWhat() {
+	public void countShouldDelegateToExactCountNoMatterWhat() {
 
 		template.useEstimatedCount(true);
 		template.count(new Query(), Person.class);

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2161,7 +2161,7 @@ If the application is fine with the limitations of working upon collection stati
 [TIP]
 ====
 By setting `MongoTemplate#useEstimatedCount(...)` to `true` _MongoTemplate#count(...)_ operations, that use an empty filter query, will be delegated to `estimatedCount`, as long as there is no transaction active and the template is not bound to a <<mongo.sessions,session>>.
-It will still be possible to obtain exact numbers via `MongoTemplate#preciseCount`, but may speed up things.
+It will still be possible to obtain exact numbers via `MongoTemplate#exactCount`, but may speed up things.
 ====
 
 [NOTE]

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -2158,6 +2158,12 @@ So in version 2.x `MongoOperations.count()` would use the collection statistics 
 As of Spring Data MongoDB 3.x any `count` operation uses regardless the existence of filter criteria the aggregation-based count approach via MongoDBs `countDocuments`.
 If the application is fine with the limitations of working upon collection statistics `MongoOperations.estimatedCount()` offers an alternative.
 
+[TIP]
+====
+By setting `MongoTemplate#useEstimatedCount(...)` to `true` _MongoTemplate#count(...)_ operations, that use an empty filter query, will be delegated to `estimatedCount`, as long as there is no transaction active and the template is not bound to a <<mongo.sessions,session>>.
+It will still be possible to obtain exact numbers via `MongoTemplate#preciseCount`, but may speed up things.
+====
+
 [NOTE]
 ====
 MongoDBs native `countDocuments` method and the `$match` aggregation, do not support `$near` and `$nearSphere` but require `$geoWithin` along with `$center` or `$centerSphere` which does not support `$minDistance` (see https://jira.mongodb.org/browse/SERVER-37043).


### PR DESCRIPTION
Introduce an option that allows users to opt in on using `estimatedDocumentCount` instead of `countDocuments` in case the used filter query is empty.