### PR TITLE
add comment geojsonpoint

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJsonPoint.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/geo/GeoJsonPoint.java
@@ -36,8 +36,8 @@ public class GeoJsonPoint extends Point implements GeoJson<List<Double>> {
 	/**
 	 * Creates {@link GeoJsonPoint} for given coordinates.
 	 *
-	 * @param x
-	 * @param y
+	 * @param x : longitude
+	 * @param y : latitude
 	 */
 	public GeoJsonPoint(double x, double y) {
 		super(x, y);


### PR DESCRIPTION
Hello, I found some discomfort while using GeoJsonPoint.
The meaning of x and y is not clear.
In my country, longitude and latitude are used more often than x and y.
I thought there would be a case like mine, so I added the following comment.
Please consider adding

thank you.
