### PR TITLE
调用mapReduce方法时不再重复获取排序配置

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1687,7 +1687,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Document mappedSort = getMappedSortObject(query, domainType);
 		if (mappedSort != null && !mappedSort.isEmpty()) {
-			mapReduce = mapReduce.sort(getMappedSortObject(query, domainType));
+			mapReduce = mapReduce.sort(mappedSort);
 		}
 
 		mapReduce = mapReduce


### PR DESCRIPTION
调用mapReduce方法中，操作判断是否有排序操作时，会获取排序配置，设置MapReduce排序配置时有重复获取，修改为使用已获取的排序配置。