### PR TITLE
Do not get sorting configuration repeatedly when calling mapReduce method

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1849,7 +1849,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		Document mappedSort = getMappedSortObject(query, domainType);
 		if (mappedSort != null && !mappedSort.isEmpty()) {
-			mapReduce = mapReduce.sort(getMappedSortObject(query, domainType));
+			mapReduce = mapReduce.sort(mappedSort);
 		}
 
 		mapReduce = mapReduce


### PR DESCRIPTION
When calling the mapReduce method, when the operation determines whether there is a sorting operation, the sorting configuration will be obtained. When setting the MapReduce sorting configuration, if there is repeated acquisition, it is modified to use the obtained sorting configuration.