### PR TITLE
add extension that can generate criteria using querydsl

### DIFF
--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
@@ -285,7 +285,7 @@ infix fun Path<String?>.regex(re: BsonRegularExpression): Criteria =
  * @since 4.0
  * @see Criteria.withinSphere
  */
-infix fun Path<GeoJson<*>>.withinSphere(circle: Circle): Criteria =
+infix fun Path<out GeoJson<*>>.withinSphere(circle: Circle): Criteria =
     Criteria(this.asName()).withinSphere(circle)
 
 /**
@@ -297,7 +297,7 @@ infix fun Path<GeoJson<*>>.withinSphere(circle: Circle): Criteria =
  * @since 4.0
  * @see Criteria.within
  */
-infix fun Path<GeoJson<*>>.within(shape: Shape): Criteria =
+infix fun Path<out GeoJson<*>>.within(shape: Shape): Criteria =
     Criteria(this.asName()).within(shape)
 
 /**
@@ -308,7 +308,7 @@ infix fun Path<GeoJson<*>>.within(shape: Shape): Criteria =
  * @since 4.0
  * @see Criteria.near
  */
-infix fun Path<GeoJson<*>>.near(point: Point): Criteria =
+infix fun Path<out GeoJson<*>>.near(point: Point): Criteria =
     Criteria(this.asName()).near(point)
 
 /**
@@ -321,7 +321,7 @@ infix fun Path<GeoJson<*>>.near(point: Point): Criteria =
  * @since 4.0
  * @see Criteria.nearSphere
  */
-infix fun Path<GeoJson<*>>.nearSphere(point: Point): Criteria =
+infix fun Path<out GeoJson<*>>.nearSphere(point: Point): Criteria =
     Criteria(this.asName()).nearSphere(point)
 
 /**
@@ -331,7 +331,7 @@ infix fun Path<GeoJson<*>>.nearSphere(point: Point): Criteria =
  * @since 4.0
  * @see Criteria.intersects
  */
-infix fun Path<GeoJson<*>>.intersects(geoJson: GeoJson<*>): Criteria =
+infix fun Path<out GeoJson<*>>.intersects(geoJson: GeoJson<*>): Criteria =
     Criteria(this.asName()).intersects(geoJson)
 
 /**

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query
+
+import java.util.regex.Pattern
+
+import org.springframework.data.geo.Circle
+import org.springframework.data.geo.Point
+import org.springframework.data.geo.Shape
+import org.springframework.data.mongodb.core.geo.GeoJson
+import org.springframework.data.mongodb.core.schema.JsonSchemaObject
+
+import com.querydsl.core.types.Path
+
+import org.bson.BsonRegularExpression
+
+/**
+ * Creates a criterion using equality.
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.isEqualTo
+ */
+infix fun <T> Path<T>.isEqualTo(value: T) =
+    Criteria(this.asName()).isEqualTo(value)
+
+/**
+ * Creates a criterion using the $ne operator.
+ *
+ * See [MongoDB Query operator: $ne](https://docs.mongodb.com/manual/reference/operator/query/ne/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.ne
+ */
+infix fun <T> Path<T>.ne(value: T): Criteria =
+    Criteria(this.asName()).ne(value)
+
+/**
+ * Creates a criterion using the $lt operator.
+ *
+ * See [MongoDB Query operator: $lt](https://docs.mongodb.com/manual/reference/operator/query/lt/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.lt
+ */
+infix fun <T> Path<T>.lt(value: T): Criteria =
+    Criteria(this.asName()).lt(value)
+
+/**
+ * Creates a criterion using the $lte operator.
+ *
+ * See [MongoDB Query operator: $lte](https://docs.mongodb.com/manual/reference/operator/query/lte/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.lte
+ */
+infix fun <T> Path<T>.lte(value: T): Criteria =
+    Criteria(this.asName()).lte(value)
+
+/**
+ * Creates a criterion using the $gt operator.
+ *
+ * See [MongoDB Query operator: $gt](https://docs.mongodb.com/manual/reference/operator/query/gt/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.gt
+ */
+infix fun <T> Path<T>.gt(value: T): Criteria =
+    Criteria(this.asName()).gt(value)
+
+/**
+ * Creates a criterion using the $gte operator.
+ *
+ * See [MongoDB Query operator: $gte](https://docs.mongodb.com/manual/reference/operator/query/gte/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.gte
+ */
+infix fun <T> Path<T>.gte(value: T): Criteria =
+    Criteria(this.asName()).gte(value)
+
+/**
+ * Creates a criterion using the $in operator.
+ *
+ * See [MongoDB Query operator: $in](https://docs.mongodb.com/manual/reference/operator/query/in/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.inValues
+ */
+fun <T> Path<T>.inValues(vararg o: Any): Criteria =
+    Criteria(this.asName()).`in`(*o)
+
+/**
+ * Creates a criterion using the $in operator.
+ *
+ * See [MongoDB Query operator: $in](https://docs.mongodb.com/manual/reference/operator/query/in/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.inValues
+ */
+infix fun <T> Path<T>.inValues(value: Collection<T>): Criteria =
+    Criteria(this.asName()).`in`(value)
+
+/**
+ * Creates a criterion using the $nin operator.
+ *
+ * See [MongoDB Query operator: $nin](https://docs.mongodb.com/manual/reference/operator/query/nin/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.nin
+ */
+fun <T> Path<T>.nin(vararg o: Any): Criteria =
+    Criteria(this.asName()).nin(*o)
+
+/**
+ * Creates a criterion using the $nin operator.
+ *
+ * See [MongoDB Query operator: $nin](https://docs.mongodb.com/manual/reference/operator/query/nin/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.nin
+ */
+infix fun <T> Path<T>.nin(value: Collection<T>): Criteria =
+    Criteria(this.asName()).nin(value)
+
+/**
+ * Creates a criterion using the $all operator.
+ *
+ * See [MongoDB Query operator: $all](https://docs.mongodb.com/manual/reference/operator/query/all/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.all
+ */
+fun Path<*>.all(vararg o: Any): Criteria =
+    Criteria(this.asName()).all(*o)
+
+/**
+ * Creates a criterion using the $all operator.
+ *
+ * See [MongoDB Query operator: $all](https://docs.mongodb.com/manual/reference/operator/query/all/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.all
+ */
+infix fun Path<*>.all(value: Collection<*>): Criteria =
+    Criteria(this.asName()).all(value)
+
+/**
+ * Creates a criterion using the $size operator.
+ *
+ * See [MongoDB Query operator: $size](https://docs.mongodb.com/manual/reference/operator/query/size/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.size
+ */
+infix fun Path<*>.size(s: Int): Criteria =
+    Criteria(this.asName()).size(s)
+
+/**
+ * Creates a criterion using the $exists operator.
+ *
+ * See [MongoDB Query operator: $exists](https://docs.mongodb.com/manual/reference/operator/query/exists/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.exists
+ */
+infix fun Path<*>.exists(b: Boolean): Criteria =
+    Criteria(this.asName()).exists(b)
+
+/**
+ * Creates a criterion using the $type operator.
+ *
+ * See [MongoDB Query operator: $type](https://docs.mongodb.com/manual/reference/operator/query/type/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.type
+ */
+infix fun Path<*>.type(t: Int): Criteria =
+    Criteria(this.asName()).type(t)
+
+/**
+ * Creates a criterion using the $type operator.
+ *
+ * See [MongoDB Query operator: $type](https://docs.mongodb.com/manual/reference/operator/query/type/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.type
+ */
+infix fun Path<*>.type(t: Collection<JsonSchemaObject.Type>): Criteria =
+    Criteria(this.asName()).type(*t.toTypedArray())
+
+/**
+ * Creates a criterion using the $type operator.
+ *
+ * See [MongoDB Query operator: $type](https://docs.mongodb.com/manual/reference/operator/query/type/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.type
+ */
+fun Path<*>.type(vararg t: JsonSchemaObject.Type): Criteria =
+    Criteria(this.asName()).type(*t)
+
+/**
+ * Creates a criterion using the $not meta operator which affects the clause directly following
+ *
+ * See [MongoDB Query operator: $not](https://docs.mongodb.com/manual/reference/operator/query/not/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.not
+ */
+fun Path<*>.not(): Criteria =
+    Criteria(this.asName()).not()
+
+/**
+ * Creates a criterion using a $regex operator.
+ *
+ * See [MongoDB Query operator: $regex](https://docs.mongodb.com/manual/reference/operator/query/regex/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.regex
+ */
+infix fun Path<String?>.regex(re: String): Criteria =
+    Criteria(this.asName()).regex(re, null)
+
+/**
+ * Creates a criterion using a $regex and $options operator.
+ *
+ * See [MongoDB Query operator: $regex](https://docs.mongodb.com/manual/reference/operator/query/regex/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.regex
+ */
+fun Path<String?>.regex(re: String, options: String?): Criteria =
+    Criteria(this.asName()).regex(re, options)
+
+/**
+ * Syntactical sugar for [isEqualTo] making obvious that we create a regex predicate.
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.regex
+ */
+infix fun Path<String?>.regex(re: Regex): Criteria =
+    Criteria(this.asName()).regex(re.toPattern())
+
+/**
+ * Syntactical sugar for [isEqualTo] making obvious that we create a regex predicate.
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.regex
+ */
+infix fun Path<String?>.regex(re: Pattern): Criteria =
+    Criteria(this.asName()).regex(re)
+
+/**
+ * Syntactical sugar for [isEqualTo] making obvious that we create a regex predicate.
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.regex
+ */
+infix fun Path<String?>.regex(re: BsonRegularExpression): Criteria =
+    Criteria(this.asName()).regex(re)
+
+/**
+ * Creates a geospatial criterion using a $geoWithin $centerSphere operation. This is only available for
+ * Mongo 2.4 and higher.
+ *
+ * See [MongoDB Query operator:
+ * $geoWithin](https://docs.mongodb.com/manual/reference/operator/query/geoWithin/)
+ *
+ * See [MongoDB Query operator:
+ * $centerSphere](https://docs.mongodb.com/manual/reference/operator/query/centerSphere/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.withinSphere
+ */
+infix fun Path<GeoJson<*>>.withinSphere(circle: Circle): Criteria =
+    Criteria(this.asName()).withinSphere(circle)
+
+/**
+ * Creates a geospatial criterion using a $geoWithin operation.
+ *
+ * See [MongoDB Query operator:
+ * $geoWithin](https://docs.mongodb.com/manual/reference/operator/query/geoWithin/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.within
+ */
+infix fun Path<GeoJson<*>>.within(shape: Shape): Criteria =
+    Criteria(this.asName()).within(shape)
+
+/**
+ * Creates a geospatial criterion using a $near operation.
+ *
+ * See [MongoDB Query operator: $near](https://docs.mongodb.com/manual/reference/operator/query/near/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.near
+ */
+infix fun Path<GeoJson<*>>.near(point: Point): Criteria =
+    Criteria(this.asName()).near(point)
+
+/**
+ * Creates a geospatial criterion using a $nearSphere operation. This is only available for Mongo 1.7 and
+ * higher.
+ *
+ * See [MongoDB Query operator:
+ * $nearSphere](https://docs.mongodb.com/manual/reference/operator/query/nearSphere/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.nearSphere
+ */
+infix fun Path<GeoJson<*>>.nearSphere(point: Point): Criteria =
+    Criteria(this.asName()).nearSphere(point)
+
+/**
+ * Creates criterion using `$geoIntersects` operator which matches intersections of the given `geoJson`
+ * structure and the documents one. Requires MongoDB 2.4 or better.
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.intersects
+ */
+infix fun Path<GeoJson<*>>.intersects(geoJson: GeoJson<*>): Criteria =
+    Criteria(this.asName()).intersects(geoJson)
+
+/**
+ * Creates a criterion using the $elemMatch operator
+ *
+ * See [MongoDB Query operator:
+ * $elemMatch](https://docs.mongodb.com/manual/reference/operator/query/elemMatch/)
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.elemMatch
+ */
+infix fun Path<*>.elemMatch(c: Criteria): Criteria =
+    Criteria(this.asName()).elemMatch(c)
+
+/**
+ * Use [Criteria.BitwiseCriteriaOperators] as gateway to create a criterion using one of the
+ * [bitwise operators](https://docs.mongodb.com/manual/reference/operator/query-bitwise/) like
+ * `$bitsAllClear`.
+ *
+ * Example:
+ * ```
+ * bits { allClear(123) }
+ * ```
+ * @author Sangyong choi
+ * @since 4.0
+ * @see Criteria.bits
+ */
+infix fun Path<*>.bits(bitwiseCriteria: Criteria.BitwiseCriteriaOperators.() -> Criteria) =
+    Criteria(this.asName()).bits().let(bitwiseCriteria)
+
+private fun Path<*>.asName(): String {
+    return this.metadata.name
+}

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensions.kt
@@ -363,5 +363,13 @@ infix fun Path<*>.bits(bitwiseCriteria: Criteria.BitwiseCriteriaOperators.() -> 
     Criteria(this.asName()).bits().let(bitwiseCriteria)
 
 private fun Path<*>.asName(): String {
-    return this.metadata.name
+    val rootName = this.root.toString()
+    val name = this.toString()
+
+    if (rootName == name) {
+        return name
+    }
+
+    // The reason add 1 is that exists "."
+    return name.substring(rootName.length + 1)
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Author.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Author.java
@@ -1,0 +1,8 @@
+package org.springframework.data.mongodb.repository;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class Author {
+    public String name;
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Book.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Book.java
@@ -1,0 +1,13 @@
+package org.springframework.data.mongodb.repository;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+public class Book {
+    public String title;
+    public Integer price;
+    public Boolean available;
+    public List<String> categories;
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Book.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Book.java
@@ -10,4 +10,5 @@ public class Book {
     public Integer price;
     public Boolean available;
     public List<String> categories;
+    public Author author;
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Building.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Building.java
@@ -1,0 +1,11 @@
+package org.springframework.data.mongodb.repository;
+
+import com.querydsl.core.annotations.QueryEntity;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+@QueryEntity
+public class Building {
+    public GeoJsonPoint location;
+}

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query
+
+import com.querydsl.core.types.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.bson.BsonRegularExpression
+import org.junit.Test
+import org.springframework.data.geo.Circle
+import org.springframework.data.geo.Point
+import org.springframework.data.mongodb.core.geo.GeoJson
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type
+import org.springframework.data.mongodb.repository.QBook
+import org.springframework.data.mongodb.repository.QBuilding
+import java.util.regex.Pattern
+
+/**
+ * Unit tests for [Criteria] extensions.
+ *
+ * @author Sangyong Choi
+ */
+class QuerydslCriteriaExtensionsTests {
+
+    @Test
+    fun `isEqualTo() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title isEqualTo "Moby-Dick"
+        val expected = Criteria("title").isEqualTo("Moby-Dick")
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `ne() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title ne "Moby-Dick"
+        val expected = Criteria("title").ne("Moby-Dick")
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `lt() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price lt 100
+        val expected = Criteria("price").lt(100)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `lte() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price lte 100
+        val expected = Criteria("price").lte(100)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `gt() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price gt 100
+        val expected = Criteria("price").gt(100)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `gte() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price gte 100
+        val expected = Criteria("price").gte(100)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `inValues(vararg) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price.inValues(1, 2, 3)
+        val expected = Criteria("price").inValues(1, 2, 3)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `inValues(list) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price inValues listOf(1, 2, 3)
+        val expected = Criteria("price").inValues(listOf(1, 2, 3))
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `nin(vararg) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price.nin(1, 2, 3)
+        val expected = Criteria("price").nin(1, 2, 3)
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `nin(list) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price nin listOf(1, 2, 3)
+        val expected = Criteria("price").nin(listOf(1, 2, 3))
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `all(vararg) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.categories.all(1, 2, 3)
+        val expected = Criteria("categories").all(1, 2, 3)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `all(list) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.categories all listOf(1, 2, 3)
+        val expected = Criteria("categories").all(listOf(1, 2, 3))
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `size() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.categories size 4
+        val expected = Criteria("categories").size(4)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `exists() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title exists true
+        val expected = Criteria("title").exists(true)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `type(Int) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title type 2
+        val expected = Criteria("title").type(2)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `type(List) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title type listOf(Type.STRING, Type.BOOLEAN)
+        val expected = Criteria("title").type(Type.STRING, Type.BOOLEAN)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `type(vararg) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title.type(Type.STRING, Type.BOOLEAN)
+        val expected = Criteria("title").type(Type.STRING, Type.BOOLEAN)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `not() should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.price.not().lt(123)
+        val expected = Criteria("price").not().lt(123)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `regex(string) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title regex "ab+c"
+        val expected = Criteria("title").regex("ab+c")
+        assertEqualCriteriaByJson(typed, expected)
+    }
+
+    @Test
+    fun `regex(string, options) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title.regex("ab+c", "g")
+        val expected = Criteria("title").regex("ab+c", "g")
+
+        assertEqualCriteriaByJson(typed, expected)
+    }
+
+    @Test
+    fun `regex(Regex) should equal expected criteria`() {
+        val book = QBook.book
+        val typed = book.title regex Regex("ab+c")
+        val expected = Criteria("title").regex(Pattern.compile("ab+c"))
+
+        assertEqualCriteriaByJson(typed, expected)
+    }
+
+    private fun assertEqualCriteriaByJson(typed: Criteria, expected: Criteria) {
+        assertThat(typed.criteriaObject.toJson()).isEqualTo(expected.criteriaObject.toJson())
+    }
+
+    @Test
+    fun `regex(Pattern) should equal expected criteria`() {
+        val book = QBook.book
+        val value = Pattern.compile("ab+c")
+        val typed = book.title regex value
+        val expected = Criteria("title").regex(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `regex(BsonRegularExpression) should equal expected criteria`() {
+        val book = QBook.book
+        val expression = BsonRegularExpression("ab+c")
+        val typed = book.title regex expression
+        val expected = Criteria("title").regex(expression)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `withinSphere() should equal expected criteria`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val value = Circle(Point(928.76, 28.345), 65.243)
+        val typed = location withinSphere value
+        val expected = Criteria("location").withinSphere(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `within() should equal expected criteria`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val value = Circle(Point(5.43421, 12.456), 52.67)
+        val typed = location within value
+        val expected = Criteria("location").within(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `near() should equal expected criteria`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val value = Point(57.431, 71.345)
+        val typed = location near value
+        val expected = Criteria("location").near(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `nearSphere() should equal expected criteria`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val value = Point(5.4321, 12.345)
+        val typed = location nearSphere value
+        val expected = Criteria("location").nearSphere(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `intersects() should equal expected criteria`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val value = GeoJsonPoint(5.481573, 51.451726)
+        val typed = location intersects value
+        val expected = Criteria("location").intersects(value)
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `maxDistance() should equal expected criteria with nearSphere`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val point = Point(0.0, 0.0)
+        val typed = location nearSphere point maxDistance 3.0
+        val expected = Criteria("location")
+            .nearSphere(point)
+            .maxDistance(3.0)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `minDistance() should equal expected criteria with nearSphere`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val point = Point(0.0, 0.0)
+        val typed = location nearSphere point minDistance 3.0
+        val expected = Criteria("location")
+            .nearSphere(point)
+            .minDistance(3.0)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `maxDistance() should equal expected criteria with near`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val point = Point(0.0, 0.0)
+        val typed = location near point maxDistance 3.0
+        val expected = Criteria("location")
+            .near(point)
+            .maxDistance(3.0)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `minDistance() should equal expected criteria with near`() {
+        val building = QBuilding.building
+        val location = building.location as Path<GeoJson<*>>
+
+        val point = Point(0.0, 0.0)
+        val typed = location near point minDistance 3.0
+        val expected = Criteria("location")
+            .near(point)
+            .minDistance(3.0)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `elemMatch() should equal expected criteria`() {
+        val book = QBook.book
+
+        val value = Criteria("price").lt(950)
+        val typed = book.title elemMatch value
+        val expected = Criteria("title").elemMatch(value)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `elemMatch(TypedCriteria) should equal expected criteria`() {
+        val book = QBook.book
+
+        val typed = book.title elemMatch (book.price lt 950)
+        val expected = Criteria("title").elemMatch(Criteria("price").lt(950))
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `bits() should equal expected criteria`() {
+        val book = QBook.book
+
+        val typed = book.title bits { allClear(123) }
+        val expected = Criteria("title").bits().allClear(123)
+
+        assertThat(typed).isEqualTo(expected)
+    }
+
+    @Test
+    fun `typed criteria inside orOperator() should equal expected criteria`() {
+        val book = QBook.book
+
+        val typed = (book.title isEqualTo "Moby-Dick").orOperator(
+            book.price lt 1200,
+            book.price gt 240
+        )
+        val expected = Criteria("title").isEqualTo("Moby-Dick")
+            .orOperator(
+                Criteria("price").lt(1200),
+                Criteria("price").gt(240)
+            )
+
+        assertThat(typed).isEqualTo(expected)
+    }
+}

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
@@ -408,4 +408,13 @@ class QuerydslCriteriaExtensionsTests {
 
         assertThat(typed).isEqualTo(expected)
     }
+
+    @Test
+    fun `isEqualTo() should equal expected criteria when nested properties`() {
+        val book = QBook.book
+        val typed = book.author.name isEqualTo "Example"
+        val expected = Criteria("author.name").isEqualTo("Example")
+
+        assertThat(typed).isEqualTo(expected)
+    }
 }

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/query/QuerydslCriteriaExtensionsTests.kt
@@ -249,10 +249,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `withinSphere() should equal expected criteria`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val value = Circle(Point(928.76, 28.345), 65.243)
-        val typed = location withinSphere value
+        val typed = building.location withinSphere value
         val expected = Criteria("location").withinSphere(value)
 
         assertThat(typed).isEqualTo(expected)
@@ -261,10 +260,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `within() should equal expected criteria`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val value = Circle(Point(5.43421, 12.456), 52.67)
-        val typed = location within value
+        val typed = building.location within value
         val expected = Criteria("location").within(value)
 
         assertThat(typed).isEqualTo(expected)
@@ -273,10 +271,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `near() should equal expected criteria`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val value = Point(57.431, 71.345)
-        val typed = location near value
+        val typed = building.location near value
         val expected = Criteria("location").near(value)
 
         assertThat(typed).isEqualTo(expected)
@@ -285,10 +282,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `nearSphere() should equal expected criteria`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val value = Point(5.4321, 12.345)
-        val typed = location nearSphere value
+        val typed = building.location nearSphere value
         val expected = Criteria("location").nearSphere(value)
 
         assertThat(typed).isEqualTo(expected)
@@ -297,10 +293,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `intersects() should equal expected criteria`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val value = GeoJsonPoint(5.481573, 51.451726)
-        val typed = location intersects value
+        val typed = building.location intersects value
         val expected = Criteria("location").intersects(value)
         assertThat(typed).isEqualTo(expected)
     }
@@ -308,10 +303,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `maxDistance() should equal expected criteria with nearSphere`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val point = Point(0.0, 0.0)
-        val typed = location nearSphere point maxDistance 3.0
+        val typed = building.location nearSphere point maxDistance 3.0
         val expected = Criteria("location")
             .nearSphere(point)
             .maxDistance(3.0)
@@ -322,10 +316,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `minDistance() should equal expected criteria with nearSphere`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val point = Point(0.0, 0.0)
-        val typed = location nearSphere point minDistance 3.0
+        val typed = building.location nearSphere point minDistance 3.0
         val expected = Criteria("location")
             .nearSphere(point)
             .minDistance(3.0)
@@ -336,10 +329,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `maxDistance() should equal expected criteria with near`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val point = Point(0.0, 0.0)
-        val typed = location near point maxDistance 3.0
+        val typed = building.location near point maxDistance 3.0
         val expected = Criteria("location")
             .near(point)
             .maxDistance(3.0)
@@ -350,10 +342,9 @@ class QuerydslCriteriaExtensionsTests {
     @Test
     fun `minDistance() should equal expected criteria with near`() {
         val building = QBuilding.building
-        val location = building.location as Path<GeoJson<*>>
 
         val point = Point(0.0, 0.0)
-        val typed = location near point minDistance 3.0
+        val typed = building.location near point minDistance 3.0
         val expected = Criteria("location")
             .near(point)
             .minDistance(3.0)


### PR DESCRIPTION
Hello. 
I am a spring data mongo user.
I usually use it in combination with querydsl .
I found some inconvenience and made an extension.
I made this extension because I want to use it like below.

```kotlin
@Document
data class Book(
    val title: String,
    val author: Author,
)

@Document
data class Author(
    val name: String,
)
```

```kotlin
val book = QBook.book

book.author.name isEqualTo "author name" 
```

Could you please consider adding this feature?
If not, I'd appreciate it if you could tell me why.
thank you.

