### PR TITLE
implementation findAll with Predicate and Pageable in ReactiveQuerydslMongoPredicateExecutor

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutor.java
@@ -46,6 +46,7 @@ import com.querydsl.core.types.Predicate;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Sangyong Choi
  * @since 2.2
  */
 public class ReactiveQuerydslMongoPredicateExecutor<T> extends QuerydslPredicateExecutorSupport<T>
@@ -118,6 +119,14 @@ public class ReactiveQuerydslMongoPredicateExecutor<T> extends QuerydslPredicate
 		Assert.notNull(orders, "Order specifiers must not be null!");
 
 		return createQueryFor(predicate).orderBy(orders).fetch();
+	}
+
+	public Mono<Page<T>> findAll(Predicate predicate, Pageable pageable) {
+
+		Assert.notNull(predicate, "Predicate must not be null!");
+		Assert.notNull(pageable, "Pageable must not be null!");
+
+		return createQueryFor(predicate).fetchPage(pageable);
 	}
 
 	/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
@@ -17,14 +17,13 @@ package org.springframework.data.mongodb.repository.support;
 
 import static org.assertj.core.api.Assertions.*;
 
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,6 +65,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Rocco Lagrotteria
+ * @author Sangyong Choi
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -164,6 +164,17 @@ public class ReactiveQuerydslMongoPredicateExecutorTests {
 		repository.findAll(person.lastname.isNotNull(), Sort.by(Direction.ASC, "firstname")) //
 				.as(StepVerifier::create) //
 				.expectNext(carter, dave, oliver) //
+				.verifyComplete();
+	}
+
+	@Test // DATAMONGO-2182
+	public void shouldSupportFindAllWithPredicateAndPageable() {
+		Pageable pageable = PageRequest.of(0, 20, Sort.by(Direction.ASC, "firstname"));
+		PageImpl<Person> personPage = new PageImpl<>(Arrays.asList(carter, dave, oliver), pageable, 3);
+		repository.findAll(person.lastname.isNotNull(), pageable) //
+				.as(StepVerifier::create) //
+				//.expectNext(carter, dave, oliver)
+				.expectNext(personPage)
 				.verifyComplete();
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/ReactiveQuerydslMongoPredicateExecutorTests.java
@@ -173,7 +173,6 @@ public class ReactiveQuerydslMongoPredicateExecutorTests {
 		PageImpl<Person> personPage = new PageImpl<>(Arrays.asList(carter, dave, oliver), pageable, 3);
 		repository.findAll(person.lastname.isNotNull(), pageable) //
 				.as(StepVerifier::create) //
-				//.expectNext(carter, dave, oliver)
 				.expectNext(personPage)
 				.verifyComplete();
 	}


### PR DESCRIPTION
Hello, I am a spring data mongo user.

If you want to do paging using ReactiveQuerydslMongoPredicateExecutor it looks like you should use something like below.
```kotlin
repository
		.findBy(person.lastname.eq(oliver.getLastname()), it -> it.page(PageRequest.of(0, 1, Sort.by("firstname"))))
```

Could it be that I can add a Pageable like I suggested ?
I think it's more convenient to add a pageable .

Did you not implement it for any special reason?
If you like this suggestion, I suggest adding it to the ReactiveQuerydslPredicateExecutor interface.
Thanks for reading my suggestion.
