### PR TITLE
Add limit 0 behavior description

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -136,6 +136,7 @@ public class Query {
 
 	/**
 	 * Limit the number of returned documents to {@code limit}.
+	 * If limit chosen is 0 it returns all documents
 	 *
 	 * @param limit
 	 * @return this.


### PR DESCRIPTION
The number of items returned by the method `Query limit(int limit)` is equal to the value passed as a parameter. However, if the value is 0 the method returns all documents ignoring the "limit", this behavior may be misleading and I think it should be detailed in the documentation.