### PR TITLE
Fix rewrite of near & nearSphere count queries using geoJson to geoWithin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-4004-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-4004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-4004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-GH-4004-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CountQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CountQuery.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.mongodb.core;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.bson.Document;
-
 import org.springframework.data.geo.Point;
+import org.springframework.data.mongodb.core.query.MetricConversion;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 
@@ -207,7 +205,7 @@ class CountQuery {
 				maxDistance = (Number) nearDoc.get("$maxDistance");
 				// geojson is in Meters but we need radians x/(6378.1*1000)
 				if(spheric && nearDoc.containsKey("$geometry")) {
-					maxDistance = BigDecimal.valueOf(maxDistance.doubleValue()).divide(BigDecimal.valueOf(6378100d), MathContext.DECIMAL64).doubleValue();
+					maxDistance = MetricConversion.metersToRadians(maxDistance.doubleValue());
 				}
 			}
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -624,9 +624,13 @@ public class Criteria implements CriteriaDefinition {
 	}
 
 	/**
-	 * Creates a geo-spatial criterion using a {@literal $maxDistance} operation, for use with $near
+	 * Creates a geo-spatial criterion using a {@literal $maxDistance} operation, for use with {@literal $near} or
+	 * {@literal $nearSphere}.
+	 * <p>
+	 * <strong>NOTE:</strong> The unit of measure for distance may depends on the used coordinate representation
+	 * (legacy vs. geoJson) as well as the target operation.
 	 *
-	 * @param maxDistance
+	 * @param maxDistance radians or meters
 	 * @return this.
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/maxDistance/">MongoDB Query operator:
 	 *      $maxDistance</a>
@@ -645,8 +649,11 @@ public class Criteria implements CriteriaDefinition {
 	/**
 	 * Creates a geospatial criterion using a {@literal $minDistance} operation, for use with {@literal $near} or
 	 * {@literal $nearSphere}.
+	 * <p>
+	 * <strong>NOTE:</strong> The unit of measure for distance may depends on the used coordinate representation
+	 * (legacy vs. geoJson) as well as the target operation.
 	 *
-	 * @param minDistance
+	 * @param minDistance radians or meters
 	 * @return this.
 	 * @since 1.7
 	 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/MetricConversion.java
@@ -17,6 +17,7 @@
 package org.springframework.data.mongodb.core.query;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 
 import org.springframework.data.geo.Distance;
@@ -27,6 +28,7 @@ import org.springframework.data.geo.Metrics;
  * {@link Metric} and {@link Distance} conversions using the metric system.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
 public class MetricConversion {
@@ -59,6 +61,28 @@ public class MetricConversion {
 	public static double getDistanceInMeters(Distance distance) {
 		return new BigDecimal(distance.getValue()).multiply(getMetricToMetersMultiplier(distance.getMetric()))
 				.doubleValue();
+	}
+
+	/**
+	 * Return {@code distance} in radians (on an earth like sphere).
+	 *
+	 * @param distance must not be {@literal null}.
+	 * @return distance in rads.
+	 * @since 3.4
+	 */
+	public static double toRadians(Distance distance) {
+		return metersToRadians(getDistanceInMeters(distance));
+	}
+
+	/**
+	 * Return {@code distance} in radians (on an earth like sphere).
+	 *
+	 * @param meters
+	 * @return distance in rads.
+	 * @since 3.4
+	 */
+	public static double metersToRadians(double meters) {
+		return BigDecimal.valueOf(meters).divide(METERS_MULTIPLIER, MathContext.DECIMAL64).doubleValue();
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CountQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CountQueryUnitTests.java
@@ -182,7 +182,7 @@ class CountQueryUnitTests {
 
 		org.bson.Document target = postProcessQueryForCount(source);
 		assertThat(target).isEqualTo(org.bson.Document.parse(
-				"{\"$or\" : [ { \"name\": \"food\" }, {\"location\": {\"$geoWithin\": {\"$centerSphere\": [[-73.99171, 40.738868], 1.567865038177514E-6]}}} ]}"));
+				"{\"$or\" : [ { \"name\": \"food\" }, {\"location\": {\"$geoWithin\": {\"$centerSphere\": [[-73.99171, 40.738868], 1.567855942887398E-6]}}} ]}"));
 	}
 
 	private org.bson.Document postProcessQueryForCount(Query source) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CountQueryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CountQueryUnitTests.java
@@ -15,17 +15,13 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.mockito.Mockito.*;
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 import static org.springframework.data.mongodb.core.query.Query.*;
 import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.data.geo.Point;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
-import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.convert.QueryMapper;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/MetricConversionUnitTests.java
@@ -65,4 +65,18 @@ public class MetricConversionUnitTests {
 		assertThat(multiplier).isCloseTo(0.00062137, offset(0.000000001));
 	}
 
+	@Test // GH-4004
+	void shouldConvertMetersToRadians/* on an earth like sphere with r=6378.137km */() {
+		assertThat(MetricConversion.metersToRadians(1000)).isCloseTo(0.000156785594d, offset(0.000000001));
+	}
+
+	@Test // GH-4004
+	void shouldConvertKilometersToRadians/* on an earth like sphere with r=6378.137km */() {
+		assertThat(MetricConversion.toRadians(new Distance(1, Metrics.KILOMETERS))).isCloseTo(0.000156785594d, offset(0.000000001));
+	}
+
+	@Test // GH-4004
+	void shouldConvertMilesToRadians/* on an earth like sphere with r=6378.137km */() {
+		assertThat(MetricConversion.toRadians(new Distance(1, Metrics.MILES))).isCloseTo(0.000252321328d, offset(0.000000001));
+	}
 }


### PR DESCRIPTION
`$near` and `$nearSphere` queries are not supported via `countDocuments` and the used aggregation match stage and need to be rewritten to `$geoWithin`. The existing logic did not cover usage of _geoJson_ types, which is fixed now. In case of `nearSphere` it is also required to convert the `$maxDistance` argument (given in _meters_ for _geoJson_) to radians which is used by `$geoWithin $centerSphere`.

Resolves: #4004