### PR TITLE
Mark mongodb-driver-sync as non-optional

### DIFF
--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -101,7 +101,6 @@
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-sync</artifactId>
       <version>${mongo}</version>
-      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This package includes important class such as com.mongodb.client.MongoCollection;
and users of the client also needs to use this class, so this transitive dependency is important for downstream users as well. If we mark it as optional, then people will need to debug and manually include it. Ideally, we should give it to them.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
