### PR TITLE
Apply conversion on document reference lookup pointing directly to the id property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-GH-4033-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-GH-4033-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-GH-4033-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-mongodb-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-GH-4033-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -617,7 +617,11 @@ public class QueryMapper {
 	}
 
 	protected Object convertAssociation(Object source, Field field) {
-		return convertAssociation(source, field.getProperty());
+		Object value = convertAssociation(source, field.getProperty());
+		if(value != null && field.isIdField() && field.getFieldType() != value.getClass()) {
+			return convertId(value, field.getFieldType());
+		}
+		return value;
 	}
 
 	/**
@@ -1043,6 +1047,9 @@ public class QueryMapper {
 			return ClassTypeInformation.OBJECT;
 		}
 
+		public Class<?> getFieldType() {
+			return Object.class;
+		}
 	}
 
 	/**
@@ -1169,6 +1176,11 @@ public class QueryMapper {
 			}
 
 			return null;
+		}
+
+		@Override
+		public Class<?> getFieldType() {
+			return property.getFieldType();
 		}
 
 		@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -437,6 +437,31 @@ public class QueryMapperUnitTests {
 		assertThat(mappedQuery).containsEntry("sample", "s1");
 	}
 
+	@Test // GH-4033
+	void convertsNestedPathToIdPropertyOfDocumentReferenceCorrectly() {
+
+		Query query = query(where("sample.foo").is("s1"));
+		org.bson.Document mappedQuery = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(WithDocumentReference.class));
+
+		assertThat(mappedQuery).containsEntry("sample", "s1");
+	}
+
+	@Test // GH-4033
+	void convertsNestedPathToIdPropertyOfDocumentReferenceCorrectlyWhenItShouldBeConvertedToObjectId() {
+
+		ObjectId id = new ObjectId();
+		Query query = query(where("sample.foo").is(id.toHexString()));
+		org.bson.Document mappedQuery = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(WithDocumentReference.class));
+
+		assertThat(mappedQuery.get("sample")).satisfies(it -> {
+
+			assertThat(it).isInstanceOf(ObjectId.class);
+			assertThat(((ObjectId) it).toHexString()).isEqualTo(id.toHexString());
+		});
+	}
+
 	@Test // GH-3853
 	void convertsListDocumentReferenceOnIdPropertyCorrectly() {
 


### PR DESCRIPTION
We now consider a potentially set target field type when converting the pointer.

Closes: #4033