### PR TITLE
add alias method

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GroupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/GroupOperation.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Sergey Shcherbakov
+ * @author Sangyong Choi
  * @since 1.3
  * @see <a href="https://docs.mongodb.org/manual/reference/aggregation/group/">MongoDB Aggregation Framework: $group</a>
  */
@@ -132,6 +133,16 @@ public class GroupOperation implements FieldsExposingAggregationOperation {
 		 */
 		public GroupOperation as(String alias) {
 			return this.groupOperation.and(operation.withAlias(alias));
+		}
+
+		/**
+		 * Allows to specify an alias for the new-operation operation.
+		 *
+		 * @param alias
+		 * @return
+		 */
+		public GroupOperation alias(String alias) {
+			return this.as(alias);
 		}
 	}
 


### PR DESCRIPTION
Hi, I am a user of spring data mongo.
I found it inconvenient when using it with Kotlin.
Since as is a reserved word in Kotlin, it must be used together with `as` .

```kotlin
Aggregation.group("field").count().`as`("alias")
```

That's why I suggest providing an alias method.

```kotlin
Aggregation.group("field").count().alias("alias")
```

If you don't like this offer, please close this PR.
Thank you 😄 