### PR TITLE
Simplify usage of user provided aggregation operations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-GH-4038-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-GH-4038-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-GH-4038-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-mongodb-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-GH-4038-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/Aggregation.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation.AddFieldsOperationBuilder;
@@ -236,6 +237,40 @@ public class Aggregation {
 	 */
 	public static AddFieldsOperationBuilder addFields() {
 		return AddFieldsOperation.builder();
+	}
+
+	/**
+	 * Creates a new {@link AggregationOperation} taking the given {@link Bson bson value} as is. <br />
+	 *
+	 * <pre class="code">
+	 * Aggregation.stage(Aggregates.search(exists(fieldPath("..."))));
+	 * </pre>
+	 *
+	 * Field mapping against a potential domain type or previous aggregation stages will not happen.
+	 *
+	 * @param aggregationOperation the must not be {@literal null}.
+	 * @return new instance of {@link AggregationOperation}.
+	 * @since 4.0
+	 */
+	public static AggregationOperation stage(Bson aggregationOperation) {
+		return new BasicAggregationOperation(aggregationOperation);
+	}
+
+	/**
+	 * Creates a new {@link AggregationOperation} taking the given {@link String json value} as is. <br />
+	 *
+	 * <pre class="code">
+	 * Aggregation.stage("{ $search : { near : { path : 'released' , origin : ... } } }");
+	 * </pre>
+	 *
+	 * Field mapping against a potential domain type or previous aggregation stages will not happen.
+	 *
+	 * @param json the JSON representation of the pipeline stage. Must not be {@literal null}.
+	 * @return new instance of {@link AggregationOperation}.
+	 * @since 4.0
+	 */
+	public static AggregationOperation stage(String json) {
+		return new BasicAggregationOperation(json);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
@@ -20,11 +20,15 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.beans.BeanUtils;
+import org.springframework.data.mongodb.CodecRegistryProvider;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
+
+import com.mongodb.MongoClientSettings;
 
 /**
  * The context for an {@link AggregationOperation}.
@@ -33,7 +37,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Christoph Strobl
  * @since 1.3
  */
-public interface AggregationOperationContext {
+public interface AggregationOperationContext extends CodecRegistryProvider {
 
 	/**
 	 * Returns the mapped {@link Document}, potentially converting the source considering mapping metadata etc.
@@ -113,5 +117,10 @@ public interface AggregationOperationContext {
 	 */
 	default AggregationOperationContext continueOnMissingFieldReference() {
 		return this;
+	}
+
+	@Override
+	default CodecRegistry getCodecRegistry() {
+		return MongoClientSettings.getDefaultCodecRegistry();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/BasicAggregationOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/BasicAggregationOperation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import java.util.Map;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.springframework.data.mongodb.util.BsonUtils;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * {@link AggregationOperation} implementation that c
+ * 
+ * @author Christoph Strobl
+ * @since 4.0
+ */
+class BasicAggregationOperation implements AggregationOperation {
+
+	private final Object value;
+
+	BasicAggregationOperation(Object value) {
+		this.value = value;
+	}
+
+	@Override
+	public Document toDocument(AggregationOperationContext context) {
+
+		if (value instanceof Document document) {
+			return document;
+		}
+
+		if (value instanceof Bson bson) {
+			return BsonUtils.asDocument(bson, context.getCodecRegistry());
+		}
+
+		if (value instanceof Map map) {
+			return new Document(map);
+		}
+
+		if (value instanceof String json && BsonUtils.isJsonDocument(json)) {
+			return BsonUtils.parse(json, context);
+		}
+
+		throw new IllegalStateException(
+				String.format("%s cannot be converted to org.bson.Document.", ObjectUtils.nullSafeClassName(value)));
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.aggregation;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.DirectFieldReference;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.ExposedField;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
@@ -140,5 +141,10 @@ class ExposedFieldsAggregationOperationContext implements AggregationOperationCo
 	 */
 	AggregationOperationContext getRootContext() {
 		return rootContext;
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return getRootContext().getCodecRegistry();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/NestedDelegatingExpressionAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/NestedDelegatingExpressionAggregationOperationContext.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.bson.Document;
 
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.ExpressionFieldReference;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 import org.springframework.util.Assert;
@@ -91,5 +92,10 @@ class NestedDelegatingExpressionAggregationOperationContext implements Aggregati
 	@Override
 	public Fields getFields(Class<?> type) {
 		return delegate.getFields(type);
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return delegate.getCodecRegistry();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 import org.springframework.lang.Nullable;
 
@@ -78,6 +79,11 @@ public class PrefixingDelegatingAggregationOperationContext implements Aggregati
 	@Override
 	public Fields getFields(Class<?> type) {
 		return delegate.getFields(type);
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return delegate.getCodecRegistry();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.bson.Document;
 
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.DirectFieldReference;
@@ -146,5 +147,10 @@ public class TypeBasedAggregationOperationContext implements AggregationOperatio
 
 	public Class<?> getType() {
 		return type;
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return this.mapper.getConverter().getCodecRegistry();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.bson.Document;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
 import org.bson.types.ObjectId;
@@ -1791,6 +1792,11 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 	 */
 	public Class<?> getWriteTarget(Class<?> source) {
 		return conversions.getCustomWriteTarget(source).orElse(source);
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return codecRegistryProvider != null ? codecRegistryProvider.getCodecRegistry() : super.getCodecRegistry();
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConverter.java
@@ -15,16 +15,18 @@
  */
 package org.springframework.data.mongodb.core.convert;
 
+import com.mongodb.MongoClientSettings;
 import org.bson.BsonValue;
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
-
 import org.springframework.core.convert.ConversionException;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.convert.EntityReader;
 import org.springframework.data.convert.TypeMapper;
+import org.springframework.data.mongodb.CodecRegistryProvider;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.util.BsonUtils;
@@ -48,7 +50,7 @@ import com.mongodb.DBRef;
  */
 public interface MongoConverter
 		extends EntityConverter<MongoPersistentEntity<?>, MongoPersistentProperty, Object, Bson>, MongoWriter<Object>,
-		EntityReader<Object, Bson> {
+		EntityReader<Object, Bson>, CodecRegistryProvider {
 
 	/**
 	 * Returns the {@link TypeMapper} being used to write type information into {@link Document}s created with that
@@ -186,6 +188,11 @@ public interface MongoConverter
 		} catch (ConversionException o_O) {
 			return convertToMongoType(id,(TypeInformation<?>)  null);
 		}
+	}
+
+	@Override
+	default CodecRegistry getCodecRegistry() {
+		return MongoClientSettings.getDefaultCodecRegistry();
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -1486,4 +1486,8 @@ public class QueryMapper {
 	public MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> getMappingContext() {
 		return mappingContext;
 	}
+
+	public MongoConverter getConverter() {
+		return converter;
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/aggregation/TestAggregationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/aggregation/TestAggregationContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.util.aggregation;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
@@ -71,5 +72,10 @@ public class TestAggregationContext implements AggregationOperationContext {
 	@Override
 	public FieldReference getReference(String name) {
 		return delegate.getReference(name);
+	}
+
+	@Override
+	public CodecRegistry getCodecRegistry() {
+		return delegate.getCodecRegistry();
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/BasicAggregationOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/BasicAggregationOperationUnitTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import com.mongodb.MongoClientSettings;
+
+/**
+ * @author Christoph Strobl
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BasicAggregationOperationUnitTests {
+
+	@Mock QueryMapper queryMapper;
+	@Mock MongoConverter converter;
+
+	TypeBasedAggregationOperationContext ctx;
+
+	@BeforeEach
+	void beforeEach() {
+
+		// no field mapping though having a type based context
+		ctx = new TypeBasedAggregationOperationContext(Person.class, new MongoMappingContext(), queryMapper);
+		when(queryMapper.getConverter()).thenReturn(converter);
+		when(converter.getCodecRegistry()).thenReturn(MongoClientSettings.getDefaultCodecRegistry());
+	}
+
+	@Test // GH-4038
+	void usesGivenDocumentAsIs() {
+
+		Document source = new Document("value", 1);
+		assertThat(new BasicAggregationOperation(source).toDocument(ctx)).isSameAs(source);
+	}
+
+	@Test // GH-4038
+	void parsesJson() {
+
+		Document source = new Document("value", 1);
+		assertThat(new BasicAggregationOperation(source.toJson()).toDocument(ctx)).isEqualTo(source);
+	}
+
+	@Test // GH-4038
+	void errorsOnInvalidValue() {
+
+		BasicAggregationOperation agg = new BasicAggregationOperation(new Object());
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> agg.toDocument(ctx));
+	}
+
+	@Test // GH-4038
+	void errorsOnNonJsonSting() {
+
+		BasicAggregationOperation agg = new BasicAggregationOperation("#005BBB #FFD500");
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> agg.toDocument(ctx));
+	}
+
+	private static class Person {
+
+		@Field("v-a-l-u-e") Object value;
+	}
+}

--- a/src/main/asciidoc/reference/aggregation-framework.adoc
+++ b/src/main/asciidoc/reference/aggregation-framework.adoc
@@ -126,6 +126,26 @@ At the time of this writing, we provide support for the following Aggregation Op
 
 Note that the aggregation operations not listed here are currently not supported by Spring Data MongoDB. Comparison aggregation operators are expressed as `Criteria` expressions.
 
+[TIP]
+====
+Unsupported aggregation operations/operators can be provided by implementing either `AggregationOperation` or `AggregationExpression`.
+`Aggregation.stage` is a shortcut for registering a pipeline stage by providing its JSON or `Bson` representation.
+
+[source,java]
+----
+Aggregation.stage("""
+    { $search : {
+        "near": {
+          "path": "released",
+          "origin": { "$date": { "$numberLong": "..." } } ,
+          "pivot": 7
+        }
+      }
+    }
+""");
+----
+====
+
 [[mongo.aggregation.projection]]
 === Projection Expressions
 


### PR DESCRIPTION
Introduce `Aggregation.stage` which allows to use a plain JSON String or any valid `Bson` representation to be used within an aggregation pipeline stage, without having to implement `AggregationOperation` directly.
The change allows to make use of driver native builder API for aggregates.