### PR TITLE
Make ChangeStreamOptionsBuilder support startAtOperationTime

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamOptions.java
@@ -40,6 +40,7 @@ import com.mongodb.client.model.changestream.FullDocument;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Tudor Marc
  * @since 2.1
  */
 public class ChangeStreamOptions {
@@ -49,6 +50,7 @@ public class ChangeStreamOptions {
 	private @Nullable FullDocument fullDocumentLookup;
 	private @Nullable Collation collation;
 	private @Nullable Object resumeTimestamp;
+	private @Nullable Object startAtOperationTime;
 	private Resume resume = Resume.UNDEFINED;
 
 	protected ChangeStreamOptions() {}
@@ -94,6 +96,20 @@ public class ChangeStreamOptions {
 	 */
 	public Optional<BsonTimestamp> getResumeBsonTimestamp() {
 		return Optional.ofNullable(resumeTimestamp).map(timestamp -> asTimestampOfType(timestamp, BsonTimestamp.class));
+	}
+
+	/**
+	 * @return {@link Optional#empty()} if not set.
+	 */
+	public Optional<Instant> getStartAtOperationTime() {
+		return Optional.ofNullable(startAtOperationTime).map(timestamp -> asTimestampOfType(timestamp, Instant.class));
+	}
+
+	/**
+	 * @return {@link Optional#empty()} if not set.
+	 */
+	public Optional<BsonTimestamp> getStartAtOperationTimeBson() {
+		return Optional.ofNullable(startAtOperationTime).map(timestamp -> asTimestampOfType(timestamp, BsonTimestamp.class));
 	}
 
 	/**
@@ -176,6 +192,9 @@ public class ChangeStreamOptions {
 		if (!ObjectUtils.nullSafeEquals(this.resumeTimestamp, that.resumeTimestamp)) {
 			return false;
 		}
+		if (!ObjectUtils.nullSafeEquals(this.startAtOperationTime, that.startAtOperationTime)) {
+			return false;
+		}
 		return resume == that.resume;
 	}
 
@@ -186,6 +205,7 @@ public class ChangeStreamOptions {
 		result = 31 * result + ObjectUtils.nullSafeHashCode(fullDocumentLookup);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(collation);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(resumeTimestamp);
+		result = 31 * result + ObjectUtils.nullSafeHashCode(startAtOperationTime);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(resume);
 		return result;
 	}
@@ -213,6 +233,7 @@ public class ChangeStreamOptions {
 	 * Builder for creating {@link ChangeStreamOptions}.
 	 *
 	 * @author Christoph Strobl
+	 * @author Tudor Marc
 	 * @since 2.1
 	 */
 	public static class ChangeStreamOptionsBuilder {
@@ -222,6 +243,7 @@ public class ChangeStreamOptions {
 		private @Nullable FullDocument fullDocumentLookup;
 		private @Nullable Collation collation;
 		private @Nullable Object resumeTimestamp;
+		private @Nullable Object startAtOperationTime;
 		private Resume resume = Resume.UNDEFINED;
 
 		private ChangeStreamOptionsBuilder() {}
@@ -352,6 +374,34 @@ public class ChangeStreamOptions {
 		}
 
 		/**
+		 * Set the cluster startAtOperationTime to open the cursor at a particular point in time.
+		 *
+		 * @param startAtOperationTime must not be {@literal null}.
+		 * @return this.
+		 */
+		public ChangeStreamOptionsBuilder startAtOperationTime(Instant startAtOperationTime) {
+
+			Assert.notNull(startAtOperationTime, "startAtOperationTime must not be null!");
+
+			this.startAtOperationTime = startAtOperationTime;
+			return this;
+		}
+
+		/**
+		 * Set the cluster startAtOperationTime to open the cursor at a particular point in time.
+		 *
+		 * @param startAtOperationTime must not be {@literal null}.
+		 * @return this.
+		 */
+		public ChangeStreamOptionsBuilder startAtOperationTime(BsonTimestamp startAtOperationTime) {
+
+			Assert.notNull(startAtOperationTime, "startAtOperationTime must not be null!");
+
+			this.startAtOperationTime = startAtOperationTime;
+			return this;
+		}
+
+		/**
 		 * Set the resume token after which to continue emitting notifications.
 		 *
 		 * @param resumeToken must not be {@literal null}.
@@ -393,6 +443,7 @@ public class ChangeStreamOptions {
 			options.fullDocumentLookup = this.fullDocumentLookup;
 			options.collation = this.collation;
 			options.resumeTimestamp = this.resumeTimestamp;
+			options.startAtOperationTime = this.startAtOperationTime;
 			options.resume = this.resume;
 
 			return options;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveChangeStreamOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveChangeStreamOperationSupport.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Tudor Marc
  * @since 2.2
  */
 class ReactiveChangeStreamOperationSupport implements ReactiveChangeStreamOperation {
@@ -178,6 +179,8 @@ class ReactiveChangeStreamOperationSupport implements ReactiveChangeStreamOperat
 			} else {
 				options.getResumeTimestamp().ifPresent(builder::resumeAt);
 				options.getResumeBsonTimestamp().ifPresent(builder::resumeAt);
+				options.getStartAtOperationTime().ifPresent(builder::startAtOperationTime);
+				options.getStartAtOperationTimeBson().ifPresent(builder::startAtOperationTime);
 			}
 
 			return builder;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamRequest.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamRequest.java
@@ -232,6 +232,7 @@ public class ChangeStreamRequest<T>
 	 * Builder for creating {@link ChangeStreamRequest}.
 	 *
 	 * @author Christoph Strobl
+	 * @author Tudor Marc
 	 * @since 2.1
 	 * @see ChangeStreamOptions
 	 */
@@ -405,6 +406,22 @@ public class ChangeStreamRequest<T>
 
 			Assert.notNull(resumeToken, "ResumeToken must not be null!");
 			this.delegate.startAfter(resumeToken);
+
+			return this;
+		}
+
+		/**
+		 * Set the cluster startAtOperationTime to open the cursor at a particular point in time.
+		 *
+		 * @param clusterTime must not be {@literal null}.
+		 * @return this.
+		 * @see ChangeStreamOptions#getStartAtOperationTime() ()
+		 * @see ChangeStreamOptionsBuilder#startAtOperationTime(java.time.Instant)
+		 */
+		public ChangeStreamRequestBuilder<T> startAtOperationTime(Instant clusterTime) {
+
+			Assert.notNull(clusterTime, "clusterTime must not be null!");
+			this.delegate.startAtOperationTime(clusterTime);
 
 			return this;
 		}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ChangeStreamOptionsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ChangeStreamOptionsUnitTests.java
@@ -18,12 +18,14 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 
 import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link ChangeStreamOptions}.
  *
  * @author Mark Paluch
+ * @author Tudor Marc
  */
 public class ChangeStreamOptionsUnitTests {
 
@@ -52,5 +54,13 @@ public class ChangeStreamOptionsUnitTests {
 
 		assertThat(options.isResumeAfter()).isFalse();
 		assertThat(options.isStartAfter()).isFalse();
+	}
+
+	@Test // DATAMONGO-2607
+	public void shouldReportStartAtOperationTime() {
+
+		ChangeStreamOptions options = ChangeStreamOptions.builder().startAtOperationTime(new BsonTimestamp()).build();
+
+		assertThat(options.getStartAtOperationTime()).isNotNull();
 	}
 }


### PR DESCRIPTION
Make ChangeStreamOptionsBuilder support startAtOperationTime

Closes #3460

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
