### PR TITLE
Add support for collection expiration to @TimeSeries.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -445,9 +446,9 @@ public class CollectionOptions {
 
 		private final GranularityDefinition granularity;
 
-		private final int expireAfterSeconds;
+		private final long expireAfterSeconds;
 
-		private TimeSeriesOptions(String timeField, @Nullable String metaField, GranularityDefinition granularity, int expireAfterSeconds) {
+		private TimeSeriesOptions(String timeField, @Nullable String metaField, GranularityDefinition granularity, long expireAfterSeconds) {
 			Assert.hasText(timeField, "Time field must not be empty or null");
 
 			this.timeField = timeField;
@@ -493,13 +494,13 @@ public class CollectionOptions {
 		}
 
 		/**
-		 * Select the expireAfterSeconds parameter to define automatic removal of documents older than a specified
-		 * number of seconds.
+		 * Select the expire parameter to define automatic removal of documents older than a specified
+		 * duration.
 		 *
 		 * @return new instance of {@link TimeSeriesOptions}.
 		 */
-		public TimeSeriesOptions expireAfterSeconds(int expireAfterSeconds) {
-			return new TimeSeriesOptions(timeField, metaField, granularity, expireAfterSeconds);
+		public TimeSeriesOptions expireAfter(Duration timeout) {
+			return new TimeSeriesOptions(timeField, metaField, granularity, timeout.getSeconds());
 		}
 
 		/**
@@ -528,7 +529,7 @@ public class CollectionOptions {
 		/**
 		 * @return {@literal -1} if not specified
 		 */
-		public int getExpireAfterSeconds() {
+		public long getExpireAfterSeconds() {
 			return expireAfterSeconds;
 		}
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -37,6 +37,7 @@ import com.mongodb.client.model.ValidationLevel;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Andreas Zink
+ * @author Ben Foster
  */
 public class CollectionOptions {
 
@@ -444,13 +445,15 @@ public class CollectionOptions {
 
 		private final GranularityDefinition granularity;
 
-		private TimeSeriesOptions(String timeField, @Nullable String metaField, GranularityDefinition granularity) {
+		private final int expireAfterSeconds;
 
+		private TimeSeriesOptions(String timeField, @Nullable String metaField, GranularityDefinition granularity, int expireAfterSeconds) {
 			Assert.hasText(timeField, "Time field must not be empty or null");
 
 			this.timeField = timeField;
 			this.metaField = metaField;
 			this.granularity = granularity;
+			this.expireAfterSeconds = expireAfterSeconds;
 		}
 
 		/**
@@ -462,7 +465,7 @@ public class CollectionOptions {
 		 * @return new instance of {@link TimeSeriesOptions}.
 		 */
 		public static TimeSeriesOptions timeSeries(String timeField) {
-			return new TimeSeriesOptions(timeField, null, Granularity.DEFAULT);
+			return new TimeSeriesOptions(timeField, null, Granularity.DEFAULT, -1);
 		}
 
 		/**
@@ -475,7 +478,7 @@ public class CollectionOptions {
 		 * @return new instance of {@link TimeSeriesOptions}.
 		 */
 		public TimeSeriesOptions metaField(String metaField) {
-			return new TimeSeriesOptions(timeField, metaField, granularity);
+			return new TimeSeriesOptions(timeField, metaField, granularity, expireAfterSeconds);
 		}
 
 		/**
@@ -486,7 +489,17 @@ public class CollectionOptions {
 		 * @see Granularity
 		 */
 		public TimeSeriesOptions granularity(GranularityDefinition granularity) {
-			return new TimeSeriesOptions(timeField, metaField, granularity);
+			return new TimeSeriesOptions(timeField, metaField, granularity, expireAfterSeconds);
+		}
+
+		/**
+		 * Select the expireAfterSeconds parameter to define automatic removal of documents older than a specified
+		 * number of seconds.
+		 *
+		 * @return new instance of {@link TimeSeriesOptions}.
+		 */
+		public TimeSeriesOptions expireAfterSeconds(int expireAfterSeconds) {
+			return new TimeSeriesOptions(timeField, metaField, granularity, expireAfterSeconds);
 		}
 
 		/**
@@ -510,6 +523,13 @@ public class CollectionOptions {
 		 */
 		public GranularityDefinition getGranularity() {
 			return granularity;
+		}
+
+		/**
+		 * @return {@literal -1} if not specified
+		 */
+		public int getExpireAfterSeconds() {
+			return expireAfterSeconds;
 		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.bson.Document;
 
@@ -67,6 +68,7 @@ import com.mongodb.client.model.ValidationOptions;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Ben Foster
  * @since 2.1
  * @see MongoTemplate
  * @see ReactiveMongoTemplate
@@ -329,6 +331,10 @@ class EntityOperations {
 			}
 			if (!Granularity.DEFAULT.equals(it.getGranularity())) {
 				options.granularity(TimeSeriesGranularity.valueOf(it.getGranularity().name().toUpperCase()));
+			}
+
+			if (it.getExpireAfterSeconds() >= 0) {
+				result.expireAfter(it.getExpireAfterSeconds(), TimeUnit.SECONDS);
 			}
 
 			result.timeSeriesOptions(options);
@@ -916,6 +922,9 @@ class EntityOperations {
 				if (!Granularity.DEFAULT.equals(timeSeries.granularity())) {
 					options = options.granularity(timeSeries.granularity());
 				}
+				if (timeSeries.expireAfterSeconds() >= 0) {
+					options = options.expireAfterSeconds(timeSeries.expireAfterSeconds());
+				}
 				collectionOptions = collectionOptions.timeSeries(options);
 			}
 
@@ -930,7 +939,8 @@ class EntityOperations {
 			if (StringUtils.hasText(source.getMetaField())) {
 				target = target.metaField(mappedNameOrDefault(source.getMetaField()));
 			}
-			return target.granularity(source.getGranularity());
+			return target.granularity(source.getGranularity())
+					.expireAfterSeconds(source.getExpireAfterSeconds());
 		}
 
 		private String mappedNameOrDefault(String name) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/DurationStyle.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/DurationStyle.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @since 2.2
  */
-enum DurationStyle {
+public enum DurationStyle {
 
 	/**
 	 * Simple formatting, for example '1s'.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/TimeSeries.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/TimeSeries.java
@@ -28,6 +28,7 @@ import org.springframework.data.mongodb.core.timeseries.Granularity;
  * Identifies a domain object to be persisted to a MongoDB Time Series collection.
  *
  * @author Christoph Strobl
+ * @author Ben Foster
  * @since 3.3
  * @see <a href="https://docs.mongodb.com/manual/core/timeseries-collections">https://docs.mongodb.com/manual/core/timeseries-collections</a>
  */
@@ -83,4 +84,12 @@ public @interface TimeSeries {
 	@AliasFor(annotation = Document.class, attribute = "collation")
 	String collation() default "";
 
+	/**
+	 * Configures the number of seconds after which the collection should expire. Defaults to -1 for no expiry.
+	 *
+	 * @return {@literal -1} by default.
+	 * @see <a href=
+	 *      "https://www.mongodb.com/docs/manual/core/timeseries/timeseries-automatic-removal/#set-up-automatic-removal-for-time-series-collections--ttl-</a>
+	 */
+	int expireAfterSeconds() default -1;
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/TimeSeries.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/TimeSeries.java
@@ -85,11 +85,41 @@ public @interface TimeSeries {
 	String collation() default "";
 
 	/**
-	 * Configures the number of seconds after which the collection should expire. Defaults to -1 for no expiry.
+	 * Configures the number of seconds after which the document should expire. Defaults to -1 for no expiry.
 	 *
 	 * @return {@literal -1} by default.
 	 * @see <a href=
 	 *      "https://www.mongodb.com/docs/manual/core/timeseries/timeseries-automatic-removal/#set-up-automatic-removal-for-time-series-collections--ttl-</a>
 	 */
 	int expireAfterSeconds() default -1;
+
+
+	/**
+	 * Alternative for {@link #expireAfterSeconds()} to configure the timeout after which the document should expire.
+	 * Defaults to an empty {@link String} for no expiry. Accepts numeric values followed by their unit of measure:
+	 * <ul>
+	 * <li><b>d</b>: Days</li>
+	 * <li><b>h</b>: Hours</li>
+	 * <li><b>m</b>: Minutes</li>
+	 * <li><b>s</b>: Seconds</li>
+	 * <li>Alternatively: A Spring {@literal template expression}. The expression can result in a
+	 * {@link java.time.Duration} or a valid expiration {@link String} according to the already mentioned
+	 * conventions.</li>
+	 * </ul>
+	 * Supports ISO-8601 style.
+	 *
+	 * <pre class="code">
+	 *
+	 * &#0064;Indexed(expireAfter = "10s") String expireAfterTenSeconds;
+	 *
+	 * &#0064;Indexed(expireAfter = "1d") String expireAfterOneDay;
+	 *
+	 * &#0064;Indexed(expireAfter = "P2D") String expireAfterTwoDays;
+	 *
+	 * &#0064;Indexed(expireAfter = "#{&#0064;mySpringBean.timeout}") String expireAfterTimeoutObtainedFromSpringBean;
+	 * </pre>
+	 *
+	 * @return empty by default.
+	 */
+	String expireAfter() default "";
 }


### PR DESCRIPTION
This will allow setting up automatic removal for time series collections (https://www.mongodb.com/docs/manual/core/timeseries/timeseries-automatic-removal/#set-up-automatic-removal-for-time-series-collections--ttl-), by adding an `expireAfterSeconds` or `expire` element to the `@TimeSeries` annotation.
Similar to `@Indexed`,  `expireAfterSeconds` on will have a default of `-1`, and will not be used if it is <= 0.  An error will be thrown if both `expireAterSeconds` and `expire` are defined.  `expire` allows all the same expressions as are supported on `@Indexed`.


Closes #4099

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
