### PR TITLE
Add collation for an index via @CompoundIndex and @Index annotations.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/CompoundIndex.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/CompoundIndex.java
@@ -46,6 +46,7 @@ import java.lang.annotation.Target;
  * @author Johno Crawford
  * @author Christoph Strobl
  * @author Dave Perryman
+ * @author Stefan Tirea
  */
 @Target({ ElementType.TYPE })
 @Documented
@@ -163,4 +164,19 @@ public @interface CompoundIndex {
 	 * @since 3.1
 	 */
 	String partialFilter() default "";
+
+	/**
+	 * The actual collation definition in JSON format or a {@link org.springframework.expression.spel.standard.SpelExpression
+	 * template expression} resolving to either a JSON String or a {@link org.bson.Document}. The keys of the JSON
+	 * document are configuration options for the collation (language-specific rules for string comparison).
+	 * <br><br>
+	 * TODO write code documentation & example!!!
+	 * <br>
+	 *
+	 * @return empty String by default.
+	 * @see <a href=
+	 * "https://www.mongodb.com/docs/manual/reference/collation/">https://www.mongodb.com/docs/manual/reference/collation/</a>
+	 * @since 3.4
+	 */
+	String collation() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Indexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/Indexed.java
@@ -31,6 +31,7 @@ import java.lang.annotation.Target;
  * @author Christoph Strobl
  * @author Jordi Llach
  * @author Mark Paluch
+ * @author Stefan Tirea
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
@@ -173,4 +174,14 @@ public @interface Indexed {
 	 * @since 3.1
 	 */
 	String partialFilter() default "";
+
+	/**
+	 * Apply collation configuration for field <br />
+	 *
+	 * @return empty by default.
+	 * @see <a href=
+	 *      "https://www.mongodb.com/docs/manual/reference/collation/">https://www.mongodb.com/docs/manual/reference/collation//</a>
+	 * @since 3.1
+	 */
+	String collation() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  * @author Martin Macko
  * @author Mark Paluch
  * @author Dave Perryman
+ * @author Stefan Tirea
  * @since 1.5
  */
 public class MongoPersistentEntityIndexResolver implements IndexResolver {
@@ -453,6 +454,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 			indexDefinition.partial(evaluatePartialFilter(index.partialFilter(), entity));
 		}
 
+		if (StringUtils.hasText(index.collation())) {
+			indexDefinition.collation(Collation.parse(index.collation()));
+		}
+
 		return new IndexDefinitionHolder(dotPath, indexDefinition, collection);
 	}
 
@@ -570,6 +575,10 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 
 		if (StringUtils.hasText(index.partialFilter())) {
 			indexDefinition.partial(evaluatePartialFilter(index.partialFilter(), persistentProperty.getOwner()));
+		}
+
+		if (StringUtils.hasText(index.collation())) {
+			indexDefinition.collation(Collation.parse(index.collation()));
 		}
 
 		return new IndexDefinitionHolder(dotPath, indexDefinition, collection);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Sort.Direction;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Stefan Tirea
  */
 public class IndexInfoUnitTests {
 
@@ -37,6 +38,7 @@ public class IndexInfoUnitTests {
 	static final String INDEX_WITH_EXPIRATION_TIME = "{ \"v\" : 2, \"key\" : { \"lastModifiedDate\" : 1 },\"name\" : \"expire-after-last-modified\", \"ns\" : \"db.collectio\", \"expireAfterSeconds\" : 3600 }";
 	static final String HASHED_INDEX = "{ \"v\" : 2, \"key\" : { \"score\" : \"hashed\" }, \"name\" : \"score_hashed\", \"ns\" : \"db.collection\" }";
 	static final String WILDCARD_INDEX = "{ \"v\" : 2, \"key\" : { \"$**\" : 1 }, \"name\" : \"$**_1\", \"wildcardProjection\" : { \"fieldA\" : 0, \"fieldB.fieldC\" : 0 } }";
+	static final String INDEX_WITH_COLLATION = "{ \"v\" : 2, \"key\" : { \"_id\" : 1 }, \"name\" : \"projectName\", \"collation\": { \"locale\": \"en_US\", \"strength\": 2 } }";
 
 	@Test
 	public void isIndexForFieldsCorrectly() {
@@ -87,7 +89,14 @@ public class IndexInfoUnitTests {
 
 	@Test // GH-3225
 	public void readsWildcardIndexProjectionCorrectly() {
-		assertThat(getIndexInfo(WILDCARD_INDEX).getWildcardProjection()).contains(new Document("fieldA", 0).append("fieldB.fieldC", 0));
+		assertThat(getIndexInfo(WILDCARD_INDEX).getWildcardProjection())
+				.contains(new Document("fieldA", 0).append("fieldB.fieldC", 0));
+	}
+
+	@Test // DATAMONGO-2133
+	public void collationParsedCorrectly() {
+		assertThat(getIndexInfo(INDEX_WITH_COLLATION).getCollation())
+				.contains(Document.parse("{ \"locale\": \"en_US\", \"strength\": 2 }"));
 	}
 
 	private static IndexInfo getIndexInfo(String documentJson) {


### PR DESCRIPTION
Closes #3002, closes #4130

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


Hi,
I recently wanted to use [Collation](https://www.mongodb.com/docs/manual/reference/collation/) with Spring Data and saw there is no support to implement it only with annotations for a specific field.
A use case would be to have an unique index which is case insensitive.
My PR adds support to use it with annotations (currently it is only possible programmatically).
I hope the implementation did not miss an obvious hurdle for this feature.

Still missing in this PR:
* Proper documentation in `@Index` & `@CompoundIndex` (see TODO)
