### PR TITLE
Fix documentation typo in BasicQuery class

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
@@ -73,7 +73,7 @@ public class BasicQuery extends Query {
 	 *
 	 * @param queryObject must not be {@literal null}.
 	 * @param fieldsObject must not be {@literal null}.
-	 * @throws IllegalArgumentException when {@code sortObject} or {@code fieldsObject} is {@literal null}.
+	 * @throws IllegalArgumentException when {@code queryObject} or {@code fieldsObject} is {@literal null}.
 	 */
 	public BasicQuery(Document queryObject, Document fieldsObject) {
 


### PR DESCRIPTION
Closes #4169

This commit is documentation typo fix in `BasicQuery` class.

This is my first time contributing to Spring project. Please forgive me if I made any mistake regarding contribution. Thank you for maintaining this awesome project.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
