### PR TITLE
Fix inconsistent strong tag appearance in documentation

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoConfigurationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoConfigurationSupport.java
@@ -207,7 +207,7 @@ public abstract class MongoConfigurationSupport {
 	 * {@link org.springframework.data.mongodb.core.index.IndexDefinition} from the entity or not.
 	 *
 	 * @return {@literal false} by default. <br />
-	 *         <strong>INFO</strong>: As of 3.x the default is set to {@literal false}; In 2.x it was {@literal true}.
+	 *         <strong>INFO:</strong> As of 3.x the default is set to {@literal false}; In 2.x it was {@literal true}.
 	 * @since 2.2
 	 */
 	protected boolean autoIndexCreation() {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -99,7 +99,7 @@ public class CollectionOptions {
 
 	/**
 	 * Create new {@link CollectionOptions} with already given settings and capped set to {@literal true}. <br />
-	 * <strong>NOTE</strong> Using capped collections requires defining {@link #size(long)}.
+	 * <strong>NOTE:</strong> Using capped collections requires defining {@link #size(long)}.
 	 *
 	 * @return new {@link CollectionOptions}.
 	 * @since 2.0

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableRemoveOperation.java
@@ -76,7 +76,7 @@ public interface ExecutableRemoveOperation {
 
 		/**
 		 * Remove and return all matching documents. <br/>
-		 * <strong>NOTE</strong> The entire list of documents will be fetched before sending the actual delete commands.
+		 * <strong>NOTE:</strong> The entire list of documents will be fetched before sending the actual delete commands.
 		 * Also, {@link org.springframework.context.ApplicationEvent}s will be published for each and every delete
 		 * operation.
 		 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveRemoveOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveRemoveOperation.java
@@ -69,7 +69,7 @@ public interface ReactiveRemoveOperation {
 
 		/**
 		 * Remove and return all matching documents. <br/>
-		 * <strong>NOTE</strong> The entire list of documents will be fetched before sending the actual delete commands.
+		 * <strong>NOTE:</strong> The entire list of documents will be fetched before sending the actual delete commands.
 		 * Also, {@link org.springframework.context.ApplicationEvent}s will be published for each and every delete
 		 * operation.
 		 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/DateOperators.java
@@ -159,7 +159,7 @@ public class DateOperators {
 	 * +/-[hh], e.g. "+03"</td>
 	 * </tr>
 	 * </table>
-	 * <strong>NOTE: </strong>Support for timezones in aggregations Requires MongoDB 3.6 or later.
+	 * <strong>NOTE:</strong> Support for timezones in aggregations Requires MongoDB 3.6 or later.
 	 *
 	 * @author Christoph Strobl
 	 * @author Mark Paluch

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/LazyLoadingProxyFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/LazyLoadingProxyFactory.java
@@ -47,7 +47,7 @@ import com.mongodb.DBRef;
 
 /**
  * {@link ProxyFactory} to create a proxy for {@link MongoPersistentProperty#getType()} to resolve a reference lazily.
- * <strong>NOTE</strong> This class is intended for internal usage only.
+ * <strong>NOTE:</strong> This class is intended for internal usage only.
  *
  * @author Christoph Strobl
  * @author Mark Paluch

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/TextIndexDefinition.java
@@ -244,7 +244,7 @@ public class TextIndexDefinition implements IndexDefinition {
 
 		/**
 		 * Define the index to span all fields using wildcard. <br/>
-		 * <strong>NOTE</strong> {@link TextIndexDefinition} cannot contain any other fields when defined with wildcard.
+		 * <strong>NOTE:</strong> {@link TextIndexDefinition} cannot contain any other fields when defined with wildcard.
 		 *
 		 * @return
 		 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndex.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndex.java
@@ -61,7 +61,7 @@ public class WildcardIndex extends Index {
 	/**
 	 * Create a new instance of {@link WildcardIndex} for the given {@literal path}. If no {@literal path} is provided the
 	 * index will be considered a root one using {@code $**}. <br />
-	 * <strong>NOTE</strong> {@link #wildcardProjectionInclude(String...)}, {@link #wildcardProjectionExclude(String...)}
+	 * <strong>NOTE:</strong> {@link #wildcardProjectionInclude(String...)}, {@link #wildcardProjectionExclude(String...)}
 	 * can only be used for top level index definitions having an {@literal empty} or {@literal null} path.
 	 *
 	 * @param path can be {@literal null}. If {@literal null} all fields will be indexed.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndexed.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/WildcardIndexed.java
@@ -119,7 +119,7 @@ public @interface WildcardIndexed {
 	/**
 	 * Explicitly specify sub fields to be in-/excluded as a {@link org.bson.Document#parse(String) prasable} String.
 	 * <br />
-	 * <strong>NOTE: </strong>Can only be applied on root level documents.
+	 * <strong>NOTE:</strong> Can only be applied on root level documents.
 	 *
 	 * @return empty by default.
 	 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Field.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Field.java
@@ -72,7 +72,7 @@ public @interface Field {
 	 * {@literal null} values are not written to the target {@code Document}. Setting the value to {@link Write#ALWAYS}
 	 * explicitly adds an entry for the given field holding {@literal null} as a value {@code 'fieldName' : null }.
 	 * <br />
-	 * <strong>NOTE</strong>Setting the value to {@link Write#ALWAYS} may lead to increased document size.
+	 * <strong>NOTE:</strong> Setting the value to {@link Write#ALWAYS} may lead to increased document size.
 	 *
 	 * @return {@link Write#NON_NULL} by default.
 	 * @since 3.3

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/MongoMappingContext.java
@@ -97,11 +97,11 @@ public class MongoMappingContext extends AbstractMappingContext<MongoPersistentE
 
 	/**
 	 * Returns whether auto-index creation is enabled or disabled. <br />
-	 * <strong>NOTE:</strong>Index creation should happen at a well-defined time that is ideally controlled by the
+	 * <strong>NOTE:</strong> Index creation should happen at a well-defined time that is ideally controlled by the
 	 * application itself.
 	 *
 	 * @return {@literal true} when auto-index creation is enabled; {@literal false} otherwise. <br />
-	 *         <strong>INFO</strong>: As of 3.x the default will is set to {@literal false} was {@literal true} in 2.x.
+	 *         <strong>INFO:</strong> As of 3.x the default will is set to {@literal false} was {@literal true} in 2.x.
 	 * @since 2.2
 	 * @see org.springframework.data.mongodb.core.index.Indexed
 	 */

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Sharded.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Sharded.java
@@ -64,7 +64,7 @@ public @interface Sharded {
 	 * is either a single or multiple indexed properties that exist in every document in the collection.
 	 * <br />
 	 * By default the {@literal id} property is used for sharding. <br />
-	 * <strong>NOTE</strong> Required indexes are not created automatically. Create these either externally, via
+	 * <strong>NOTE:</strong> Required indexes are not created automatically. Create these either externally, via
 	 * {@link org.springframework.data.mongodb.core.index.IndexOperations#ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition)}
 	 * or by annotating your domain model with {@link org.springframework.data.mongodb.core.index.Indexed}/
 	 * {@link org.springframework.data.mongodb.core.index.CompoundIndex} along with enabled

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/NearQuery.java
@@ -225,7 +225,7 @@ public final class NearQuery {
 
 	/**
 	 * Creates a new {@link NearQuery} starting at the given {@link Point}. <br />
-	 * <strong>NOTE</strong> There is a difference in using {@link Point} versus {@link GeoJsonPoint}. {@link Point}
+	 * <strong>NOTE:</strong> There is a difference in using {@link Point} versus {@link GeoJsonPoint}. {@link Point}
 	 * values are rendered as coordinate pairs in the legacy format and operate upon radians, whereas the
 	 * {@link GeoJsonPoint} uses according to its specification {@literal meters} as unit of measure. This may lead to
 	 * different results when using a {@link Metrics#NEUTRAL neutral Metric}.
@@ -241,7 +241,7 @@ public final class NearQuery {
 	 * Creates a {@link NearQuery} starting near the given {@link Point} using the given {@link Metric} to adapt given
 	 * values to further configuration. E.g. setting a {@link #maxDistance(double)} will be interpreted as a value of the
 	 * initially set {@link Metric}. <br />
-	 * <strong>NOTE</strong> There is a difference in using {@link Point} versus {@link GeoJsonPoint}. {@link Point}
+	 * <strong>NOTE:</strong> There is a difference in using {@link Point} versus {@link GeoJsonPoint}. {@link Point}
 	 * values are rendered as coordinate pairs in the legacy format and operate upon radians, whereas the
 	 * {@link GeoJsonPoint} uses according to its specification {@literal meters} as unit of measure. This may lead to
 	 * different results when using a {@link Metrics#NEUTRAL neutral Metric}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsOperations.java
@@ -173,7 +173,7 @@ public interface ReactiveGridFsOperations {
 
 	/**
 	 * Returns a {@link Flux} emitting all files matching the given query. <br />
-	 * <strong>Note:</strong> Currently {@link Sort} criteria defined at the {@link Query} will not be regarded as MongoDB
+	 * <strong>NOTE:</strong> Currently {@link Sort} criteria defined at the {@link Query} will not be regarded as MongoDB
 	 * does not support ordering for GridFS file access.
 	 *
 	 * @see <a href="https://jira.mongodb.org/browse/JAVA-431">MongoDB Jira: JAVA-431</a>
@@ -185,7 +185,7 @@ public interface ReactiveGridFsOperations {
 	/**
 	 * Returns a {@link Mono} emitting a single {@link com.mongodb.client.gridfs.model.GridFSFile} matching the given
 	 * query or {@link Mono#empty()} in case no file matches. <br />
-	 * <strong>NOTE</strong> If more than one file matches the given query the resulting {@link Mono} emits an error. If
+	 * <strong>NOTE:</strong> If more than one file matches the given query the resulting {@link Mono} emits an error. If
 	 * you want to obtain the first found file use {@link #findFirst(Query)}.
 	 *
 	 * @param query must not be {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsResource.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/gridfs/ReactiveGridFsResource.java
@@ -136,7 +136,7 @@ public class ReactiveGridFsResource implements GridFsObject<Object, Publisher<Da
 
 	/**
 	 * Obtain the data as {@link InputStream}. <br />
-	 * <strong>NOTE</strong> Buffers data in memory. Use {@link #getDownloadStream()} for large files.
+	 * <strong>NOTE:</strong> Buffers data in memory. Use {@link #getDownloadStream()} for large files.
 	 *
 	 * @throws IllegalStateException if the underlying {@link Publisher} has already been consumed.
 	 * @see org.springframework.core.io.InputStreamResource#getInputStream()


### PR DESCRIPTION
In the documentation key words that use <strong> tags, e.g. "NOTE:" or "INFO:" were inconsistently formatted.
I have:
* capitalized the entire key word (NOTE, INFO)
* added/moved the : inside the <strong> tags
* added/moved the whitespace after the closing tag

Unfortunately, your code formatting instructions caused changes to most files (I used current version of IntelliJ and the eclipse formatter adapter plugin and I have applied the import settings to a fresh copy of intellij's default profile),
=> Since this PR is adding at most a single character into java docs, it should not cause any problems.
However, multiple existing lines already exceed 120 chars

My first contribution here! :)

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
