### PR TITLE
Fix javadoc param names.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ScriptOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ScriptOperators.java
@@ -446,7 +446,7 @@ public class ScriptOperators {
 			/**
 			 * Define the optional {@code initArgs} for the {@link #init(String)} function.
 			 *
-			 * @param function must not be {@literal null}.
+			 * @param args must not be {@literal null}.
 			 * @return this.
 			 */
 			@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatialIndexTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/geo/GeoSpatialIndexTests.java
@@ -117,8 +117,8 @@ public class GeoSpatialIndexTests extends AbstractIntegrationTests {
 	/**
 	 * Returns whether an index with the given name exists for the given entity type.
 	 *
-	 * @param indexName
 	 * @param entityType
+	 * @param type
 	 * @return
 	 */
 	private boolean hasIndexOfType(Class<?> entityType, final String type) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/SubscriptionUtils.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/SubscriptionUtils.java
@@ -45,7 +45,7 @@ class SubscriptionUtils {
 	 * Wait for all {@link Subscription Subscriptions} to {@link Subscription#isActive() become active} but not longer
 	 * than {@link #DEFAULT_TIMEOUT}.
 	 *
-	 * @param subscription
+	 * @param subscriptions
 	 * @throws InterruptedException
 	 */
 	static void awaitSubscriptions(Subscription... subscriptions) throws InterruptedException {
@@ -131,7 +131,8 @@ class SubscriptionUtils {
 	/**
 	 * {@link MessageListener} implementation collecting received {@link Message messages}.
 	 *
-	 * @param <M>
+	 * @param <S> source message type.
+	 * @param <T> target message type.
 	 */
 	static class CollectingMessageListener<S, T> implements MessageListener<S, T> {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/Assertions.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/test/util/Assertions.java
@@ -32,7 +32,7 @@ public abstract class Assertions extends org.assertj.core.api.Assertions {
 	/**
 	 * Create assertion for {@link Document}.
 	 *
-	 * @param actual the actual value.
+	 * @param document the actual value.
 	 * @return the created assertion object.
 	 */
 	public static DocumentAssert assertThat(Document document) {


### PR DESCRIPTION
Fixed param names in javadocs

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
