### PR TITLE
Support automatic registration of converters

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -161,6 +161,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Yadhukrishna S Pai
  * @author Anton Barkan
  * @author Bartłomiej Mazur
+ * @author Sangyong Choi
  */
 public class MongoTemplate implements MongoOperations, ApplicationContextAware, IndexOperationsProvider {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -72,16 +72,7 @@ import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
 import org.springframework.data.mongodb.core.aggregation.AggregationPipeline;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
-import org.springframework.data.mongodb.core.convert.DbRefResolver;
-import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
-import org.springframework.data.mongodb.core.convert.JsonSchemaMapper;
-import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import org.springframework.data.mongodb.core.convert.MongoJsonSchemaMapper;
-import org.springframework.data.mongodb.core.convert.MongoWriter;
-import org.springframework.data.mongodb.core.convert.QueryMapper;
-import org.springframework.data.mongodb.core.convert.UpdateMapper;
+import org.springframework.data.mongodb.core.convert.*;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.index.IndexOperationsProvider;
 import org.springframework.data.mongodb.core.index.MongoMappingEventPublisher;
@@ -2766,10 +2757,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	private MongoConverter getDefaultMongoConverter(MongoDatabaseFactory factory) {
-		List<Converter> converters;
+		List<DocumentFieldConverter> converters;
 		if (listableBeanFactory != null) {
 			converters = listableBeanFactory
-					.getBeansOfType(Converter.class)
+					.getBeansOfType(DocumentFieldConverter.class)
 					.values()
 					.stream()
 					.toList();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2765,11 +2765,16 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	private MongoConverter getDefaultMongoConverter(MongoDatabaseFactory factory) {
-		List<Converter> converters = listableBeanFactory
-				.getBeansOfType(Converter.class)
-				.values()
-				.stream()
-				.toList();
+		List<Converter> converters;
+		if (listableBeanFactory != null) {
+			converters = listableBeanFactory
+					.getBeansOfType(Converter.class)
+					.values()
+					.stream()
+					.toList();
+		} else {
+			converters = Collections.emptyList();
+		}
 
 		DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
 		MongoCustomConversions conversions = new MongoCustomConversions(converters);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -19,6 +19,7 @@ import static org.springframework.data.mongodb.core.query.SerializationUtils.*;
 
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mongodb.core.convert.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
@@ -87,14 +88,6 @@ import org.springframework.data.mongodb.core.aggregation.PrefixingDelegatingAggr
 import org.springframework.data.mongodb.core.aggregation.RelaxedTypeBasedAggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.TypeBasedAggregationOperationContext;
 import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
-import org.springframework.data.mongodb.core.convert.DbRefResolver;
-import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import org.springframework.data.mongodb.core.convert.MongoWriter;
-import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
-import org.springframework.data.mongodb.core.convert.QueryMapper;
-import org.springframework.data.mongodb.core.convert.UpdateMapper;
 import org.springframework.data.mongodb.core.index.MongoMappingEventPublisher;
 import org.springframework.data.mongodb.core.index.ReactiveIndexOperations;
 import org.springframework.data.mongodb.core.index.ReactiveMongoPersistentEntityIndexCreator;
@@ -2585,10 +2578,10 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	}
 
 	private MappingMongoConverter getDefaultMongoConverter() {
-		List<Converter> converters;
+		List<DocumentFieldConverter> converters;
 		if (listableBeanFactory != null) {
 			converters = listableBeanFactory
-					.getBeansOfType(Converter.class)
+					.getBeansOfType(DocumentFieldConverter.class)
 					.values()
 					.stream()
 					.toList();

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -159,6 +159,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
  * @author Roman Puchkovskiy
  * @author Mathieu Ouellet
  * @author Yadhukrishna S Pai
+ * @author Sangyong Choi
  * @since 2.0
  */
 public class ReactiveMongoTemplate implements ReactiveMongoOperations, ApplicationContextAware {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentFieldConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentFieldConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2011-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.convert;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * @author Sangyong choi
+ */
+public interface DocumentFieldConverter<S, T> extends Converter<S, T> {
+}


### PR DESCRIPTION
Hi, i am spring-data-mongo user.
I had some inconvenience when registered converters.
Is currently manually register converters.
```kotlin
@Bean
fun mongoCustomConversions(): MongoCustomConversions {
    val converters = applicationContext.getBeansOfType(Converter::class.java).values
        .stream().collect(Collectors.toList())
    return MongoCustomConversions(converters)
}
```
Can I change to automatic registration from manually registration ?
If it's not possible, can you tell me why?