### PR TITLE
update Type "boolean" to "bool"

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaObject.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaObject.java
@@ -295,7 +295,7 @@ public interface JsonSchemaObject {
 		Type OBJECT = jsonTypeOf("object");
 		Type ARRAY = jsonTypeOf("array");
 		Type NUMBER = jsonTypeOf("number");
-		Type BOOLEAN = jsonTypeOf("boolean");
+		Type BOOLEAN = jsonTypeOf("bool");
 		Type STRING = jsonTypeOf("string");
 		Type NULL = jsonTypeOf("null");
 


### PR DESCRIPTION
mongodb command :  {$type}  
When you use boolean match，you will have a error like : Query failed with error code 2 and error message 'Unknown type name alias: boolean'

because mongodb manual {$type : "bool" } , not "boolean";
link [mongodb type desc](https://www.mongodb.com/docs/manual/reference/operator/query/type/ )
