### PR TITLE
Aligns the context entries with the rest of the portfolio

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/ContextProviderFactory.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/ContextProviderFactory.java
@@ -85,7 +85,8 @@ public class ContextProviderFactory {
 
 			Observation currentObservation = observationRegistry.getCurrentObservation();
 			if (currentObservation != null) {
-				requestContext.put(Observation.class, currentObservation);
+				// Aligned with ObservationThreadLocalAccessor.KEY
+				requestContext.put("micrometer.observation", currentObservation);
 			}
 
 			return requestContext;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -196,7 +196,7 @@ public class MongoObservationCommandListener implements CommandListener {
 		}
 
 		if (log.isDebugEnabled()) {
-			log.debug("No observation was found - will not create any child spans");
+			log.debug("No observation was found - will not create any child observations");
 		}
 
 		return null;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -42,6 +42,11 @@ public class MongoObservationCommandListener implements CommandListener {
 
 	private static final Log log = LogFactory.getLog(MongoObservationCommandListener.class);
 
+	/**
+	 * Aligns with ObservationThreadLocalAccessor.KEY.
+	 */
+	private static final String MICROMETER_OBSERVATION_KEY = "micrometer.observation";
+
 	private final ObservationRegistry observationRegistry;
 	private final @Nullable ConnectionString connectionString;
 
@@ -114,7 +119,7 @@ public class MongoObservationCommandListener implements CommandListener {
 
 		observation.start();
 
-		requestContext.put("micrometer.observation", observation);
+		requestContext.put(MICROMETER_OBSERVATION_KEY, observation);
 
 		if (log.isDebugEnabled()) {
 			log.debug(
@@ -131,7 +136,7 @@ public class MongoObservationCommandListener implements CommandListener {
 			return;
 		}
 
-		Observation observation = requestContext.getOrDefault("micrometer.observation", null);
+		Observation observation = requestContext.getOrDefault(MICROMETER_OBSERVATION_KEY, null);
 		if (observation == null) {
 			return;
 		}
@@ -155,7 +160,7 @@ public class MongoObservationCommandListener implements CommandListener {
 			return;
 		}
 
-		Observation observation = requestContext.getOrDefault("micrometer.observation", null);
+		Observation observation = requestContext.getOrDefault(MICROMETER_OBSERVATION_KEY, null);
 		if (observation == null) {
 			return;
 		}
@@ -180,7 +185,7 @@ public class MongoObservationCommandListener implements CommandListener {
 	@Nullable
 	private static Observation observationFromContext(RequestContext context) {
 
-		Observation observation = context.getOrDefault("micrometer.observation", null);
+		Observation observation = context.getOrDefault(MICROMETER_OBSERVATION_KEY, null);
 
 		if (observation != null) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -114,8 +114,7 @@ public class MongoObservationCommandListener implements CommandListener {
 
 		observation.start();
 
-		requestContext.put(Observation.class, observation);
-		requestContext.put(MongoHandlerContext.class, observationContext);
+		requestContext.put("micrometer.observation", observation);
 
 		if (log.isDebugEnabled()) {
 			log.debug(
@@ -132,12 +131,12 @@ public class MongoObservationCommandListener implements CommandListener {
 			return;
 		}
 
-		Observation observation = requestContext.getOrDefault(Observation.class, null);
+		Observation observation = requestContext.getOrDefault("micrometer.observation", null);
 		if (observation == null) {
 			return;
 		}
 
-		MongoHandlerContext context = requestContext.get(MongoHandlerContext.class);
+		MongoHandlerContext context = (MongoHandlerContext) observation.getContext();
 		context.setCommandSucceededEvent(event);
 
 		if (log.isDebugEnabled()) {
@@ -156,12 +155,12 @@ public class MongoObservationCommandListener implements CommandListener {
 			return;
 		}
 
-		Observation observation = requestContext.getOrDefault(Observation.class, null);
+		Observation observation = requestContext.getOrDefault("micrometer.observation", null);
 		if (observation == null) {
 			return;
 		}
 
-		MongoHandlerContext context = requestContext.get(MongoHandlerContext.class);
+		MongoHandlerContext context = (MongoHandlerContext) observation.getContext();
 		context.setCommandFailedEvent(event);
 
 		if (log.isDebugEnabled()) {
@@ -181,7 +180,7 @@ public class MongoObservationCommandListener implements CommandListener {
 	@Nullable
 	private static Observation observationFromContext(RequestContext context) {
 
-		Observation observation = context.getOrDefault(Observation.class, null);
+		Observation observation = context.getOrDefault("micrometer.observation", null);
 
 		if (observation != null) {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/ReactiveIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/ReactiveIntegrationTests.java
@@ -73,7 +73,7 @@ public class ReactiveIntegrationTests extends SampleTestRunner {
 					.verifyComplete();
 
 			repository.findByLastname("Matthews") //
-					.contextWrite(Context.of(Observation.class, intermediate)) //
+					.contextWrite(Context.of("micrometer.observation", intermediate)) //
 					.as(StepVerifier::create).assertNext(actual -> {
 
 						assertThat(actual).extracting("firstname", "lastname").containsExactly("Dave", "Matthews");


### PR DESCRIPTION
without this change each project will set the observation in the reactive context to `micrometer.observation` and only for mongodb will we need to set it to `Observation.class`. This has to be changed to be consistent.