### PR TITLE
Add missing hints for Querydsl integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-4244-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4244-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4244-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4244-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbQuerySupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbQuerySupport.java
@@ -22,8 +22,6 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
 
-import org.springframework.beans.DirectFieldAccessor;
-
 import com.mongodb.MongoClientSettings;
 import com.querydsl.core.support.QueryMixin;
 import com.querydsl.core.types.OrderSpecifier;
@@ -49,11 +47,10 @@ abstract class SpringDataMongodbQuerySupport<Q extends SpringDataMongodbQuerySup
 
 	@SuppressWarnings("unchecked")
 	SpringDataMongodbQuerySupport(MongodbDocumentSerializer serializer) {
+
 		super(serializer);
 		this.serializer = serializer;
-
-		DirectFieldAccessor fieldAccessor = new DirectFieldAccessor(this);
-		this.superQueryMixin = (QueryMixin<Q>) fieldAccessor.getPropertyValue("queryMixin");
+		this.superQueryMixin = super.getQueryMixin();
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/aot/MongoRuntimeHintsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/aot/MongoRuntimeHintsUnitTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.aot;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.data.mongodb.classloading.HidingClassLoader;
+import org.springframework.data.mongodb.repository.support.QuerydslMongoPredicateExecutor;
+import org.springframework.data.mongodb.repository.support.ReactiveQuerydslMongoPredicateExecutor;
+
+import com.mongodb.client.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ */
+class MongoRuntimeHintsUnitTests {
+
+	@Test // GH-4244
+	void doesNotRegisterTypesForQuerydslIntegrationWhenQuerydslNotPresent() {
+
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new MongoRuntimeHints().registerHints(runtimeHints, new HidingClassLoader("com.querydsl"));
+
+		assertThat(runtimeHints)
+				.matches(RuntimeHintsPredicates.reflection().onType(QuerydslMongoPredicateExecutor.class).negate()
+						.and(RuntimeHintsPredicates.reflection().onType(ReactiveQuerydslMongoPredicateExecutor.class).negate()));
+
+	}
+
+	@Test // GH-4244
+	void registersTypesForQuerydslIntegration() {
+
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new MongoRuntimeHints().registerHints(runtimeHints, null);
+
+		assertThat(runtimeHints).matches(RuntimeHintsPredicates.reflection().onType(QuerydslMongoPredicateExecutor.class)
+				.and(RuntimeHintsPredicates.reflection().onType(ReactiveQuerydslMongoPredicateExecutor.class)));
+	}
+
+	@Test // GH-4244
+	void onlyRegistersReactiveTypesForQuerydslIntegrationWhenNoSyncClientPresent() {
+
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new MongoRuntimeHints().registerHints(runtimeHints, HidingClassLoader.hide(MongoClient.class));
+
+		assertThat(runtimeHints).matches(RuntimeHintsPredicates.reflection().onType(QuerydslMongoPredicateExecutor.class)
+				.negate().and(RuntimeHintsPredicates.reflection().onType(ReactiveQuerydslMongoPredicateExecutor.class)));
+	}
+
+	@Test // GH-4244
+	@Disabled("TODO: ReactiveWrappers does not support ClassLoader")
+	void doesNotRegistersReactiveTypesForQuerydslIntegrationWhenReactorNotPresent() {
+
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new MongoRuntimeHints().registerHints(runtimeHints, new HidingClassLoader("reactor.core"));
+
+		assertThat(runtimeHints).matches(RuntimeHintsPredicates.reflection().onType(QuerydslMongoPredicateExecutor.class)
+				.and(RuntimeHintsPredicates.reflection().onType(ReactiveQuerydslMongoPredicateExecutor.class).negate()));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/classloading/HidingClassLoader.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/classloading/HidingClassLoader.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.classloading;
+
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.springframework.instrument.classloading.ShadowingClassLoader;
+import org.springframework.util.Assert;
+
+/**
+ * is intended for testing code that depends on the presence/absence of certain classes. Classes can be:
+ * <ul>
+ * <li>shadowed: reloaded by this classloader no matter if they are loaded already by the SystemClassLoader</li>
+ * <li>hidden: not loaded by this classloader no matter if they are loaded already by the SystemClassLoader. Trying to
+ * load these classes results in a {@link ClassNotFoundException}</li>
+ * <li>all other classes get loaded by the SystemClassLoader</li>
+ * </ul>
+ *
+ * @author Jens Schauder
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ */
+public class HidingClassLoader extends ShadowingClassLoader {
+
+	private final Collection<String> hidden;
+
+	public HidingClassLoader(String... hidden) {
+		this(Arrays.asList(hidden));
+	}
+
+	public HidingClassLoader(Collection<String> hidden) {
+
+		super(URLClassLoader.getSystemClassLoader(), false);
+
+		this.hidden = hidden;
+	}
+
+	/**
+	 * Creates a new {@link HidingClassLoader} with the packages of the given classes hidden.
+	 *
+	 * @param packages must not be {@literal null}.
+	 * @return
+	 */
+	public static HidingClassLoader hide(Class<?>... packages) {
+
+		Assert.notNull(packages, "Packages must not be null");
+
+		return new HidingClassLoader(Arrays.stream(packages)//
+				.map(it -> it.getPackage().getName())//
+				.collect(Collectors.toList()));
+	}
+
+	public static HidingClassLoader hideTypes(Class<?>... types) {
+
+		Assert.notNull(types, "Types must not be null!");
+
+		return new HidingClassLoader(Arrays.stream(types)//
+				.map(it -> it.getName())//
+				.collect(Collectors.toList()));
+	}
+
+	@Override
+	public Class<?> loadClass(String name) throws ClassNotFoundException {
+
+		Class<?> loaded = super.loadClass(name);
+		checkIfHidden(loaded);
+		return loaded;
+	}
+
+	@Override
+	protected boolean isEligibleForShadowing(String className) {
+		return isExcluded(className);
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+
+		Class<?> loaded = super.findClass(name);
+		checkIfHidden(loaded);
+		return loaded;
+	}
+
+	private void checkIfHidden(Class<?> type) throws ClassNotFoundException {
+
+		if (hidden.stream().anyMatch(it -> type.getName().startsWith(it))) {
+			throw new ClassNotFoundException();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds missing reflection configuration for Querydsl integration. 
We now also make sure to call the `queryMixing` getter instead of reading the field via reflection.

Manual registration of `Q` classes is still required (see: spring-projects/spring-data-commons#2721)

Closes: #4244 

---

Should be back ported to _4.0.x_