### PR TITLE
Fix "firsntame" typo in reference documentation

### DIFF
--- a/src/main/asciidoc/reference/document-references.adoc
+++ b/src/main/asciidoc/reference/document-references.adoc
@@ -437,7 +437,7 @@ class Entity {
 // referenced object
 {
   "_id" : "9a48e32",
-  "firsntame" : "Josh",      <2>
+  "firstname" : "Josh",      <2>
   "lastname" : "Long",       <2>
 }
 ----


### PR DESCRIPTION
A typo found in documentation have been updated.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
