### PR TITLE
Nullable annotation added in constructor argument.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOptions.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Yadhukrishna S Pai
+ * @author Soumya Prakash Behera
  * @see Aggregation#withOptions(AggregationOptions)
  * @see TypedAggregation#withOptions(AggregationOptions)
  * @since 1.6
@@ -65,7 +66,7 @@ public class AggregationOptions {
 	 * @param explain whether to get the execution plan for the aggregation instead of the actual results.
 	 * @param cursor can be {@literal null}, used to pass additional options to the aggregation.
 	 */
-	public AggregationOptions(boolean allowDiskUse, boolean explain, Document cursor) {
+	public AggregationOptions(boolean allowDiskUse, boolean explain, @Nullable Document cursor) {
 		this(allowDiskUse, explain, cursor, null);
 	}
 


### PR DESCRIPTION
In one of the constructors of the AggregationOptions class, Nullable annotation is missing for an argument. This cursor parameter canbe null, however as it is not marked as Nullable, in some projects the sonar quality check is failing stating the reason "Nullness of parameters should be guaranteed."

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
