### PR TITLE
Adding support for InsertManyOptions for insert and insertAll methods

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.mongodb.core;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
@@ -47,12 +47,12 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
-import com.mongodb.ClientSessionOptions;
-import com.mongodb.ReadPreference;
-import com.mongodb.client.ClientSession;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.UpdateResult;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Interface that specifies a basic set of MongoDB operations. Implemented by {@link MongoTemplate}. Not often used but
@@ -1371,6 +1371,19 @@ public interface MongoOperations extends FluentMongoOperations {
 	<T> Collection<T> insert(Collection<? extends T> batchToSave, Class<?> entityClass);
 
 	/**
+	 * Insert a Collection of objects into a collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the batch of objects to save. Must not be {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects that.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given type.
+	 */
+    <T> Collection<T> insert(Collection<? extends T> batchToSave, Class<?> entityClass, InsertManyOptions options);
+
+    /**
 	 * Insert a batch of objects into the specified collection in a single batch write to the database.
 	 *
 	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
@@ -1378,6 +1391,17 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * @return the inserted objects that.
 	 */
 	<T> Collection<T> insert(Collection<? extends T> batchToSave, String collectionName);
+
+	/**
+	 * Insert a batch of objects into the specified collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects that.
+	 */
+	<T> Collection<T> insert(Collection<? extends T> batchToSave, String collectionName, InsertManyOptions options);
 
 	/**
 	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
@@ -1389,6 +1413,18 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *           {@link #getCollectionName(Class) derived} for the given objects.
 	 */
 	<T> Collection<T> insertAll(Collection<? extends T> objectsToSave);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the list of objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the given objects.
+	 */
+	<T> Collection<T> insertAll(Collection<? extends T> objectsToSave, InsertManyOptions options);
 
 	/**
 	 * Save the object to the collection for the entity type of the object to save. This will perform an insert if the

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -15,17 +15,16 @@
  */
 package org.springframework.data.mongodb.core;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
-import java.util.Collection;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.reactivestreams.client.ClientSession;
+import com.mongodb.reactivestreams.client.MongoCollection;
 import org.bson.Document;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-
 import org.springframework.data.geo.GeoResult;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -47,13 +46,12 @@ import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import com.mongodb.ClientSessionOptions;
-import com.mongodb.ReadPreference;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.UpdateResult;
-import com.mongodb.reactivestreams.client.ClientSession;
-import com.mongodb.reactivestreams.client.MongoCollection;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Interface that specifies a basic set of MongoDB operations executed in a reactive way.
@@ -68,6 +66,7 @@ import com.mongodb.reactivestreams.client.MongoCollection;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Mathieu Ouellet
+ * @author Tomasz Forys
  * @since 2.0
  * @see Flux
  * @see Mono
@@ -1147,6 +1146,16 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	<T> Flux<T> insert(Collection<? extends T> batchToSave, String collectionName);
 
 	/**
+	 * Insert a batch of objects into the specified collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insert(Collection<? extends T> batchToSave, String collectionName, InsertManyOptions options);
+	/**
 	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
 	 * class.
 	 *
@@ -1156,6 +1165,52 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 *           {@link #getCollectionName(Class) derived} for the given objects.
 	 */
 	<T> Flux<T> insertAll(Collection<? extends T> objectsToSave);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the list of objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the saved objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the given objects.
+	 */
+	<T> Flux<T> insertAll(Collection<? extends T> objectsToSave, InsertManyOptions options);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> objectsToSave, InsertManyOptions options);
+
+	/**
+	 * Insert a Collection of objects into a collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the type.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> batchToSave, Class<?> entityClass, InsertManyOptions options);
+
+	/**
+	 * Insert objects into the specified collection in a single batch write to the database with additional insert
+	 * options.
+	 *
+	 * @param batchToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> batchToSave, String collectionName, InsertManyOptions options);
 
 	/**
 	 * Insert the object into the collection for the entity type of the object to save. <br />

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -15,29 +15,27 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.mockito.Mockito.*;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
-import static org.springframework.data.mongodb.test.util.Assertions.*;
-
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerCursor;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.DistinctIterable;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MapReduceIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.*;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.math.BigInteger;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-
 import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -105,33 +103,24 @@ import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.CollectionUtils;
 
-import com.mongodb.MongoClientSettings;
-import com.mongodb.MongoException;
-import com.mongodb.MongoNamespace;
-import com.mongodb.ReadPreference;
-import com.mongodb.ServerAddress;
-import com.mongodb.ServerCursor;
-import com.mongodb.WriteConcern;
-import com.mongodb.client.AggregateIterable;
-import com.mongodb.client.DistinctIterable;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MapReduceIterable;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
-import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.CountOptions;
-import com.mongodb.client.model.CreateCollectionOptions;
-import com.mongodb.client.model.DeleteOptions;
-import com.mongodb.client.model.FindOneAndDeleteOptions;
-import com.mongodb.client.model.FindOneAndReplaceOptions;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.MapReduceAction;
-import com.mongodb.client.model.ReplaceOptions;
-import com.mongodb.client.model.TimeSeriesGranularity;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.UpdateResult;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 /**
  * Unit tests for {@link MongoTemplate}.
@@ -2174,7 +2163,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		Collection<Person> saved = template.insertAll(Arrays.asList(entity1, entity2));
 
 		verify(afterSaveCallback, times(2)).onAfterSave(any(), any(), anyString());
-		assertThat(saved.iterator().next().getId()).isEqualTo("after-save");
+		assertThat(saved).hasSize(2);
+		assertThat(saved).map(e -> e.getId()).containsExactly("after-save", "after-save");
 	}
 
 	@Test // DATAMONGO-2479

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -15,29 +15,32 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
-import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
-
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.TimeSeriesGranularity;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.reactivestreams.client.AggregatePublisher;
+import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
+import com.mongodb.reactivestreams.client.DistinctPublisher;
+import com.mongodb.reactivestreams.client.FindPublisher;
+import com.mongodb.reactivestreams.client.MapReducePublisher;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import org.assertj.core.api.Assertions;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -54,7 +57,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -96,30 +98,26 @@ import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.CollectionUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
-import com.mongodb.MongoClientSettings;
-import com.mongodb.ReadPreference;
-import com.mongodb.client.model.CountOptions;
-import com.mongodb.client.model.CreateCollectionOptions;
-import com.mongodb.client.model.DeleteOptions;
-import com.mongodb.client.model.FindOneAndDeleteOptions;
-import com.mongodb.client.model.FindOneAndReplaceOptions;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.ReplaceOptions;
-import com.mongodb.client.model.TimeSeriesGranularity;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.InsertManyResult;
-import com.mongodb.client.result.InsertOneResult;
-import com.mongodb.client.result.UpdateResult;
-import com.mongodb.reactivestreams.client.AggregatePublisher;
-import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
-import com.mongodb.reactivestreams.client.DistinctPublisher;
-import com.mongodb.reactivestreams.client.FindPublisher;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
-import com.mongodb.reactivestreams.client.MongoClient;
-import com.mongodb.reactivestreams.client.MongoCollection;
-import com.mongodb.reactivestreams.client.MongoDatabase;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
 
 /**
  * Unit tests for {@link ReactiveMongoTemplate}.
@@ -1359,7 +1357,7 @@ public class ReactiveMongoTemplateUnitTests {
 		entity1.id = "2";
 		entity1.firstname = "luke";
 
-		when(collection.insertMany(anyList())).then(invocation -> {
+		when(collection.insertMany(anyList(), any())).then(invocation -> {
 			List<?> list = invocation.getArgument(0);
 			return Flux.fromIterable(list).map(i -> mock(InsertManyResult.class));
 		});


### PR DESCRIPTION
Adding support for InsertManyOptions for insert and insertAll methods on ReactiveMongoTemplate and MongoTemplate
Using writer on MongoTemplate.doInsertAll (which wasn't used)
Closes #4252

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
