### PR TITLE
Adding support for InsertManyOptions for insert and insertAll methods

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -51,6 +51,7 @@ import com.mongodb.ClientSessionOptions;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 
@@ -71,6 +72,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Thomas Darimont
  * @author Maninder Singh
  * @author Mark Paluch
+ * @author Tomasz Forys
  */
 public interface MongoOperations extends FluentMongoOperations {
 
@@ -1371,6 +1373,19 @@ public interface MongoOperations extends FluentMongoOperations {
 	<T> Collection<T> insert(Collection<? extends T> batchToSave, Class<?> entityClass);
 
 	/**
+	 * Insert a Collection of objects into a collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the batch of objects to save. Must not be {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects that.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given type.
+	 */
+    <T> Collection<T> insert(Collection<? extends T> batchToSave, Class<?> entityClass, InsertManyOptions options);
+
+    /**
 	 * Insert a batch of objects into the specified collection in a single batch write to the database.
 	 *
 	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
@@ -1378,6 +1393,17 @@ public interface MongoOperations extends FluentMongoOperations {
 	 * @return the inserted objects that.
 	 */
 	<T> Collection<T> insert(Collection<? extends T> batchToSave, String collectionName);
+
+	/**
+	 * Insert a batch of objects into the specified collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects that.
+	 */
+	<T> Collection<T> insert(Collection<? extends T> batchToSave, String collectionName, InsertManyOptions options);
 
 	/**
 	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
@@ -1389,6 +1415,18 @@ public interface MongoOperations extends FluentMongoOperations {
 	 *           {@link #getCollectionName(Class) derived} for the given objects.
 	 */
 	<T> Collection<T> insertAll(Collection<? extends T> objectsToSave);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the list of objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the given objects.
+	 */
+	<T> Collection<T> insertAll(Collection<? extends T> objectsToSave, InsertManyOptions options);
 
 	/**
 	 * Save the object to the collection for the entity type of the object to save. This will perform an insert if the

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoOperations.java
@@ -50,6 +50,7 @@ import org.springframework.util.ClassUtils;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.ReadPreference;
+import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -68,6 +69,7 @@ import com.mongodb.reactivestreams.client.MongoCollection;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Mathieu Ouellet
+ * @author Tomasz Forys
  * @since 2.0
  * @see Flux
  * @see Mono
@@ -1147,6 +1149,16 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	<T> Flux<T> insert(Collection<? extends T> batchToSave, String collectionName);
 
 	/**
+	 * Insert a batch of objects into the specified collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the list of objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insert(Collection<? extends T> batchToSave, String collectionName, InsertManyOptions options);
+	/**
 	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
 	 * class.
 	 *
@@ -1156,6 +1168,52 @@ public interface ReactiveMongoOperations extends ReactiveFluentMongoOperations {
 	 *           {@link #getCollectionName(Class) derived} for the given objects.
 	 */
 	<T> Flux<T> insertAll(Collection<? extends T> objectsToSave);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the list of objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the saved objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the given objects.
+	 */
+	<T> Flux<T> insertAll(Collection<? extends T> objectsToSave, InsertManyOptions options);
+
+	/**
+	 * Insert a mixed Collection of objects into a database collection determining the collection name to use based on the
+	 * class with additional insert options.
+	 *
+	 * @param objectsToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> objectsToSave, InsertManyOptions options);
+
+	/**
+	 * Insert a Collection of objects into a collection in a single batch write to the database with additional
+	 * insert options.
+	 *
+	 * @param batchToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param entityClass class that determines the collection to use. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 * @throws org.springframework.data.mapping.MappingException if the target collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} for the type.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> batchToSave, Class<?> entityClass, InsertManyOptions options);
+
+	/**
+	 * Insert objects into the specified collection in a single batch write to the database with additional insert
+	 * options.
+	 *
+	 * @param batchToSave the publisher which provides objects to save. Must not be {@literal null}.
+	 * @param collectionName name of the collection to store the object in. Must not be {@literal null}.
+	 * @param options options for insert many operation. Must not be {@literal null}.
+	 * @return the inserted objects.
+	 */
+	<T> Flux<T> insertAll(Mono<? extends Collection<? extends T>> batchToSave, String collectionName, InsertManyOptions options);
 
 	/**
 	 * Insert the object into the collection for the entity type of the object to save. <br />

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -142,6 +142,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Michael J. Simons
  * @author Roman Puchkovskiy
  * @author Yadhukrishna S Pai
+ * @author Tomasz Forys
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
@@ -2186,7 +2187,8 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		Collection<Person> saved = template.insertAll(Arrays.asList(entity1, entity2));
 
 		verify(afterSaveCallback, times(2)).onAfterSave(any(), any(), anyString());
-		assertThat(saved.iterator().next().getId()).isEqualTo("after-save");
+		assertThat(saved).hasSize(2);
+		assertThat(saved).map(e -> e.getId()).containsExactly("after-save", "after-save");
 	}
 
 	@Test // DATAMONGO-2479

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
@@ -86,6 +86,7 @@ import org.springframework.data.mongodb.test.util.MongoServerCondition;
 import org.springframework.data.mongodb.test.util.ReactiveMongoTestTemplate;
 
 import com.mongodb.WriteConcern;
+import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.reactivestreams.client.MongoClient;
 
 /**
@@ -93,6 +94,7 @@ import com.mongodb.reactivestreams.client.MongoClient;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tomasz Forys
  */
 @ExtendWith({ MongoClientExtension.class, MongoServerCondition.class })
 public class ReactiveMongoTemplateTests {
@@ -537,13 +539,58 @@ public class ReactiveMongoTemplateTests {
 		ReactiveMongoTemplate template = new ReactiveMongoTemplate(factory);
 		template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
 
-		ObjectId id = new ObjectId();
-		Person person = new Person(id, "Amol");
-		person.setAge(28);
+		ObjectId duplicatedId = new ObjectId();
+		Person first = new Person(duplicatedId, "Amol");
+		first.setAge(28);
+		Person second = new Person(duplicatedId, "Bmol");
+		first.setAge(29);
+		Person uniquePerson = new Person("Cmol", 30);
 
-		template.insertAll(Arrays.asList(person, person)) //
+		template.insertAll(Arrays.asList(first, second, uniquePerson)) //
 				.as(StepVerifier::create) //
 				.verifyError(DataIntegrityViolationException.class);
+
+		Query query = new Query(where("firstName").is(uniquePerson.getFirstName()));
+		Person found = template.findOne(query, Person.class).block();
+		assertThat(found).isNull();
+	}
+
+	@Test
+	void storeCorrectObjectsOnInsertAllWithInsertManyOptionsAndUniqueViolation() {
+
+		ReactiveMongoTemplate template = new ReactiveMongoTemplate(factory);
+		template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
+
+		ObjectId duplicatedId = new ObjectId();
+		Person first = new Person(duplicatedId, "Amol");
+		first.setAge(28);
+		Person second = new Person(duplicatedId, "Bmol");
+		first.setAge(29);
+		Person uniquePerson = new Person("Cmol", 30);
+
+		template.insertAll(Arrays.asList(first, second, uniquePerson), new InsertManyOptions().ordered(false)) //
+				.as(StepVerifier::create) //
+				.verifyError(DataIntegrityViolationException.class);
+
+		Query query = new Query(where("firstName").is(uniquePerson.getFirstName()));
+		Person found = template.findOne(query, Person.class).block();
+		assertThat(found).isNotNull();
+		assertThat(found.getAge()).isEqualTo(30);
+	}
+
+	@Test
+	void testNullInsertManyOptionsValidation() {
+
+		ReactiveMongoTemplate template = new ReactiveMongoTemplate(factory);
+		template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
+
+		Person person = new Person("Amol", 30);
+
+		template.insertAll(Arrays.asList(person), null) //
+				.as(StepVerifier::create) //
+				.verifyErrorSatisfies(error ->
+						assertThat(error).isInstanceOf(IllegalArgumentException.class)
+								.hasMessage("InsertManyOptions must not be null"));
 	}
 
 	@Test // DATAMONGO-1444

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -131,6 +131,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
  * @author Roman Puchkovskiy
  * @author Mathieu Ouellet
  * @author Yadhukrishna S Pai
+ * @author Tomasz Forys
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -1372,7 +1373,7 @@ public class ReactiveMongoTemplateUnitTests {
 		entity1.id = "2";
 		entity1.firstname = "luke";
 
-		when(collection.insertMany(anyList())).then(invocation -> {
+		when(collection.insertMany(anyList(), any())).then(invocation -> {
 			List<?> list = invocation.getArgument(0);
 			return Flux.fromIterable(list).map(i -> mock(InsertManyResult.class));
 		});


### PR DESCRIPTION
Adding support for InsertManyOptions for insert and insertAll methods on ReactiveMongoTemplate and MongoTemplate
Using writer on MongoTemplate.doInsertAll (which wasn't used)
Closes #4252

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).**

Clean PR @christophstrobl regarding #4252