### PR TITLE
Fix regression in findAndReplace when using native mongodb types as domain value

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -283,6 +283,10 @@ class EntityOperations {
 	 * @see EntityProjectionIntrospector#introspect(Class, Class)
 	 */
 	public <M, D> EntityProjection<M, D> introspectProjection(Class<M> resultType, Class<D> entityType) {
+
+		if (!queryMapper.getMappingContext().hasPersistentEntityFor(entityType)) {
+			return (EntityProjection) EntityProjection.nonProjecting(resultType);
+		}
 		return introspector.introspect(resultType, entityType);
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -2392,6 +2392,17 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 				.isEqualTo(new com.mongodb.client.model.TimeSeriesOptions("time_stamp").toString());
 	}
 
+	@Test // GH-4300
+	void findAndReplaceAllowsDocumentSourceType() {
+
+		template.findAndReplace(new Query(), new Document("spring", "data"), FindAndReplaceOptions.options().upsert(),
+				Document.class, "coll-1", Person.class);
+
+		verify(db).getCollection(eq("coll-1"), eq(Document.class));
+		verify(collection).findOneAndReplace((Bson) any(Bson.class), eq(new Document("spring", "data")),
+				any(FindOneAndReplaceOptions.class));
+	}
+
 	class AutogenerateableId {
 
 		@Id BigInteger id;


### PR DESCRIPTION
This PR fixes a regression that prevented native `org.bson.Document` to serve as source for a `findAndReplace` operation.

Closes: #4300 