### PR TITLE
Support hints on Update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-3218-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3218-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/HintFunction.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/HintFunction.java
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
  * Function object to apply a query hint. Can be an index name or a BSON document.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 4.1
  */
 class HintFunction {
@@ -65,6 +66,23 @@ class HintFunction {
 	 */
 	public boolean isPresent() {
 		return (hint instanceof String hintString && StringUtils.hasText(hintString)) || hint instanceof Bson;
+	}
+
+	/**
+	 * Apply the hint to consumers depending on the hint format if {@link #isPresent() present}.
+	 *
+	 * @param registryProvider
+	 * @param stringConsumer
+	 * @param bsonConsumer
+	 * @param <R>
+	 */
+	public <R> void ifPresent(@Nullable CodecRegistryProvider registryProvider, Function<String, R> stringConsumer,
+			Function<Bson, R> bsonConsumer) {
+
+		if (!isPresent()) {
+			return;
+		}
+		apply(registryProvider, stringConsumer, bsonConsumer);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryOperations.java
@@ -715,6 +715,7 @@ class QueryOperations {
 						.arrayFilters(update.getArrayFilters().stream().map(ArrayFilter::asDocument).collect(Collectors.toList()));
 			}
 
+			HintFunction.from(getQuery().getHint()).ifPresent(codecRegistryProvider, options::hintString, options::hint);
 			applyCollation(domainType, options::collation);
 
 			if (callback != null) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -978,6 +978,28 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 		assertThat(options.getValue().getCollation().getLocale()).isEqualTo("fr");
 	}
 
+	@Test // GH-3218
+	void updateUsesHintStringFromQuery() {
+
+		template.updateFirst(new Query().withHint("index-1"), new Update().set("spring", "data"), Human.class);
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateOne(any(Bson.class), any(Bson.class), options.capture());
+
+		assertThat(options.getValue().getHintString()).isEqualTo("index-1");
+	}
+
+	@Test // GH-3218
+	void updateUsesHintDocumentFromQuery() {
+
+		template.updateFirst(new Query().withHint("{ name : 1 }"), new Update().set("spring", "data"), Human.class);
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateOne(any(Bson.class), any(Bson.class), options.capture());
+
+		assertThat(options.getValue().getHint()).isEqualTo(new Document("name", 1));
+	}
+
 	@Test // DATAMONGO-1518
 	void replaceOneShouldUseCollationWhenPresent() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -350,7 +350,28 @@ public class ReactiveMongoTemplateUnitTests {
 		verify(collection).updateMany(any(), any(Bson.class), options.capture());
 
 		assertThat(options.getValue().getCollation().getLocale()).isEqualTo("fr");
+	}
 
+	@Test // GH-3218
+	void updateUsesHintStringFromQuery() {
+
+		template.updateFirst(new Query().withHint("index-1"), new Update().set("spring", "data"), Person.class).subscribe();
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateOne(any(Bson.class), any(Bson.class), options.capture());
+
+		assertThat(options.getValue().getHintString()).isEqualTo("index-1");
+	}
+
+	@Test // GH-3218
+	void updateUsesHintDocumentFromQuery() {
+
+		template.updateFirst(new Query().withHint("{ firstname : 1 }"), new Update().set("spring", "data"), Person.class).subscribe();
+
+		ArgumentCaptor<UpdateOptions> options = ArgumentCaptor.forClass(UpdateOptions.class);
+		verify(collection).updateOne(any(Bson.class), any(Bson.class), options.capture());
+
+		assertThat(options.getValue().getHint()).isEqualTo(new Document("firstname", 1));
 	}
 
 	@Test // DATAMONGO-1518

--- a/src/main/asciidoc/reference/mongodb.adoc
+++ b/src/main/asciidoc/reference/mongodb.adoc
@@ -922,6 +922,7 @@ Most methods return the `Update` object to provide a fluent style for the API.
 * *updateMulti*: Updates all objects that match the query document criteria with the updated document.
 
 WARNING: `updateFirst` does not support ordering. Please use <<mongo-template.find-and-upsert, findAndModify>> to apply `Sort`.
+NOTE: Index hints for the update operation can be provided via `Query.withHint(...)`.
 
 [[mongodb-template-update.update]]
 ==== Methods in the `Update` Class


### PR DESCRIPTION
This PR makes sure to read `Query` hints and apply them to the MongoDB `UpdateOptions` when running an _update _via `Reactive-/MongoTemplate`.

Closes: #3218