### PR TITLE
Support $expr via criteria query. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-2750-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpressionCriteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationExpressionCriteria.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.aggregation.EvaluationOperators.Expr;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.lang.Nullable;
+
+/**
+ * A {@link CriteriaDefinition criteria} to use {@code $expr} within a
+ * {@link org.springframework.data.mongodb.core.query.Query}.
+ *
+ * @author Christoph Strobl
+ * @since 4.1
+ */
+public class AggregationExpressionCriteria implements CriteriaDefinition {
+
+	private final AggregationExpression expression;
+
+	AggregationExpressionCriteria(AggregationExpression expression) {
+		this.expression = expression;
+	}
+
+	/**
+	 * @param expression must not be {@literal null}.
+	 * @return new instance of {@link AggregationExpressionCriteria}.
+	 */
+	public static AggregationExpressionCriteria whereExpr(AggregationExpression expression) {
+		return new AggregationExpressionCriteria(expression);
+	}
+
+	@Override
+	public Document getCriteriaObject() {
+
+		if (expression instanceof Expr expr) {
+			return new Document(getKey(), expr.get(0));
+		}
+		return new Document(getKey(), expression);
+	}
+
+	@Nullable
+	@Override
+	public String getKey() {
+		return "$expr";
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -41,6 +41,9 @@ import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.mapping.context.InvalidPersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoExpression;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationExpression;
+import org.springframework.data.mongodb.core.aggregation.RelaxedTypeBasedAggregationOperationContext;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter.NestedDocument;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -558,6 +561,13 @@ public class QueryMapper {
 
 		if (source instanceof Example) {
 			return exampleMapper.getMappedExample((Example<?>) source, entity);
+		}
+
+		if(source instanceof MongoExpression exr) {
+			if(source instanceof AggregationExpression age) {
+				return age.toDocument(new RelaxedTypeBasedAggregationOperationContext(entity.getType(), this.mappingContext, this));
+			}
+			return exr.toDocument();
 		}
 
 		if (source instanceof List) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -37,6 +37,7 @@ import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Shape;
 import org.springframework.data.mongodb.InvalidMongoDbApiUsageException;
+import org.springframework.data.mongodb.MongoExpression;
 import org.springframework.data.mongodb.core.geo.GeoJson;
 import org.springframework.data.mongodb.core.geo.Sphere;
 import org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type;
@@ -145,6 +146,37 @@ public class Criteria implements CriteriaDefinition {
 	 */
 	public static Criteria matchingDocumentStructure(MongoJsonSchema schema) {
 		return new Criteria().andDocumentStructureMatches(schema);
+	}
+
+	/**
+	 * Static factory method to create a {@link Criteria} matching a documents against the given {@link MongoExpression
+	 * expression}.
+	 * <p>
+	 * The {@link MongoExpression expression} can be either something that directly renders to the store native
+	 * representation like
+	 *
+	 * <pre class="code">
+	 * expr(() -> Document.parse("{ $gt : [ '$spent', '$budget'] }")))
+	 * </pre>
+	 * 
+	 * or an {@link org.springframework.data.mongodb.core.aggregation.AggregationExpression} which will be subject to
+	 * context (domain type) specific field mapping.
+	 *
+	 * <pre class="code">
+	 * expr(valueOf("amountSpent").greaterThan("budget"))
+	 * </pre>
+	 * 
+	 * @param expression must not be {@literal null}.
+	 * @return new instance of {@link Criteria}.
+	 * @since 4.1
+	 */
+	public static Criteria expr(MongoExpression expression) {
+
+		Assert.notNull(expression, "Expression must not be null");
+
+		Criteria criteria = new Criteria();
+		criteria.criteria.put("$expr", expression);
+		return criteria;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -19,6 +19,7 @@ import static org.springframework.util.ObjectUtils.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -46,7 +47,6 @@ import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
 import org.springframework.data.mongodb.util.RegexFlags;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -1394,7 +1394,7 @@ public class Criteria implements CriteriaDefinition {
 
 			Assert.hasText(bitmask, "Bitmask must not be null");
 
-			target.criteria.put(operator, new Binary(Base64Utils.decodeFromString(bitmask)));
+			target.criteria.put(operator, new Binary(Base64.getDecoder().decode(bitmask)));
 			return target;
 		}
 


### PR DESCRIPTION
This PR introduces `AggregationExpressionCriteria` and `Criteria.expr` to be used along with `Query` to run an `$expr` operator within the find query.

```java
query(whereExpr(valueOf("spent").greaterThan("budget")))
```

Closes: #2750