### PR TITLE
Allow reading already resolved DBRef values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-4312-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4312-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4312-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-4312-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -668,9 +668,32 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			return;
 		}
 
-		DBRef dbref = value instanceof DBRef ? (DBRef) value : null;
+		if (value instanceof DBRef dbref) {
+			accessor.setProperty(property, dbRefResolver.resolveDbRef(property, dbref, callback, handler));
+			return;
+		}
 
-		accessor.setProperty(property, dbRefResolver.resolveDbRef(property, dbref, callback, handler));
+		/*
+		 * The value might be a pre resolved full document (eg. resulting from an aggregation $lookup).
+		 * In this case we try to map that object to the target type without an additional step ($dbref resolution server roundtrip)
+		 * in between.
+		 */
+		if (value instanceof Document document) {
+			if(property.isMap()) {
+				if(document.isEmpty() || document.values().iterator().next() instanceof DBRef) {
+					accessor.setProperty(property, dbRefResolver.resolveDbRef(property, null, callback, handler));
+				} else {
+					accessor.setProperty(property, readMap(context, document, property.getTypeInformation()));
+				}
+			} else {
+				accessor.setProperty(property, read(property.getActualType(), document));
+			}
+		} else if (value instanceof Collection<?> collection && collection.size() > 0
+				&& collection.iterator().next() instanceof Document) {
+			accessor.setProperty(property, readCollectionOrArray(context, collection, property.getTypeInformation()));
+		} else {
+			accessor.setProperty(property, dbRefResolver.resolveDbRef(property, null, callback, handler));
+		}
 	}
 
 	@Nullable


### PR DESCRIPTION
This PR adds the ability to read (eg. by an aggregation `$lookup` stage) already fully resolved references between documents.
No proxy will be created for lazy loading references and we'll also skip the additional server roundtrip to load the reference by its `_id`.

The change only effects usage of `@DBRef` and does not change handling of `@DocumentReference` which do not have a dedicated type that would allow to distinguish between already resolved and raw references.

Since this is changing the behaviour of how we deal with `DBRef`s I'd keep it on _main_ for the time being and not back port it to any of the maintenance branches.

Closes: #4312 