### PR TITLE
Update UUID parsing in ParameterBindingJsonReader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-3750-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3750-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/DateTimeFormatter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/DateTimeFormatter.java
@@ -29,7 +29,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 
 /**
- * JsonBuffer implementation borrowed from <a href=
+ * DateTimeFormatter implementation borrowed from <a href=
  * "https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/json/DateTimeFormatter.java">MongoDB
  * Inc.</a> licensed under the Apache License, Version 2.0. <br />
  * Formatted and modified.
@@ -40,133 +40,23 @@ import java.util.TimeZone;
  */
 class DateTimeFormatter {
 
-	private static final FormatterImpl FORMATTER_IMPL;
-
-	static {
-		FormatterImpl dateTimeHelper;
-		try {
-			dateTimeHelper = loadDateTimeFormatter(
-					"org.springframework.data.mongodb.util.json.DateTimeFormatter$Java8DateTimeFormatter");
-		} catch (LinkageError e) {
-			// this is expected if running on a release prior to Java 8: fallback to JAXB.
-			dateTimeHelper = loadDateTimeFormatter(
-					"org.springframework.data.mongodb.util.json.DateTimeFormatter$JaxbDateTimeFormatter");
-		}
-
-		FORMATTER_IMPL = dateTimeHelper;
-	}
-
-	private static FormatterImpl loadDateTimeFormatter(final String className) {
-
-		try {
-			return (FormatterImpl) Class.forName(className).getDeclaredConstructor().newInstance();
-		} catch (ClassNotFoundException e) {
-			// this is unexpected as it means the class itself is not found
-			throw new ExceptionInInitializerError(e);
-		} catch (InstantiationException e) {
-			// this is unexpected as it means the class can't be instantiated
-			throw new ExceptionInInitializerError(e);
-		} catch (IllegalAccessException e) {
-			// this is unexpected as it means the no-args constructor isn't accessible
-			throw new ExceptionInInitializerError(e);
-		} catch (NoSuchMethodException e) {
-			throw new ExceptionInInitializerError(e);
-		} catch (InvocationTargetException e) {
-			throw new ExceptionInInitializerError(e);
-		}
-	}
-
 	static long parse(final String dateTimeString) {
-		return FORMATTER_IMPL.parse(dateTimeString);
+		try {
+			return ISO_OFFSET_DATE_TIME.parse(dateTimeString, new TemporalQuery<Instant>() {
+				@Override
+				public Instant queryFrom(final TemporalAccessor temporal) {
+					return Instant.from(temporal);
+				}
+			}).toEpochMilli();
+		} catch (DateTimeParseException e) {
+			throw new IllegalArgumentException(e.getMessage());
+		}
 	}
 
 	static String format(final long dateTime) {
-		return FORMATTER_IMPL.format(dateTime);
+		return ZonedDateTime.ofInstant(Instant.ofEpochMilli(dateTime), ZoneId.of("Z")).format(ISO_OFFSET_DATE_TIME);
 	}
 
-	private interface FormatterImpl {
-		long parse(String dateTimeString);
-
-		String format(long dateTime);
+	private DateTimeFormatter() {
 	}
-
-	// Reflective use of DatatypeConverter avoids a compile-time dependency on the java.xml.bind module in Java 9
-	static class JaxbDateTimeFormatter implements FormatterImpl {
-
-		private static final Method DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD;
-		private static final Method DATATYPE_CONVERTER_PRINT_DATE_TIME_METHOD;
-
-		static {
-			try {
-				DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD = Class.forName("jakarta.xml.bind.DatatypeConverter")
-						.getDeclaredMethod("parseDateTime", String.class);
-				DATATYPE_CONVERTER_PRINT_DATE_TIME_METHOD = Class.forName("jakarta.xml.bind.DatatypeConverter")
-						.getDeclaredMethod("printDateTime", Calendar.class);
-			} catch (NoSuchMethodException e) {
-				throw new ExceptionInInitializerError(e);
-			} catch (ClassNotFoundException e) {
-				throw new ExceptionInInitializerError(e);
-			}
-		}
-
-		@Override
-		public long parse(final String dateTimeString) {
-			try {
-				return ((Calendar) DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD.invoke(null, dateTimeString)).getTimeInMillis();
-			} catch (IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			} catch (InvocationTargetException e) {
-				throw (RuntimeException) e.getCause();
-			}
-		}
-
-		@Override
-		public String format(final long dateTime) {
-			Calendar calendar = Calendar.getInstance();
-			calendar.setTimeInMillis(dateTime);
-			calendar.setTimeZone(TimeZone.getTimeZone("Z"));
-			try {
-				return (String) DATATYPE_CONVERTER_PRINT_DATE_TIME_METHOD.invoke(null, calendar);
-			} catch (IllegalAccessException e) {
-				throw new IllegalStateException();
-			} catch (InvocationTargetException e) {
-				throw (RuntimeException) e.getCause();
-			}
-		}
-	}
-
-	static class Java8DateTimeFormatter implements FormatterImpl {
-
-		// if running on Java 8 or above then java.time.format.DateTimeFormatter will be available and initialization will
-		// succeed.
-		// Otherwise it will fail.
-		static {
-			try {
-				Class.forName("java.time.format.DateTimeFormatter");
-			} catch (ClassNotFoundException e) {
-				throw new ExceptionInInitializerError(e);
-			}
-		}
-
-		@Override
-		public long parse(final String dateTimeString) {
-			try {
-				return ISO_OFFSET_DATE_TIME.parse(dateTimeString, new TemporalQuery<Instant>() {
-					@Override
-					public Instant queryFrom(final TemporalAccessor temporal) {
-						return Instant.from(temporal);
-					}
-				}).toEpochMilli();
-			} catch (DateTimeParseException e) {
-				throw new IllegalArgumentException(e.getMessage());
-			}
-		}
-
-		@Override
-		public String format(final long dateTime) {
-			return ZonedDateTime.ofInstant(Instant.ofEpochMilli(dateTime), ZoneId.of("Z")).format(ISO_OFFSET_DATE_TIME);
-		}
-	}
-
-	private DateTimeFormatter() {}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -211,6 +211,38 @@ class ParameterBindingJsonReaderUnitTests {
 		assertThat(target).isEqualTo(Document.parse("{ 'end_date' : { $gte : { $date : " + time + " } } } "));
 	}
 
+	@Test // GH-3750
+	public void shouldParseISODate() {
+
+		String json = "{ 'value' : ISODate(\"1970-01-01T00:00:00Z\") }";
+		Date value = parse(json).get("value", Date.class);
+		assertThat(value.getTime()).isZero();
+	}
+
+	@Test // GH-3750
+	public void shouldParseISODateWith24HourTimeSpecification() {
+
+		String json = "{ 'value' : ISODate(\"2013-10-04T12:07:30.443Z\") }";
+		Date value = parse(json).get("value", Date.class);
+		assertThat(value.getTime()).isEqualTo(1380888450443L);
+	}
+
+	@Test // GH-3750
+	public void shouldParse$date() {
+
+		String json = "{ 'value' : { \"$date\" : \"2015-04-16T14:55:57.626Z\" } }";
+		Date value = parse(json).get("value", Date.class);
+		assertThat(value.getTime()).isEqualTo(1429196157626L);
+	}
+
+	@Test // GH-3750
+	public void shouldParse$dateWithTimeOffset() {
+
+		String json = "{ 'value' :{ \"$date\" : \"2015-04-16T16:55:57.626+02:00\" } }";
+		Date value = parse(json).get("value", Date.class);
+		assertThat(value.getTime()).isEqualTo(1429196157626L);
+	}
+
 	@Test // DATAMONGO-2418
 	void shouldNotAccessSpElEvaluationContextWhenNoSpElPresentInBindableTarget() {
 
@@ -485,7 +517,6 @@ class ParameterBindingJsonReaderUnitTests {
 		Document target = parse("{ 'parent' : null }");
 		assertThat(target).isEqualTo(new Document("parent", null));
 	}
-
 
 	@Test // GH-4089
 	void retainsSpelArgumentTypeViaArgumentIndex() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -27,6 +27,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import org.bson.BsonBinary;
+import org.bson.BsonBinarySubType;
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
 import org.junit.jupiter.api.Test;
@@ -545,6 +547,23 @@ class ParameterBindingJsonReaderUnitTests {
 		String source = "\\\" + new java.lang.Object() + \\\"";
 		Document target = parse("{ arg0 : :#{?0} }", source);
 		assertThat(target.get("arg0")).isEqualTo(source);
+	}
+
+	@Test // GH-3750
+	void shouldParseUUIDasStandardRepresentation() {
+
+		String json = "{ 'value' : UUID(\"b5f21e0c-2a0d-42d6-ad03-d827008d8ab6\") }";
+
+		BsonBinary value = parse(json).get("value", BsonBinary.class);
+		assertThat(value.getType()).isEqualTo(BsonBinarySubType.UUID_STANDARD.getValue());
+	}
+
+	@Test // GH-3750
+	public void shouldParse$uuidAsStandardRepresentation() {
+
+		String json = "{ 'value' : { '$uuid' : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\" } } }";
+		BsonBinary value = parse(json).get("value", BsonBinary.class);
+		assertThat(value.getType()).isEqualTo(BsonBinarySubType.UUID_STANDARD.getValue());
 	}
 
 	private static Document parse(String json, Object... args) {


### PR DESCRIPTION
Follow changes in MongoDB's json parsing and update $uuid and $date parsing.
Also favour `Base64` over `Base64Utils` and remove its usage.

Closes: #3750 