### PR TITLE
Add Hint annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-3230-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-3230-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Hint.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Hint.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Annotation to declare index hints for repository query, update and aggregate operations. The index is specified by
+ * its name.
+ * 
+ * @author Christoph Strobl
+ * @since 4.1
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Documented
+public @interface Hint {
+
+	String value() default "";
+
+	/**
+	 * The name of the index to use. In case of an {@literal aggregation} the index is evaluated against the initial
+	 * collection or view. Specify the index either by the index name.
+	 * 
+	 * @return the index name.
+	 */
+	@AliasFor("value")
+	String indexName() default "";
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/Query.java
@@ -39,13 +39,14 @@ import org.springframework.data.mongodb.core.annotation.Collation;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 @QueryAnnotation
+@Hint
 public @interface Query {
 
 	/**
 	 * Takes a MongoDB JSON string to define the actual query to be executed. This one will take precedence over the
 	 * method name then.
 	 *
-	 * @return empty {@link String}	by default.
+	 * @return empty {@link String} by default.
 	 */
 	String value() default "";
 
@@ -53,7 +54,7 @@ public @interface Query {
 	 * Defines the fields that should be returned for the given query. Note that only these fields will make it into the
 	 * domain object returned.
 	 *
-	 * @return empty {@link String}	by default.
+	 * @return empty {@link String} by default.
 	 */
 	String fields() default "";
 
@@ -129,4 +130,21 @@ public @interface Query {
 	 */
 	@AliasFor(annotation = Collation.class, attribute = "value")
 	String collation() default "";
+
+	/**
+	 * The name of the index to use. <br />
+	 * {@code @Query(value = "...", hint = "lastname-idx")} can be used as shortcut for:
+	 *
+	 * <pre class="code">
+	 * &#64;Query(...)
+	 * &#64;Hint("lastname-idx")
+	 * List&lt;User&gt; findAllByLastname(String collation);
+	 * </pre>
+	 *
+	 * @return the index name.
+	 * @since 4.1
+	 * @see Hint#indexName()
+	 */
+	@AliasFor(annotation = Hint.class, attribute = "indexName")
+	String hint() default "";
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -135,6 +135,7 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 		applyQueryMetaAttributesWhenPresent(query);
 		query = applyAnnotatedDefaultSortIfPresent(query);
 		query = applyAnnotatedCollationIfPresent(query, accessor);
+		query = applyHintIfPresent(query);
 
 		FindWithQuery<?> find = typeToRead == null //
 				? executableFind //
@@ -223,6 +224,21 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 
 		return QueryUtils.applyCollation(query, method.hasAnnotatedCollation() ? method.getAnnotatedCollation() : null,
 				accessor, getQueryMethod().getParameters(), expressionParser, evaluationContextProvider);
+	}
+
+	/**
+	 * If present apply the hint from the {@link org.springframework.data.mongodb.repository.Hint} annotation.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 4.1
+	 */
+	Query applyHintIfPresent(Query query) {
+
+		if(!method.hasAnnotatedHint()) {
+			return query;
+		}
+		return query.withHint(method.getAnnotatedHint());
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractReactiveMongoQuery.java
@@ -160,6 +160,7 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 			applyQueryMetaAttributesWhenPresent(query);
 			query = applyAnnotatedDefaultSortIfPresent(query);
 			query = applyAnnotatedCollationIfPresent(query, accessor);
+			query = applyHintIfPresent(query);
 
 			FindWithQuery<?> find = typeToRead == null //
 					? findOperationWithProjection //
@@ -267,6 +268,21 @@ public abstract class AbstractReactiveMongoQuery implements RepositoryQuery {
 
 		return QueryUtils.applyCollation(query, method.hasAnnotatedCollation() ? method.getAnnotatedCollation() : null,
 				accessor, getQueryMethod().getParameters(), expressionParser, evaluationContextProvider);
+	}
+
+	/**
+	 * If present apply the hint from the {@link org.springframework.data.mongodb.repository.Hint} annotation.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 4.1
+	 */
+	Query applyHintIfPresent(Query query) {
+
+		if(!method.hasAnnotatedHint()) {
+			return query;
+		}
+		return query.withHint(method.getAnnotatedHint());
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AggregationUtils.java
@@ -103,6 +103,21 @@ abstract class AggregationUtils {
 	}
 
 	/**
+	 * If present apply the hint from the {@link org.springframework.data.mongodb.repository.Hint} annotation.
+	 *
+	 * @param builder must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 4.1
+	 */
+	static AggregationOptions.Builder applyHint(AggregationOptions.Builder builder, MongoQueryMethod queryMethod) {
+
+		if(!queryMethod.hasAnnotatedHint()) {
+			return builder;
+		}
+		return builder.hint(queryMethod.getAnnotatedHint());
+	}
+
+	/**
 	 * Append {@code $sort} aggregation stage if {@link ConvertingParameterAccessor#getSort()} is present.
 	 *
 	 * @param aggregationPipeline

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/MongoQueryMethod.java
@@ -33,6 +33,7 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.Hint;
 import org.springframework.data.mongodb.repository.Meta;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Tailable;
@@ -360,6 +361,27 @@ public class MongoQueryMethod extends QueryMethod {
 	public String[] getAnnotatedAggregation() {
 		return findAnnotatedAggregation().orElseThrow(() -> new IllegalStateException(
 				"Expected to find @Aggregation annotation but did not; Make sure to check hasAnnotatedAggregation() before."));
+	}
+
+	/**
+	 * @return {@literal true} if the {@link Hint} annotation is present and the index name is not empty.
+	 * @since 4.1
+	 */
+	public boolean hasAnnotatedHint() {
+		return StringUtils.hasText(getAnnotatedHint());
+	}
+
+	/**
+	 * Returns the aggregation pipeline declared via a {@link Hint} annotation.
+	 *
+	 * @return the index name (might be empty) or {@literal null} if not present.
+	 * @since 4.1
+	 */
+	@Nullable
+	public String getAnnotatedHint() {
+
+		Optional<Hint> hint = doFindAnnotation(Hint.class);
+		return hint.map(Hint::indexName).orElse(null);
 	}
 
 	private Optional<String[]> findAnnotatedAggregation() {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveStringBasedAggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/ReactiveStringBasedAggregation.java
@@ -128,6 +128,7 @@ public class ReactiveStringBasedAggregation extends AbstractReactiveMongoQuery {
 		AggregationUtils.applyCollation(builder, method.getAnnotatedCollation(), accessor, method.getParameters(),
 				expressionParser, evaluationContextProvider);
 		AggregationUtils.applyMeta(builder, method);
+		AggregationUtils.applyHint(builder, method);
 
 		return builder.build();
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedAggregation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/StringBasedAggregation.java
@@ -29,6 +29,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
+import org.springframework.data.mongodb.core.aggregation.AggregationOptions.Builder;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -178,6 +179,7 @@ public class StringBasedAggregation extends AbstractMongoQuery {
 		AggregationUtils.applyCollation(builder, method.getAnnotatedCollation(), accessor, method.getParameters(),
 				expressionParser, evaluationContextProvider);
 		AggregationUtils.applyMeta(builder, method);
+		AggregationUtils.applyHint(builder, method);
 
 		return builder.build();
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedAggregationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/query/StringBasedAggregationUnitTests.java
@@ -58,6 +58,7 @@ import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.Hint;
 import org.springframework.data.mongodb.repository.Meta;
 import org.springframework.data.mongodb.repository.Person;
 import org.springframework.data.projection.ProjectionFactory;
@@ -260,6 +261,13 @@ public class StringBasedAggregationUnitTests {
 				.withMessageContaining("Page");
 	}
 
+	@Test // GH-3230
+	void aggregatePicksUpHintFromAnnotation() {
+
+		AggregationInvocation invocation = executeAggregation("withHint");
+		assertThat(hintOf(invocation)).isEqualTo("idx");
+	}
+
 	private AggregationInvocation executeAggregation(String name, Object... args) {
 
 		Class<?>[] argTypes = Arrays.stream(args).map(Object::getClass).toArray(Class[]::new);
@@ -299,6 +307,12 @@ public class StringBasedAggregationUnitTests {
 	@Nullable
 	private Collation collationOf(AggregationInvocation invocation) {
 		return invocation.aggregation.getOptions() != null ? invocation.aggregation.getOptions().getCollation().orElse(null)
+				: null;
+	}
+
+	@Nullable
+	private Object hintOf(AggregationInvocation invocation) {
+		return invocation.aggregation.getOptions() != null ? invocation.aggregation.getOptions().getHintObject().orElse(null)
 				: null;
 	}
 
@@ -350,6 +364,10 @@ public class StringBasedAggregationUnitTests {
 
 		@Aggregation(RAW_GROUP_BY_LASTNAME_STRING)
 		String simpleReturnType();
+
+		@Hint("idx")
+		@Aggregation(RAW_GROUP_BY_LASTNAME_STRING)
+		String withHint();
 	}
 
 	private interface UnsupportedRepository extends Repository<Person, Long> {

--- a/src/main/asciidoc/reference/mongo-repositories.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories.adoc
@@ -297,6 +297,25 @@ lower / upper bounds (`$gt` / `$gte` & `$lt` / `$lte`) according to `Range`
 
 NOTE: If the property criterion compares a document, the order of the fields and exact equality in the document matters.
 
+[[mongodb.repositories.queries.hint]]
+=== Repository Index Hints
+
+The `@Hint` annotation allows to override MongoDB's default index selection and forces the database to use the specified index instead.
+
+.Example of index hints
+====
+[source,java]
+----
+@Hint("lastname-idx") <1>
+List<Person> findByLastname(String lastname);
+
+@Query(value = "{ 'firstname' : ?0 }", hint="firstname-idx") <2>
+List<Person> findByFirstname(String firstname);
+----
+<1> Use the index with name `lastname-idx`.
+<2> The `@Query` annotation defines the `hint` alias which is equivalent to explicitly adding the `@Hint` annotation.
+====
+
 [[mongodb.repositories.queries.update]]
 === Repository Update Methods
 


### PR DESCRIPTION
This commit introduces the `@Hint` annotation that allows to override MongoDB's default index selection for repository query, update and aggregate operations.

```java
@Hint("lastname-idx")
List<Person> findByLastname(String lastname);
```

Closes: #3230