### PR TITLE
Fix regression in value to String mapping. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-4371-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4371-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4371-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4371-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -2313,8 +2313,10 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			if (source instanceof Collection<?> collection) {
 
 				Class<?> rawType = typeHint.getType();
-				if (!Object.class.equals(rawType)) {
+				if (!Object.class.equals(rawType) && !String.class.equals(rawType)) {
+
 					if (!rawType.isArray() && !ClassUtils.isAssignable(Iterable.class, rawType)) {
+
 						throw new MappingException(
 								String.format(INCOMPATIBLE_TYPES, source, source.getClass(), rawType, getPath()));
 					}
@@ -2341,11 +2343,6 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 
 			if (source instanceof DBRef dbRef) {
 				return (S) dbRefConverter.convert(context, dbRef, typeHint);
-			}
-
-			if (source instanceof Collection) {
-				throw new MappingException(
-						String.format(INCOMPATIBLE_TYPES, source, BasicDBList.class, typeHint.getType(), getPath()));
 			}
 
 			if (BsonUtils.supportsBson(source)) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2831,6 +2831,18 @@ class MappingMongoConverterUnitTests {
 		assertThat(converter.read(Cyclic.class, source).cycle.value).isEqualTo("v2");
 	}
 
+	@Test // GH-4371
+	void shouldConvertTypesToStringTargetType() {
+		
+		org.bson.Document source = org.bson.Document.parse("""
+				{
+				  city : ["Gotham", "Metropolis"]
+				}
+				""");
+
+		assertThat(converter.read(Address.class, source).city).isEqualTo("Gotham,Metropolis");
+	}
+
 	static class GenericType<T> {
 		T content;
 	}


### PR DESCRIPTION
Previous versions allow arbitrary values to be mapped to an string property by calling the ObjectToString converter. This behaviour got lost and is not reestablished.

Closes: #4371 