### PR TITLE
Fix Querydsl conversion for properties with explicit target type. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-4359-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4359-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4359-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-4359-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbSerializer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbSerializer.java
@@ -27,6 +27,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -149,11 +150,14 @@ class SpringDataMongodbSerializer extends MongodbDocumentSerializer {
 
 	protected Object convert(@Nullable Path<?> path, @Nullable Constant<?> constant) {
 
+		MongoPersistentProperty property = getPropertyFor(path);
+
 		if (!isReference(path)) {
+			if(property != null && property.hasExplicitWriteTarget()) {
+				return converter.convertToMongoType(constant.getConstant(), TypeInformation.of(property.getFieldType()));
+			}
 			return super.convert(path, constant);
 		}
-
-		MongoPersistentProperty property = getPropertyFor(path);
 
 		if (property.isDocumentReference()) {
 			return converter.toDocumentPointer(constant.getConstant(), property).getPointer();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbSerializerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SpringDataMongodbSerializerUnitTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.repository.Person.Sex;
 import org.springframework.data.mongodb.repository.QAddress;
@@ -244,6 +245,15 @@ public class SpringDataMongodbSerializerUnitTests {
 		Predicate predicate = QPerson.person.spiritAnimal.id.eq("007");
 
 		assertThat(serializer.handle(predicate)).isEqualTo(Document.parse("{ 'spiritAnimal' : '007' }"));
+	}
+
+	@Test // GH-4359
+	void parsesValueToExplicitTargetFieldType() {
+
+		ObjectId oid = new ObjectId();
+		Predicate predicate = QWithCustomTargetTypeProperty.withCustomTargetTypeProperty.customFieldType.eq(oid.toHexString());
+
+		assertThat(serializer.handle(predicate)).isEqualTo(new Document("customFieldType", oid));
 	}
 
 	class Address {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/WithCustomTargetTypeProperty.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/WithCustomTargetTypeProperty.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository.support;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+/**
+ * @author Christoph Strobl
+ */
+@org.springframework.data.mongodb.core.mapping.Document
+public class WithCustomTargetTypeProperty {
+
+	@Field(targetType = FieldType.OBJECT_ID) //
+	String customFieldType;
+}


### PR DESCRIPTION
This PR makes sure to convert values, for _Querydsl_ predicates pointing to a property with an explicitly annotated target type, into the desired format.

Resolves: #4359 