### PR TITLE
Add support for MongoDB Kotlin sync/coroutine Driver.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-4393-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4393-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4393-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4393-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -104,11 +104,23 @@
 			<version>${mongo}</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-kotlin-sync</artifactId>
+			<version>${mongo}</version>
+			<optional>true</optional>
+		</dependency>
 
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongodb-driver-reactivestreams</artifactId>
 			<version>${mongo.reactivestreams}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-kotlin-coroutine</artifactId>
+			<version>${mongo}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/SimpleMongoClientDatabaseFactoryExtension.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/SimpleMongoClientDatabaseFactoryExtension.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core
+
+import com.mongodb.kotlin.client.MongoClient
+import org.springframework.beans.DirectFieldAccessor
+
+/**
+ * Extension for [SimpleMongoClientDatabaseFactory] that accepts a [MongoClient].
+ *
+ * @author Christoph Strobl
+ * @since 4.2
+ */
+fun SimpleMongoClientDatabaseFactory(client: MongoClient, database: String): SimpleMongoClientDatabaseFactory =
+	SimpleMongoClientDatabaseFactory(
+		DirectFieldAccessor(client).getPropertyValue("wrapped") as com.mongodb.client.MongoClient,
+		database
+	)

--- a/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactoryExtension.kt
+++ b/spring-data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactoryExtension.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core
+
+import com.mongodb.kotlin.client.coroutine.MongoClient
+import org.springframework.beans.DirectFieldAccessor
+
+/**
+ * Extension for [SimpleReactiveMongoDatabaseFactory] that accepts a [MongoClient].
+ *
+ * @author Christoph Strobl
+ * @since 4.2
+ */
+fun SimpleReactiveMongoDatabaseFactory(client: MongoClient, database: String): SimpleReactiveMongoDatabaseFactory =
+	SimpleReactiveMongoDatabaseFactory(
+		DirectFieldAccessor(client).getPropertyValue("wrapped") as com.mongodb.reactivestreams.client.MongoClient,
+		database
+	)

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/SimpleMongoClientDatabaseFactoryExtensionTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/SimpleMongoClientDatabaseFactoryExtensionTests.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core
+
+import com.mongodb.kotlin.client.MongoClient
+import org.bson.Document
+import org.junit.jupiter.api.Test
+import org.springframework.data.mongodb.test.util.Assertions.assertThat
+
+/**
+ * @author Christoph Strobl
+ */
+class SimpleMongoClientDatabaseFactoryExtensionTests {
+
+	@Test // GH-4393
+	fun `extension allows to create SimpleMongoClientDatabaseFactory with a Kotlin Driver instance`() {
+
+		val factory = SimpleMongoClientDatabaseFactory(MongoClient.create(), "test")
+
+		assertThat(factory.mongoDatabase.runCommand(Document("ping", 1))).containsKey("ok")
+	}
+}

--- a/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactoryExtensionTests.kt
+++ b/spring-data-mongodb/src/test/kotlin/org/springframework/data/mongodb/core/SimpleReactiveMongoDatabaseFactoryExtensionTests.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mongodb.core
+
+import com.mongodb.kotlin.client.coroutine.MongoClient
+import org.bson.Document
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+/**
+ * @author Christoph Strobl
+ */
+class SimpleReactiveMongoDatabaseFactoryExtensionTests {
+
+	@Test // GH-4393
+	fun `extension allows to create SimpleReactiveMongoDatabaseFactory with a Kotlin Coroutine Driver instance`() {
+
+		val factory = SimpleReactiveMongoDatabaseFactory(MongoClient.create(), "test")
+
+		factory.mongoDatabase.flatMap { Mono.from(it.runCommand(Document("ping", 1))) }
+			.`as` { StepVerifier.create(it) }
+			.expectNextCount(1)
+			.verifyComplete()
+	}
+}


### PR DESCRIPTION
Provide an extension for `SimpleMongoClientDatabaseFactory` & `SimpleReactiveMongoDatabaseFactory` that accepts a `com.mongodb.kotlin.client.MongoClient` respectively `com.mongodb.kotlin.client.coroutine.MongoClient`

Since the Kotlin driver is wrapping the Java driver we can unwrap the instance and pass it on to the factory.

Though unfortunate that there's no public API to access the wrapped instance the provided tests will alert on driver changes. 

Closes: #4393 