### PR TITLE
Map collection and fields for `$lookup`/`$graphLookup` aggregation stage against domain type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-4379-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4379-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4379-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4379-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.beans.BeanUtils;
 import org.springframework.data.mongodb.CodecRegistryProvider;
+import org.springframework.data.mongodb.MongoCollectionUtils;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -77,6 +78,29 @@ public interface AggregationOperationContext extends CodecRegistryProvider {
 	 * @throws IllegalArgumentException if the context does not expose a field with the given name
 	 */
 	FieldReference getReference(String name);
+
+	/**
+	 * Obtain the target field name for a given field/type combination.
+	 * 
+	 * @param type The type containing the field.
+	 * @param field The property/field name
+	 * @return never {@literal null}.
+	 * @since 4.2
+	 */
+	default String getMappedFieldName(Class<?> type, String field) {
+		return field;
+	}
+
+	/**
+	 * Obtain the collection name for a given {@link Class type} combination.
+	 *
+	 * @param type
+	 * @return never {@literal null}.
+	 * @since 4.2
+	 */
+	default String getCollection(Class<?> type) {
+		return MongoCollectionUtils.getPreferredCollectionName(type);
+	}
 
 	/**
 	 * Returns the {@link Fields} exposed by the type. May be a {@literal class} or an {@literal interface}. The default

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationContext.java
@@ -81,7 +81,7 @@ public interface AggregationOperationContext extends CodecRegistryProvider {
 
 	/**
 	 * Obtain the target field name for a given field/type combination.
-	 * 
+	 *
 	 * @param type The type containing the field.
 	 * @param field The property/field name
 	 * @return never {@literal null}.
@@ -103,7 +103,7 @@ public interface AggregationOperationContext extends CodecRegistryProvider {
 	}
 
 	/**
-	 * Returns the {@link Fields} exposed by the type. May be a {@literal class} or an {@literal interface}. The default
+	 * Returns the {@link Fields} exposed by the type. Can be a {@literal class} or an {@literal interface}. The default
 	 * implementation uses {@link BeanUtils#getPropertyDescriptors(Class) property descriptors} discover fields from a
 	 * {@link Class}.
 	 *
@@ -133,7 +133,7 @@ public interface AggregationOperationContext extends CodecRegistryProvider {
 
 	/**
 	 * This toggle allows the {@link AggregationOperationContext context} to use any given field name without checking for
-	 * its existence. Typically the {@link AggregationOperationContext} fails when referencing unknown fields, those that
+	 * its existence. Typically, the {@link AggregationOperationContext} fails when referencing unknown fields, those that
 	 * are not present in one of the previous stages or the input source, throughout the pipeline.
 	 *
 	 * @return a more relaxed {@link AggregationOperationContext}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/LookupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/LookupOperation.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  */
 public class LookupOperation implements FieldsExposingAggregationOperation, InheritsFieldsAggregationOperation {
 
-	private final String from;
+	private Object from;
 
 	@Nullable //
 	private final Field localField;
@@ -97,6 +97,22 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 	 */
 	public LookupOperation(String from, @Nullable Field localField, @Nullable Field foreignField, @Nullable Let let,
 			@Nullable AggregationPipeline pipeline, Field as) {
+		this((Object) from, localField, foreignField, let, pipeline, as);
+	}
+
+	/**
+	 * Creates a new {@link LookupOperation} for the given combination of {@link Field}s and {@link AggregationPipeline
+	 * pipeline}.
+	 *
+	 * @param from must not be {@literal null}. Can be eiter the target collection name or a {@link Class}.
+	 * @param localField can be {@literal null} if {@literal pipeline} is present.
+	 * @param foreignField can be {@literal null} if {@literal pipeline} is present.
+	 * @param let can be {@literal null} if {@literal localField} and {@literal foreignField} are present.
+	 * @param as must not be {@literal null}.
+	 * @since 4.1
+	 */
+	private LookupOperation(Object from, @Nullable Field localField, @Nullable Field foreignField, @Nullable Let let,
+			@Nullable AggregationPipeline pipeline, Field as) {
 
 		Assert.notNull(from, "From must not be null");
 		if (pipeline == null) {
@@ -125,12 +141,14 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 
 		Document lookupObject = new Document();
 
-		lookupObject.append("from", from);
+		lookupObject.append("from", getCollectionName(context));
+		
 		if (localField != null) {
 			lookupObject.append("localField", localField.getTarget());
 		}
+		
 		if (foreignField != null) {
-			lookupObject.append("foreignField", foreignField.getTarget());
+			lookupObject.append("foreignField", getForeignFieldName(context));
 		}
 		if (let != null) {
 			lookupObject.append("let", let.toDocument(context).get("$let", Document.class).get("vars"));
@@ -142,6 +160,16 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		lookupObject.append("as", as.getTarget());
 
 		return new Document(getOperator(), lookupObject);
+	}
+
+	String getCollectionName(AggregationOperationContext context) {
+		return from instanceof Class<?> type ? context.getCollection(type) : from.toString();
+	}
+
+	String getForeignFieldName(AggregationOperationContext context) {
+
+		return from instanceof Class<?> type ? context.getMappedFieldName(type, foreignField.getTarget())
+				: foreignField.getTarget();
 	}
 
 	@Override
@@ -158,16 +186,28 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		return new LookupOperationBuilder();
 	}
 
-	public static interface FromBuilder {
+	public interface FromBuilder {
 
 		/**
 		 * @param name the collection in the same database to perform the join with, must not be {@literal null} or empty.
 		 * @return never {@literal null}.
 		 */
 		LocalFieldBuilder from(String name);
+
+		/**
+		 * Use the given type to determine name of the foreign collection and map
+		 * {@link ForeignFieldBuilder#foreignField(String)} against it to consider eventually present
+		 * {@link org.springframework.data.mongodb.core.mapping.Field} annotations.
+		 * 
+		 * @param type the type of the target collection in the same database to perform the join with, must not be
+		 *          {@literal null}.
+		 * @return never {@literal null}.
+		 * @since 4.2
+		 */
+		LocalFieldBuilder from(Class<?> type);
 	}
 
-	public static interface LocalFieldBuilder extends PipelineBuilder {
+	public interface LocalFieldBuilder extends PipelineBuilder {
 
 		/**
 		 * @param name the field from the documents input to the {@code $lookup} stage, must not be {@literal null} or
@@ -177,7 +217,7 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		ForeignFieldBuilder localField(String name);
 	}
 
-	public static interface ForeignFieldBuilder {
+	public interface ForeignFieldBuilder {
 
 		/**
 		 * @param name the field from the documents in the {@code from} collection, must not be {@literal null} or empty.
@@ -246,7 +286,7 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		LookupOperation as(String name);
 	}
 
-	public static interface AsBuilder extends PipelineBuilder {
+	public interface AsBuilder extends PipelineBuilder {
 
 		/**
 		 * @param name the name of the new array field to add to the input documents, must not be {@literal null} or empty.
@@ -264,7 +304,7 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 	public static final class LookupOperationBuilder
 			implements FromBuilder, LocalFieldBuilder, ForeignFieldBuilder, AsBuilder {
 
-		private @Nullable String from;
+		private @Nullable Object from;
 		private @Nullable Field localField;
 		private @Nullable Field foreignField;
 		private @Nullable ExposedField as;
@@ -285,6 +325,14 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 
 			Assert.hasText(name, "'From' must not be null or empty");
 			from = name;
+			return this;
+		}
+
+		@Override
+		public LocalFieldBuilder from(Class<?> type) {
+
+			Assert.notNull(type, "'From' must not be null");
+			from = type;
 			return this;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/LookupOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/LookupOperation.java
@@ -109,7 +109,7 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 	 * @param foreignField can be {@literal null} if {@literal pipeline} is present.
 	 * @param let can be {@literal null} if {@literal localField} and {@literal foreignField} are present.
 	 * @param as must not be {@literal null}.
-	 * @since 4.1
+	 * @since 4.2
 	 */
 	private LookupOperation(Object from, @Nullable Field localField, @Nullable Field foreignField, @Nullable Let let,
 			@Nullable AggregationPipeline pipeline, Field as) {
@@ -142,11 +142,11 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		Document lookupObject = new Document();
 
 		lookupObject.append("from", getCollectionName(context));
-		
+
 		if (localField != null) {
 			lookupObject.append("localField", localField.getTarget());
 		}
-		
+
 		if (foreignField != null) {
 			lookupObject.append("foreignField", getForeignFieldName(context));
 		}
@@ -198,7 +198,7 @@ public class LookupOperation implements FieldsExposingAggregationOperation, Inhe
 		 * Use the given type to determine name of the foreign collection and map
 		 * {@link ForeignFieldBuilder#foreignField(String)} against it to consider eventually present
 		 * {@link org.springframework.data.mongodb.core.mapping.Field} annotations.
-		 * 
+		 *
 		 * @param type the type of the target collection in the same database to perform the join with, must not be
 		 *          {@literal null}.
 		 * @return never {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/PrefixingDelegatingAggregationOperationContext.java
@@ -30,9 +30,8 @@ import org.springframework.lang.Nullable;
 
 /**
  * {@link AggregationOperationContext} implementation prefixing non-command keys on root level with the given prefix.
- * Useful when mapping fields to domain specific types while having to prefix keys for query purpose.
- * <br />
- * Fields to be excluded from prefixing my be added to a {@literal denylist}.
+ * Useful when mapping fields to domain specific types while having to prefix keys for query purpose. <br />
+ * Fields to be excluded from prefixing can be added to a {@literal denylist}.
  *
  * @author Christoph Strobl
  * @author Mark Paluch

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/TypeBasedAggregationOperationContext.java
@@ -93,6 +93,20 @@ public class TypeBasedAggregationOperationContext implements AggregationOperatio
 	}
 
 	@Override
+	public String getCollection(Class<?> type) {
+
+		MongoPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(type);
+		return persistentEntity != null ? persistentEntity.getCollection() : AggregationOperationContext.super.getCollection(type);
+	}
+
+	@Override
+	public String getMappedFieldName(Class<?> type, String field) {
+
+		PersistentPropertyPath<MongoPersistentProperty> persistentPropertyPath = mappingContext.getPersistentPropertyPath(field, type);
+		return persistentPropertyPath.getLeafProperty().getFieldName();
+	}
+
+	@Override
 	public Fields getFields(Class<?> type) {
 
 		Assert.notNull(type, "Type must not be null");

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTestUtils.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTestUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
+import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
+
+/**
+ * @author Christoph Strobl
+ * @since 2023/06
+ */
+public final class AggregationTestUtils {
+
+	public static AggregationContextBuilder<TypeBasedAggregationOperationContext> strict(Class<?> type) {
+
+		AggregationContextBuilder<AggregationOperationContext> builder = new AggregationContextBuilder<>();
+		builder.strict = true;
+		return builder.forType(type);
+	}
+
+	public static AggregationContextBuilder<TypeBasedAggregationOperationContext> relaxed(Class<?> type) {
+
+		AggregationContextBuilder<AggregationOperationContext> builder = new AggregationContextBuilder<>();
+		builder.strict = false;
+		return builder.forType(type);
+	}
+
+	public static class AggregationContextBuilder<T extends AggregationOperationContext> {
+
+		Class<?> targetType;
+		MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext;
+		QueryMapper queryMapper;
+		boolean strict;
+
+		public AggregationContextBuilder<TypeBasedAggregationOperationContext> forType(Class<?> type) {
+
+			this.targetType = type;
+			return (AggregationContextBuilder<TypeBasedAggregationOperationContext>) this;
+		}
+
+		public AggregationContextBuilder<T> using(
+				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
+
+			this.mappingContext = mappingContext;
+			return this;
+		}
+
+		public AggregationContextBuilder<T> using(QueryMapper queryMapper) {
+
+			this.queryMapper = queryMapper;
+			return this;
+		}
+
+		public T ctx() {
+			//
+			if (targetType == null) {
+				return (T) Aggregation.DEFAULT_CONTEXT;
+			}
+
+			MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty>  ctx = mappingContext != null ? mappingContext : MongoTestMappingContext.newTestContext().init();
+			QueryMapper qm = queryMapper != null ? queryMapper
+					: new QueryMapper(new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, ctx));
+			return (T) (strict ? new TypeBasedAggregationOperationContext(targetType, ctx, qm)
+					: new RelaxedTypeBasedAggregationOperationContext(targetType, ctx, qm));
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTestUtils.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,35 +14,18 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2023 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.springframework.data.mongodb.core.aggregation;
 
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
-import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
 
 /**
  * @author Christoph Strobl
- * @since 2023/06
  */
 public final class AggregationTestUtils {
 
@@ -92,7 +75,9 @@ public final class AggregationTestUtils {
 				return (T) Aggregation.DEFAULT_CONTEXT;
 			}
 
-			MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty>  ctx = mappingContext != null ? mappingContext : MongoTestMappingContext.newTestContext().init();
+			MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> ctx = mappingContext != null
+					? mappingContext
+					: MongoTestMappingContext.newTestContext().init();
 			QueryMapper qm = queryMapper != null ? queryMapper
 					: new QueryMapper(new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, ctx));
 			return (T) (strict ? new TypeBasedAggregationOperationContext(targetType, ctx, qm)


### PR DESCRIPTION
This commit enables using a _type_ parameter to define the from collection of a `$lookup`/`$graphLookup` aggregation stage. In doing so we can derive the target collection name from the type and use the given information to also map the _from_ field against the domain object to so that the user is able to operate on property names instead of the target document field name.

Resolves: #4379 