### PR TITLE
Fix schema generation for encrypted fields that are considered domain entities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-4454-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4454-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreator.java
@@ -203,8 +203,9 @@ class MappingMongoJsonSchemaCreator implements MongoJsonSchemaCreator {
 								target.properties(nestedProperties.toArray(new JsonSchemaProperty[0])), required));
 					}
 				}
-				return targetProperties.size() == 1 ? targetProperties.iterator().next()
+				JsonSchemaProperty schemaProperty = targetProperties.size() == 1 ? targetProperties.iterator().next()
 						: JsonSchemaProperty.merged(targetProperties);
+				return applyEncryptionDataIfNecessary(property, schemaProperty);
 			}
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
@@ -1140,7 +1140,7 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 				enc.append("bsonType", type.toBsonType().value()); // TODO: no samples with type -> is it bson type all the way?
 			}
 
-			if(StringUtils.hasText(algorithm)) {
+			if (StringUtils.hasText(algorithm)) {
 				enc.append("algorithm", algorithm);
 			}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
@@ -36,6 +36,7 @@ import org.springframework.data.mongodb.core.schema.TypedJsonSchemaObject.Timest
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link JsonSchemaProperty} implementation.
@@ -1139,7 +1140,9 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 				enc.append("bsonType", type.toBsonType().value()); // TODO: no samples with type -> is it bson type all the way?
 			}
 
-			enc.append("algorithm", algorithm);
+			if(StringUtils.hasText(algorithm)) {
+				enc.append("algorithm", algorithm);
+			}
 
 			propertySpecification.append("encrypt", enc);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
@@ -271,6 +271,17 @@ class MappingMongoJsonSchemaCreatorUnitTests {
 				.containsEntry("properties.value", new Document("type", "string"));
 	}
 
+	@Test // GH-4454
+	void wrapEncryptedEntityTypeLikeProperty() {
+
+		MongoJsonSchema schema = MongoJsonSchemaCreator.create() //
+				.filter(MongoJsonSchemaCreator.encryptedOnly()) // filter non encrypted fields
+				.createSchemaFor(WithEncryptedEntityLikeProperty.class);
+
+		assertThat(schema.schemaDocument()) //
+				.containsEntry("properties.domainTypeValue", Document.parse("{'encrypt': {'bsonType': 'object' } }"));
+	}
+
 	// --> TYPES AND JSON
 
 	// --> ENUM
@@ -675,5 +686,10 @@ class MappingMongoJsonSchemaCreatorUnitTests {
 
 	static class PropertyClashWithA {
 		Integer aNonEncrypted;
+	}
+
+	@Encrypted(algorithm = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
+	static class WithEncryptedEntityLikeProperty {
+		@Encrypted SomeDomainType domainTypeValue;
 	}
 }


### PR DESCRIPTION
This PR makes sure to consider the encrypted annotation on fields that are considered domain type property values, encrypting the entire object if necessary.

Closes: #4454 