### PR TITLE
Fix mapping custom field names in downstream stages in TypedAggregation pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-4443-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4443-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4443-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4443-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRenderer.java
@@ -63,7 +63,7 @@ class AggregationOperationRenderer {
 					contextToUse = new InheritingExposedFieldsAggregationOperationContext(fields, contextToUse);
 				} else {
 					contextToUse = fields.exposesNoFields() ? DEFAULT_CONTEXT
-							: new ExposedFieldsAggregationOperationContext(exposedFieldsOperation.getFields(), contextToUse);
+							: new ExposedFieldsAggregationOperationContext(fields, contextToUse);
 				}
 			}
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
@@ -61,6 +61,11 @@ class ExposedFieldsAggregationOperationContext implements AggregationOperationCo
 	}
 
 	@Override
+	public Document getMappedObject(Document document) {
+		return rootContext.getMappedObject(document);
+	}
+
+	@Override
 	public FieldReference getReference(Field field) {
 
 		if (field.isInternal()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ExposedFieldsAggregationOperationContext.java
@@ -61,11 +61,6 @@ class ExposedFieldsAggregationOperationContext implements AggregationOperationCo
 	}
 
 	@Override
-	public Document getMappedObject(Document document) {
-		return rootContext.getMappedObject(document);
-	}
-
-	@Override
 	public FieldReference getReference(Field field) {
 
 		if (field.isInternal()) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/InheritingExposedFieldsAggregationOperationContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/InheritingExposedFieldsAggregationOperationContext.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
+import org.bson.Document;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldReference;
 
 /**
@@ -22,6 +23,7 @@ import org.springframework.data.mongodb.core.aggregation.ExposedFields.FieldRefe
  * {@link AggregationOperationContext}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 1.9
  */
 class InheritingExposedFieldsAggregationOperationContext extends ExposedFieldsAggregationOperationContext {
@@ -41,6 +43,11 @@ class InheritingExposedFieldsAggregationOperationContext extends ExposedFieldsAg
 		super(exposedFields, previousContext);
 
 		this.previousContext = previousContext;
+	}
+
+	@Override
+	public Document getMappedObject(Document document) {
+		return previousContext.getMappedObject(document);
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.aggregation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.aggregation.FieldsExposingAggregationOperation.InheritsFieldsAggregationOperation;
+
+/**
+ * @author Christoph Strobl
+ */
+public class AggregationOperationRendererUnitTests {
+
+	@Test // GH-4443
+	void nonFieldsExposingAggregationOperationContinuesWithSameContextForNextStage() {
+
+		AggregationOperationContext rootContext = mock(AggregationOperationContext.class);
+		AggregationOperation stage1 = mock(AggregationOperation.class);
+		AggregationOperation stage2 = mock(AggregationOperation.class);
+
+		AggregationOperationRenderer.toDocument(List.of(stage1, stage2), rootContext);
+
+		verify(stage1).toPipelineStages(eq(rootContext));
+		verify(stage2).toPipelineStages(eq(rootContext));
+	}
+
+	@Test // GH-4443
+	void fieldsExposingAggregationOperationNotExposingFieldsForcesUseOfDefaultContextForNextStage() {
+
+		AggregationOperationContext rootContext = mock(AggregationOperationContext.class);
+		FieldsExposingAggregationOperation stage1 = mock(FieldsExposingAggregationOperation.class);
+		ExposedFields stage1fields = mock(ExposedFields.class);
+		AggregationOperation stage2 = mock(AggregationOperation.class);
+
+		when(stage1.getFields()).thenReturn(stage1fields);
+		when(stage1fields.exposesNoFields()).thenReturn(true);
+
+		AggregationOperationRenderer.toDocument(List.of(stage1, stage2), rootContext);
+
+		verify(stage1).toPipelineStages(eq(rootContext));
+		verify(stage2).toPipelineStages(eq(AggregationOperationRenderer.DEFAULT_CONTEXT));
+	}
+
+	@Test // GH-4443
+	void fieldsExposingAggregationOperationForcesNewContextForNextStage() {
+
+		AggregationOperationContext rootContext = mock(AggregationOperationContext.class);
+		FieldsExposingAggregationOperation stage1 = mock(FieldsExposingAggregationOperation.class);
+		ExposedFields stage1fields = mock(ExposedFields.class);
+		AggregationOperation stage2 = mock(AggregationOperation.class);
+
+		when(stage1.getFields()).thenReturn(stage1fields);
+		when(stage1fields.exposesNoFields()).thenReturn(false);
+
+		ArgumentCaptor<AggregationOperationContext> captor = ArgumentCaptor.forClass(AggregationOperationContext.class);
+
+		AggregationOperationRenderer.toDocument(List.of(stage1, stage2), rootContext);
+
+		verify(stage1).toPipelineStages(eq(rootContext));
+		verify(stage2).toPipelineStages(captor.capture());
+
+		assertThat(captor.getValue()).isInstanceOf(ExposedFieldsAggregationOperationContext.class)
+				.isNotInstanceOf(InheritingExposedFieldsAggregationOperationContext.class);
+	}
+
+	@Test // GH-4443
+	void inheritingFieldsExposingAggregationOperationForcesNewContextForNextStageKeepingReferenceToPreviousContext() {
+
+		AggregationOperationContext rootContext = mock(AggregationOperationContext.class);
+		InheritsFieldsAggregationOperation stage1 = mock(InheritsFieldsAggregationOperation.class);
+		InheritsFieldsAggregationOperation stage2 = mock(InheritsFieldsAggregationOperation.class);
+		InheritsFieldsAggregationOperation stage3 = mock(InheritsFieldsAggregationOperation.class);
+
+		ExposedFields exposedFields = mock(ExposedFields.class);
+		when(exposedFields.exposesNoFields()).thenReturn(false);
+		when(stage1.getFields()).thenReturn(exposedFields);
+		when(stage2.getFields()).thenReturn(exposedFields);
+		when(stage3.getFields()).thenReturn(exposedFields);
+
+		ArgumentCaptor<AggregationOperationContext> captor = ArgumentCaptor.forClass(AggregationOperationContext.class);
+
+		AggregationOperationRenderer.toDocument(List.of(stage1, stage2, stage3), rootContext);
+
+		verify(stage1).toPipelineStages(captor.capture());
+		verify(stage2).toPipelineStages(captor.capture());
+		verify(stage3).toPipelineStages(captor.capture());
+
+		assertThat(captor.getAllValues().get(0)).isEqualTo(rootContext);
+
+		assertThat(captor.getAllValues().get(1))
+				.asInstanceOf(InstanceOfAssertFactories.type(InheritingExposedFieldsAggregationOperationContext.class))
+				.extracting("previousContext").isSameAs(captor.getAllValues().get(0));
+
+		assertThat(captor.getAllValues().get(2))
+				.asInstanceOf(InstanceOfAssertFactories.type(InheritingExposedFieldsAggregationOperationContext.class))
+				.extracting("previousContext").isSameAs(captor.getAllValues().get(1));
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationTests.java
@@ -2010,6 +2010,25 @@ public class AggregationTests {
 		assertThat(mappedResults.get(0)).containsEntry("item_id", "1");
 	}
 
+	@Test // GH-4443
+	void projectShouldResetContextToAvoidMappingFieldsAgainstANoLongerExistingTarget() {
+
+		Item item1 = Item.builder().itemId("1").tags(Arrays.asList("a", "b")).build();
+		Item item2 = Item.builder().itemId("1").tags(Arrays.asList("a", "c")).build();
+		mongoTemplate.insert(Arrays.asList(item1, item2), Item.class);
+
+		TypedAggregation<Item> aggregation = newAggregation(Item.class,
+				match(where("itemId").is("1")),
+				unwind("tags"),
+				project().and("itemId").as("itemId").and("tags").as("tags"),
+				match(where("itemId").is("1").and("tags").is("c")));
+
+		AggregationResults<Document> results = mongoTemplate.aggregate(aggregation, Document.class);
+		List<Document> mappedResults = results.getMappedResults();
+		assertThat(mappedResults).hasSize(1);
+		assertThat(mappedResults.get(0)).containsEntry("itemId", "1");
+	}
+
 	private void createUsersWithReferencedPersons() {
 
 		mongoTemplate.dropCollection(User.class);


### PR DESCRIPTION
This PR uses the root AggregationOperationContext in nested ExposedFieldsAggregationOperationContext to properly apply mapping for domain properties that use @Field.

Closes #4443