### PR TITLE
Correct misspellings in documentation

### DIFF
--- a/src/main/asciidoc/reference/document-references.adoc
+++ b/src/main/asciidoc/reference/document-references.adoc
@@ -88,7 +88,7 @@ class Person {
 ----
 Account account = …
 
-tempate.insert(account);                               <2>
+template.insert(account);                               <2>
 
 template.update(Person.class)
   .matching(where("id").is(…))
@@ -441,7 +441,7 @@ class Entity {
   "lastname" : "Long",       <2>
 }
 ----
-<1> Read/wirte the keys `fn` & `ln` from/to the linkage document based on the lookup query.
+<1> Read/write the keys `fn` & `ln` from/to the linkage document based on the lookup query.
 <2> Use non _id_ fields for the lookup of the target documents.
 ====
 
@@ -477,7 +477,7 @@ class ToDocumentPointerConverter implements Converter<ReferencedObject, Document
   }
 }
 ----
-<1> Read/wirte the keys `_id` from/to the reference document to use them in the lookup query.
+<1> Read/write the keys `_id` from/to the reference document to use them in the lookup query.
 <2> The collection name can be read from the reference document using its key.
 ====
 

--- a/src/main/asciidoc/reference/mongo-json-schema.adoc
+++ b/src/main/asciidoc/reference/mongo-json-schema.adoc
@@ -33,7 +33,7 @@ embedded schema objects that describe properties and subdocuments.
 <2> `required` is a property that describes which properties are required in a document. It can be specified optionally, along with other
 schema constraints. See MongoDB's documentation on https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/#available-keywords[available keywords].
 <3> `properties` is related to a schema object that describes an `object` type. It contains property-specific schema constraints.
-<4> `firstname` specifies constraints for the `firsname` field inside the document. Here, it is a string-based `properties` element declaring
+<4> `firstname` specifies constraints for the `firstname` field inside the document. Here, it is a string-based `properties` element declaring
  possible field values.
 <5> `address` is a subdocument defining a schema for values in its `postCode` field.
 ====

--- a/src/main/asciidoc/reference/mongo-repositories-aggregation.adoc
+++ b/src/main/asciidoc/reference/mongo-repositories-aggregation.adoc
@@ -77,7 +77,7 @@ Therefore, the `Sort` properties are mapped against the methods return type `Per
 <4> `$skip`, `$limit` and `$sort` can be passed on via a `Pageable` argument. Same as in <2>, the operators are appended to the pipeline definition. Methods accepting `Pageable` can return `Slice` for easier pagination.
 <5> Aggregation methods can return `Stream` to consume results directly from an underlying cursor. Make sure to close the stream after consuming it to release the server-side cursor by either calling `close()` or through `try-with-resources`.
 <6> Map the result of an aggregation returning a single `Document` to an instance of a desired `SumValue` target type.
-<7> Aggregations resulting in single document holding just an accumulation result like eg. `$sum` can be extracted directly from the result `Document`.
+<7> Aggregations resulting in single document holding just an accumulation result like e.g. `$sum` can be extracted directly from the result `Document`.
 To gain more control, you might consider `AggregationResult` as method return type as shown in <7>.
 <8> Obtain the raw `AggregationResults` mapped to the generic target wrapper type `SumValue` or `org.bson.Document`.
 <9> Like in <6>, a single value can be directly obtained from multiple result ``Document``s.


### PR DESCRIPTION
👋  I fixed a few spelling mistakes that I stumbled upon in the documentation.