### PR TITLE
Add support for replaceOne operation

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoOperations.java
@@ -1754,6 +1754,129 @@ public interface MongoOperations extends FluentMongoOperations {
 	<T> List<T> findAllAndRemove(Query query, Class<T> entityClass, String collectionName);
 
 	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document. <br />
+	 * The collection name is derived from the {@literal replacement} type. <br />
+	 * Options are defaulted to {@link ReplaceOptions#empty()}. <br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	default <T> UpdateResult replace(Query query, T replacement) {
+		return replace(query, replacement, ReplaceOptions.empty());
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement}
+	 * document.<br />
+	 * Options are defaulted to {@link ReplaceOptions#empty()}. <br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	default <T> UpdateResult replace(Query query, T replacement, String collectionName) {
+		return replace(query, replacement, ReplaceOptions.empty(), collectionName);
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link ReplaceOptions} into account.<br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	default <T> UpdateResult replace(Query query, T replacement, ReplaceOptions options) {
+		return replace(query, replacement, options, getCollectionName(ClassUtils.getUserClass(replacement)));
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link ReplaceOptions} into account.<br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	default <T> UpdateResult replace(Query query, T replacement, ReplaceOptions options, String collectionName) {
+
+		Assert.notNull(replacement, "Replacement must not be null");
+		return replace(query, replacement, options, (Class<T>) ClassUtils.getUserClass(replacement), collectionName);
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link ReplaceOptions} into account.<br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @param entityType the type used for mapping the {@link Query} to domain type fields and deriving the collection
+	 *          from. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	default <S> UpdateResult replace(Query query, S replacement, ReplaceOptions options, Class<S> entityType) {
+
+		return replace(query, replacement, options, entityType,
+				getCollectionName(ClassUtils.getUserClass(entityType)));
+	}
+
+	/**
+	 * Triggers
+	 * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>
+	 * to replace a single document matching {@link Criteria} of given {@link Query} with the {@code replacement} document
+	 * taking {@link ReplaceOptions} into account.<br />
+	 * <strong>NOTE:</strong> The replacement entity must not hold an {@literal id}.
+	 *
+	 * @param query the {@link Query} class that specifies the {@link Criteria} used to find a record and also an optional
+	 *          fields specification. Must not be {@literal null}.
+	 * @param replacement the replacement document. Must not be {@literal null}.
+	 * @param options the {@link FindAndModifyOptions} holding additional information. Must not be {@literal null}.
+	 * @param entityType the type used for mapping the {@link Query} to domain type fields. Must not be {@literal null}.
+	 * @param collectionName the collection to query. Must not be {@literal null}.
+	 * @return the {@link UpdateResult} which lets you access the results of the previous replacement.
+	 * @throws org.springframework.data.mapping.MappingException if the collection name cannot be
+	 *           {@link #getCollectionName(Class) derived} from the given replacement value.
+	 */
+	<S> UpdateResult replace(Query query, S replacement, ReplaceOptions options, Class<S> entityType,
+							 String collectionName);
+
+	/**
 	 * Returns the underlying {@link MongoConverter}.
 	 *
 	 * @return never {@literal null}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReplaceOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReplaceOptions.java
@@ -1,0 +1,84 @@
+/**
+ * Options for
+ * <a href="https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/">replaceOne</a>.
+ * <br />
+ * Defaults to
+ * <dl>
+ * <dt>upsert</dt>
+ * <dd>false</dd>
+ * </dl>
+ *
+ * @author Jakub Zurawa
+ */
+package org.springframework.data.mongodb.core;
+
+public class ReplaceOptions {
+	private boolean upsert;
+
+	private static final ReplaceOptions NONE = new ReplaceOptions() {
+
+		private static final String ERROR_MSG = "ReplaceOptions.none() cannot be changed; Please use ReplaceOptions.options() instead";
+
+		@Override
+		public ReplaceOptions upsert() {
+			throw new UnsupportedOperationException(ERROR_MSG);
+		}
+	};
+
+	/**
+	 * Static factory method to create a {@link ReplaceOptions} instance.
+	 * <dl>
+	 * <dt>upsert</dt>
+	 * <dd>false</dd>
+	 * </dl>
+	 *
+	 * @return new instance of {@link ReplaceOptions}.
+	 */
+	public static ReplaceOptions options() {
+		return new ReplaceOptions();
+	}
+
+	/**
+	 * Static factory method returning an unmodifiable {@link ReplaceOptions} instance.
+	 *
+	 * @return unmodifiable {@link ReplaceOptions} instance.
+	 * @since 2.2
+	 */
+	public static ReplaceOptions none() {
+		return NONE;
+	}
+
+	/**
+	 * Static factory method to create a {@link ReplaceOptions} instance with
+	 * <dl>
+	 * <dt>upsert</dt>
+	 * <dd>false</dd>
+	 * </dl>
+	 *
+	 * @return new instance of {@link ReplaceOptions}.
+	 */
+	public static ReplaceOptions empty() {
+		return new ReplaceOptions();
+	}
+
+	/**
+	 * Insert a new document if not exists.
+	 *
+	 * @return this.
+	 */
+	public ReplaceOptions upsert() {
+
+		this.upsert = true;
+		return this;
+	}
+
+	/**
+	 * Get the bit indicating if to create a new document if not exists.
+	 *
+	 * @return {@literal true} if set.
+	 */
+	public boolean isUpsert() {
+		return upsert;
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -116,6 +116,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Mark Paluch
  * @author Laszlo Csontos
  * @author duozhilin
+ * @author Jakub Zurawa
  */
 @ExtendWith(MongoClientExtension.class)
 public class MongoTemplateTests {
@@ -3870,6 +3871,21 @@ public class MongoTemplateTests {
 				.matching(expr(StringOperators.valueOf("emailAddress").regexFind(".*@vmware.com$", "i"))).firstValue();
 
 		assertThat(loaded).isEqualTo(source2);
+	}
+
+	@Test // GH-4300
+	public void replaceShouldReplaceDocument() {
+
+		org.bson.Document doc = new org.bson.Document("foo", "bar");
+		String collectionName = "replace";
+		template.save(doc, collectionName);
+
+		org.bson.Document replacement = new org.bson.Document("foo", "baz");
+		UpdateResult updateResult = template.replace(query(where("foo").is("bar")), replacement, ReplaceOptions.options(),
+				collectionName);
+
+		assertThat(updateResult.wasAcknowledged()).isTrue();
+		assertThat(template.findOne(query(where("foo").is("baz")), org.bson.Document.class, collectionName)).isNotNull();
 	}
 
 	private AtomicReference<ImmutableVersioned> createAfterSaveReference() {


### PR DESCRIPTION
This pr adds replaceOne method to MongoOperations.
Closes: https://github.com/spring-projects/spring-data-mongodb/issues/4462