### PR TITLE
Provide `DocumentReferenceSource` to document reference lookup for use of properties in constructor creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.x-4484-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4484-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4484-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.x-4484-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -1976,8 +1976,9 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			}
 
 			if (property.isDocumentReference()) {
-				return (T) dbRefResolver.resolveReference(property, accessor.get(property), referenceLookupDelegate,
-						context::convert);
+				return (T) dbRefResolver.resolveReference(property,
+					new DocumentReferenceSource(accessor.getDocument(), accessor.get(property)),
+					referenceLookupDelegate, context::convert);
 			}
 
 			return super.getPropertyValue(property);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -98,6 +98,7 @@ import com.mongodb.DBRef;
  * @author Roman Puchkovskiy
  * @author Heesu Jung
  * @author Divya Srivastava
+ * @author Julia Lee
  */
 public class MappingMongoConverter extends AbstractMongoConverter implements ApplicationContextAware {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateDocumentReferenceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateDocumentReferenceTests.java
@@ -1265,6 +1265,32 @@ public class MongoTemplateDocumentReferenceTests {
 				.isEqualTo(new ObjectRefHavingStringIdTargetType(id.toHexString(), "me-the-referenced-object"));
 	}
 
+	@Test // GH-4484
+	void resolveReferenceForOneToManyLookupWithSelfVariableWhenUsedInCtorArgument() {
+
+		OneToManyStylePublisherWithRequiredArgsCtor publisher = new OneToManyStylePublisherWithRequiredArgsCtor("p-100", null);
+		template.save(publisher);
+
+		OneToManyStyleBook book1 = new OneToManyStyleBook();
+		book1.id = "id-1";
+		book1.publisherId = publisher.id;
+
+		OneToManyStyleBook book2 = new OneToManyStyleBook();
+		book2.id = "id-2";
+		book2.publisherId = "p-200";
+
+		OneToManyStyleBook book3 = new OneToManyStyleBook();
+		book3.id = "id-3";
+		book3.publisherId = publisher.id;
+
+		template.save(book1);
+		template.save(book2);
+		template.save(book3);
+
+		OneToManyStylePublisherWithRequiredArgsCtor target = template.findOne(query(where("id").is(publisher.id)), OneToManyStylePublisherWithRequiredArgsCtor.class);
+		assertThat(target.books).containsExactlyInAnyOrder(book1, book3);
+	}
+
 	static class SingleRefRoot {
 
 		String id;
@@ -2247,6 +2273,42 @@ public class MongoTemplateDocumentReferenceTests {
 
 		public String toString() {
 			return "MongoTemplateDocumentReferenceTests.WithListOfRefs(id=" + this.getId() + ", refs=" + this.getRefs() + ")";
+		}
+	}
+
+	static class OneToManyStylePublisherWithRequiredArgsCtor {
+
+		@Id
+		String id;
+
+		@ReadOnlyProperty
+		@DocumentReference(lookup="{'publisherId':?#{#self._id} }")
+		List<OneToManyStyleBook> books;
+
+		public OneToManyStylePublisherWithRequiredArgsCtor(String id, List<OneToManyStyleBook> books) {
+			this.id = id;
+			this.books = books;
+		}
+
+		public String getId() {
+			return this.id;
+		}
+
+		public List<OneToManyStyleBook> getBooks() {
+			return this.books;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public void setBooks(List<OneToManyStyleBook> books) {
+			this.books = books;
+		}
+
+		public String toString() {
+			return "MongoTemplateDocumentReferenceTests.OneToManyStylePublisherWithRequiredArgsCtor(id=" + this.getId() + ", book="
+				+ this.getBooks() + ")";
 		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateDocumentReferenceTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateDocumentReferenceTests.java
@@ -57,6 +57,7 @@ import com.mongodb.client.model.Filters;
  * {@link DocumentReference} related integration tests for {@link MongoTemplate}.
  *
  * @author Christoph Strobl
+ * @author Julia Lee
  */
 @ExtendWith(MongoClientExtension.class)
 public class MongoTemplateDocumentReferenceTests {


### PR DESCRIPTION
This commit enables a source entity with a one-to-many @DocumentReference lookup property to be instantiated properly when the referenced entity - which contains the linking value - is used as a constructor argument.