### PR TITLE
Correctly read unwrapped properties during constructor creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-4491-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-4491-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-4491-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-4491-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2346,6 +2346,24 @@ class MappingMongoConverterUnitTests {
 				.isEqualTo(expected);
 	}
 
+	@Test // GH-4491
+	void readUnwrappedTypeWithComplexValueUsingConstructor() {
+
+		org.bson.Document source = new org.bson.Document("_id", "id-1").append("stringValue", "hello").append("address",
+				new org.bson.Document("s", "1007 Mountain Drive").append("city", "Gotham"));
+
+		WithUnwrappedConstructor target = converter.read(WithUnwrappedConstructor.class, source);
+
+		Address expected = new Address();
+		expected.city = "Gotham";
+		expected.street = "1007 Mountain Drive";
+
+		assertThat(target.embeddableValue.stringValue) //
+				.isEqualTo("hello");
+		assertThat(target.embeddableValue.address) //
+				.isEqualTo(expected);
+	}
+
 	@Test // DATAMONGO-1902
 	void writeUnwrappedTypeWithComplexValue() {
 
@@ -3420,6 +3438,18 @@ class MappingMongoConverterUnitTests {
 		String id;
 
 		@Unwrapped.Nullable EmbeddableType embeddableValue;
+	}
+
+	static class WithUnwrappedConstructor {
+
+		private final String id;
+
+		private final @Unwrapped.Empty EmbeddableType embeddableValue;
+
+		public WithUnwrappedConstructor(String id, EmbeddableType embeddableValue) {
+			this.id = id;
+			this.embeddableValue = embeddableValue;
+		}
 	}
 
 	static class WithPrefixedNullableUnwrapped {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/AbstractEncryptionTestBase.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/AbstractEncryptionTestBase.java
@@ -353,7 +353,7 @@ public abstract class AbstractEncryptionTestBase {
 		template.save(p3);
 
 		template.execute(Person.class, collection -> {
-			collection.find(new Document()).forEach(it -> System.out.println(it.toJson()));
+			collection.find(new Document());
 			return null;
 		});
 


### PR DESCRIPTION
Closes #4491 

Should be backported until `4.0.x`