### PR TITLE
MongoTemplate doFind for ad-hoc query method visibility as protected.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2606,7 +2606,7 @@ public class MongoTemplate
 	 *
 	 * @since 2.0
 	 */
-	<S, T> List<T> doFind(CollectionPreparer<MongoCollection<Document>> collectionPreparer, String collectionName,
+	protected <S, T> List<T> doFind(CollectionPreparer<MongoCollection<Document>> collectionPreparer, String collectionName,
 			Document query, Document fields, Class<S> sourceClass, Class<T> targetClass, CursorPreparer preparer) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(sourceClass);


### PR DESCRIPTION
Need:
The method that's being called when using method-like queries has default package visibility, compared to other methods with protected visibility.

In order to extend `MongoTemplate` without placing the new class in the `org.springframework.data.mongodb.core` package, I added the `protected` as method visibility.