### PR TITLE
Document list/map/set initialization on read.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.3.0-SNAPSHOT</version>
+	<version>4.3.x-4571-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.x-4571-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.x-4571-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.x-4571-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/BsonUtils.java
@@ -593,7 +593,7 @@ public class BsonUtils {
 
 		Map<String, Object> source = asMap(bson);
 		if (fieldName.isKey()) {
-			return source.get(fieldName.name()) != null;
+			return source.containsKey(fieldName.name());
 		}
 
 		String[] parts = fieldName.parts();

--- a/src/main/antora/modules/ROOT/pages/mongodb/mapping/mapping.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mapping/mapping.adoc
@@ -274,6 +274,17 @@ calling `get()` before the actual conversion
 |===
 ====
 
+.Collection Handling
+[NOTE]
+====
+Collection handing depends on the actual values retrieved from the MongoDB.
+
+* If a document does **not** contain the field mapped to a collection, the mapping will not touch the property.
+Which means the value will remain `null`, a java default or any value set during object creation.
+* If the document contains the field to be mapped, but the field holds a `null` value (like: `{ 'list' : null }`), the property value is set to `null` overriding any default value set during object creation.
+* If the document contains the field to be mapped to a collection which is **not** `null` (like: `{ 'list' : [ ... ] }`), the collection is populated with the mapped values overriding any default value set during object creation.
+====
+
 [[mapping-configuration]]
 == Mapping Configuration
 


### PR DESCRIPTION
Update the reference documentation about collection initialization on read.
Add required tests to make sure it behaves as expected and simplify `BeanUtils` value presence check.

See: #4571