### PR TITLE
Allow custom MongoHandlerObservationConvention usage

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -39,6 +39,7 @@ import com.mongodb.event.CommandSucceededEvent;
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
  * @author Greg Turnquist
+ * @author François Kha
  * @since 4.0
  */
 public class MongoObservationCommandListener implements CommandListener {
@@ -48,7 +49,7 @@ public class MongoObservationCommandListener implements CommandListener {
 	private final ObservationRegistry observationRegistry;
 	private final @Nullable ConnectionString connectionString;
 
-	private final MongoHandlerObservationConvention observationConvention = new DefaultMongoHandlerObservationConvention();
+	private final MongoHandlerObservationConvention observationConvention;
 
 	/**
 	 * Create a new {@link MongoObservationCommandListener} to record {@link Observation}s.
@@ -61,6 +62,7 @@ public class MongoObservationCommandListener implements CommandListener {
 
 		this.observationRegistry = observationRegistry;
 		this.connectionString = null;
+		this.observationConvention = new DefaultMongoHandlerObservationConvention();
 	}
 
 	/**
@@ -77,6 +79,26 @@ public class MongoObservationCommandListener implements CommandListener {
 
 		this.observationRegistry = observationRegistry;
 		this.connectionString = connectionString;
+		this.observationConvention = new DefaultMongoHandlerObservationConvention();
+	}
+
+	/**
+	 * Create a new {@link MongoObservationCommandListener} to record {@link Observation}s. This constructor attaches the
+	 * {@link ConnectionString} to every {@link Observation} and uses the given {@link MongoHandlerObservationConvention}
+	 *
+	 * @param observationRegistry must not be {@literal null}
+	 * @param connectionString must not be {@literal null}
+	 * @param observationConvention must not be {@literal null}
+	 */
+	public MongoObservationCommandListener(ObservationRegistry observationRegistry, ConnectionString connectionString, MongoHandlerObservationConvention observationConvention) {
+
+		Assert.notNull(observationRegistry, "ObservationRegistry must not be null");
+		Assert.notNull(connectionString, "ConnectionString must not be null");
+		Assert.notNull(observationConvention, "MongoHandlerObservationConvention must not be null");
+
+		this.observationRegistry = observationRegistry;
+		this.connectionString = connectionString;
+		this.observationConvention = observationConvention;
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
@@ -72,7 +72,7 @@ class MongoObservationCommandListenerTests {
 	void commandStartedShouldNotInstrumentWhenAdminDatabase() {
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(null, 0, null, "admin", "", null));
+		listener.commandStarted(new CommandStartedEvent(null, 0, 0, null, "admin", "", null));
 
 		// then
 		assertThat(meterRegistry).hasNoMetrics();
@@ -82,7 +82,7 @@ class MongoObservationCommandListenerTests {
 	void commandStartedShouldNotInstrumentWhenNoRequestContext() {
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(null, 0, null, "some name", "", null));
+		listener.commandStarted(new CommandStartedEvent(null,0, 0, null, "some name", "", null));
 
 		// then
 		assertThat(meterRegistry).hasNoMetrics();
@@ -92,7 +92,7 @@ class MongoObservationCommandListenerTests {
 	void commandStartedShouldNotInstrumentWhenNoParentSampleInRequestContext() {
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(), 0, null, "some name", "", null));
+		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(),0, 0, null, "some name", "", null));
 
 		// then
 		assertThat(meterRegistry).hasMeterWithName("spring.data.mongodb.command.active");
@@ -106,13 +106,13 @@ class MongoObservationCommandListenerTests {
 		RequestContext traceRequestContext = getContext();
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(traceRequestContext, 0, //
+		listener.commandStarted(new CommandStartedEvent(traceRequestContext,0, 0, //
 				new ConnectionDescription( //
 						new ServerId( //
 								new ClusterId("description"), //
 								new ServerAddress("localhost", 1234))), "database", "insert", //
 				new BsonDocument("collection", new BsonString("user"))));
-		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, null, "insert", null, 0));
+		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0,0, null, "insert", null, 0));
 
 		// then
 		assertThatTimerRegisteredWithTags();
@@ -126,14 +126,14 @@ class MongoObservationCommandListenerTests {
 		RequestContext traceRequestContext = getContext();
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(traceRequestContext, 0, //
+		listener.commandStarted(new CommandStartedEvent(traceRequestContext, 0,0, //
 				new ConnectionDescription( //
 						new ServerId( //
 								new ClusterId("description"), //
 								new ServerAddress("localhost", 1234))), //
 				"database", "aggregate", //
 				new BsonDocument("aggregate", new BsonString("user"))));
-		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, null, "aggregate", null, 0));
+		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext,0, 0, null, "aggregate", null, 0));
 
 		// then
 		assertThatTimerRegisteredWithTags();
@@ -147,9 +147,9 @@ class MongoObservationCommandListenerTests {
 		RequestContext traceRequestContext = getContext();
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(traceRequestContext, 0, null, "database", "insert",
+		listener.commandStarted(new CommandStartedEvent(traceRequestContext, 0, 0, null, "database", "insert",
 				new BsonDocument("collection", new BsonString("user"))));
-		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, null, "insert", null, 0));
+		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, 0, null, "insert", null, 0));
 
 		assertThat(meterRegistry).hasTimerWithNameAndTags(MongoObservation.MONGODB_COMMAND_OBSERVATION.getName(),
 				KeyValues.of(LowCardinalityCommandKeyNames.MONGODB_COLLECTION.withValue("user"),
@@ -174,7 +174,7 @@ class MongoObservationCommandListenerTests {
 				"database", "insert", //
 				new BsonDocument("collection", new BsonString("user"))));
 		listener.commandFailed( //
-				new CommandFailedEvent(traceRequestContext, 0, null, "insert", 0, new IllegalAccessException()));
+				new CommandFailedEvent(traceRequestContext, 0, 0, null, "insert", 0, new IllegalAccessException()));
 
 		// then
 		assertThatTimerRegisteredWithTags();
@@ -191,7 +191,7 @@ class MongoObservationCommandListenerTests {
 		traceRequestContext.put(ObservationThreadLocalAccessor.KEY, observation);
 
 		// when
-		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, null, "insert", null, 0));
+		listener.commandSucceeded(new CommandSucceededEvent(traceRequestContext, 0, 0, null, "insert", null, 0));
 
 		verify(observation).getContext();
 		verifyNoMoreInteractions(observation);
@@ -208,7 +208,7 @@ class MongoObservationCommandListenerTests {
 		traceRequestContext.put(ObservationThreadLocalAccessor.KEY, observation);
 
 		// when
-		listener.commandFailed(new CommandFailedEvent(traceRequestContext, 0, null, "insert", 0, null));
+		listener.commandFailed(new CommandFailedEvent(traceRequestContext, 0, 0, null, "insert", 0, null));
 
 		verify(observation).getContext();
 		verifyNoMoreInteractions(observation);
@@ -233,7 +233,7 @@ class MongoObservationCommandListenerTests {
 				customObservationConvention);
 
 		// when
-		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(), 0, null, "some name", "", null));
+		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(), 0, 0,null, "some name", "", null));
 
 		// then
 		assertThat(meterRegistry).hasMeterWithName("custom.name.active");


### PR DESCRIPTION
Hi all,

This is an attempt at fixing #4321. 
this is my first PR, please let me know if something is wrong.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
