### PR TITLE
Fix nested projection retrieval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.2.3-SNAPSHOT</version>
+	<version>4.2.x-4609-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.3-SNAPSHOT</version>
+		<version>4.2.x-4609-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.3-SNAPSHOT</version>
+		<version>4.2.x-4609-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.2.3-SNAPSHOT</version>
+		<version>4.2.x-4609-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -595,7 +595,6 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			}
 
 			ConversionContext propertyContext = context.forProperty(prop);
-			MongoDbPropertyValueProvider valueProviderToUse = valueProvider.withContext(propertyContext);
 
 			if (prop.isAssociation()) {
 
@@ -623,7 +622,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 				continue;
 			}
 
-			accessor.setProperty(prop, valueProviderToUse.getPropertyValue(prop));
+			accessor.setProperty(prop, valueProvider.getPropertyValue(prop));
 		}
 	}
 
@@ -2436,17 +2435,7 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 			this.returnedTypeDescriptor = projection;
 		}
 
-		@Override
-		public ConversionContext forProperty(MongoPersistentProperty property) {
 
-			if(returnedTypeDescriptor.isProjection() && returnedTypeDescriptor.getDomainType().equals(property.getTypeInformation())) {
-				if(returnedTypeDescriptor.getMappedType().getType().isInterface()) {
-					return this;
-				}
-			 }
-
-			 return super.forProperty(property);
-		}
 
 		@Override
 		public ConversionContext forProperty(String name) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -2437,6 +2437,18 @@ public class MappingMongoConverter extends AbstractMongoConverter implements App
 		}
 
 		@Override
+		public ConversionContext forProperty(MongoPersistentProperty property) {
+
+			if(returnedTypeDescriptor.isProjection() && returnedTypeDescriptor.getDomainType().equals(property.getTypeInformation())) {
+				if(returnedTypeDescriptor.getMappedType().getType().isInterface()) {
+					return this;
+				}
+			 }
+
+			 return super.forProperty(property);
+		}
+
+		@Override
 		public ConversionContext forProperty(String name) {
 
 			EntityProjection<?, ?> property = returnedTypeDescriptor.findProperty(name);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2558,7 +2558,7 @@ public class MongoTemplateTests {
 	public void shouldReadNestedProjection() {
 
 		MyPerson walter = new MyPerson("Walter");
-		walter.address = new Address("some", "city");
+		walter.address = new Address("spring", "data");
 		template.save(walter);
 
 		PersonPWA result = template.query(MyPerson.class)
@@ -2566,7 +2566,7 @@ public class MongoTemplateTests {
 				.matching(where("id").is(walter.id))
 				.firstValue();
 
-		System.out.println("result: " + result.getAddress().getCity());
+		assertThat(result.getAddress().getCity()).isEqualTo("data");
 	}
 
 	interface PersonPWA {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -2554,6 +2554,30 @@ public class MongoTemplateTests {
 		assertThat(projection.getName()).isEqualTo("Walter");
 	}
 
+	@Test // GH-4609
+	public void shouldReadNestedProjection() {
+
+		MyPerson walter = new MyPerson("Walter");
+		walter.address = new Address("some", "city");
+		template.save(walter);
+
+		PersonPWA result = template.query(MyPerson.class)
+				.as(PersonPWA.class)
+				.matching(where("id").is(walter.id))
+				.firstValue();
+
+		System.out.println("result: " + result.getAddress().getCity());
+	}
+
+	interface PersonPWA {
+		String getName();
+		AdressProjection getAddress();
+	}
+
+	interface AdressProjection {
+		String getCity();
+	}
+
 	@Test // GH-4300
 	public void findAndReplaceShouldAllowNativeDomainTypesAndReturnAProjection() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -2851,6 +2851,44 @@ class MappingMongoConverterUnitTests {
 		assertThat(person.getAddresses()).extracting(AddressProjection::getStreet).hasSize(1).containsOnly("hwy");
 	}
 
+	@Test // GH-4609
+	void projectShouldReadNestedInterfaceProjection() {
+
+		org.bson.Document source = new org.bson.Document("foo", "spring").append("address",
+				new org.bson.Document("s", "data").append("city", "mongodb"));
+
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjection<WithNestedInterfaceProjection, Person> projection = introspector.introspect(WithNestedInterfaceProjection.class,
+				Person.class);
+		WithNestedInterfaceProjection person = converter.project(projection, source);
+
+		assertThat(person.getFirstname()).isEqualTo("spring");
+		assertThat(person.getAddress().getStreet()).isEqualTo("data");
+	}
+
+	@Test // GH-4609
+	void projectShouldReadNestedDtoProjection() {
+
+		org.bson.Document source = new org.bson.Document("foo", "spring").append("address",
+				new org.bson.Document("s", "data").append("city", "mongodb"));
+
+		EntityProjectionIntrospector introspector = EntityProjectionIntrospector.create(converter.getProjectionFactory(),
+				EntityProjectionIntrospector.ProjectionPredicate.typeHierarchy()
+						.and((target, underlyingType) -> !converter.conversions.isSimpleType(target)),
+				mappingContext);
+
+		EntityProjection<WithNestedDtoProjection, Person> projection = introspector.introspect(WithNestedDtoProjection.class,
+				Person.class);
+		WithNestedDtoProjection person = converter.project(projection, source);
+
+		assertThat(person.getFirstname()).isEqualTo("spring");
+		assertThat(person.getAddress().getStreet()).isEqualTo("data");
+	}
+
 	@Test // GH-2860
 	void projectShouldReadProjectionWithNestedEntity() {
 
@@ -3206,6 +3244,7 @@ class MappingMongoConverterUnitTests {
 		String lastname;
 
 		Set<Address> addresses;
+		Address address;
 
 		Person() {
 
@@ -3248,6 +3287,16 @@ class MappingMongoConverterUnitTests {
 		Set<AddressProjection> getAddresses();
 	}
 
+	interface WithNestedInterfaceProjection {
+		String getFirstname();
+		AddressProjection getAddress();
+	}
+
+	interface WithNestedDtoProjection {
+		String getFirstname();
+		AddressDto getAddress();
+	}
+
 	interface ProjectionWithNestedEntity {
 
 		Set<Address> getAddresses();
@@ -3256,6 +3305,19 @@ class MappingMongoConverterUnitTests {
 	interface AddressProjection {
 
 		String getStreet();
+	}
+
+	class AddressDto {
+
+		String street;
+
+		public String getStreet() {
+			return street;
+		}
+
+		public void setStreet(String street) {
+			this.street = street;
+		}
 	}
 
 	static class PersonDto {


### PR DESCRIPTION
This PR makes sure we do not create the context for reading projected values twice for the very same property.

Fixes: #4609 