### PR TITLE
Do not set `AggregationOptions.allowDiskUse` by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.3.0-SNAPSHOT</version>
+	<version>4.3.0-GH-4664-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-GH-4664-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-GH-4664-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-GH-4664-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2191,8 +2191,11 @@ public class MongoTemplate
 							.getCollation());
 
 			AggregateIterable<Document> aggregateIterable = delegate.prepare(collection).aggregate(pipeline, Document.class) //
-					.collation(collation.map(Collation::toMongoCollation).orElse(null)) //
-					.allowDiskUse(options.isAllowDiskUse());
+					.collation(collation.map(Collation::toMongoCollation).orElse(null));
+
+			if (options.isAllowDiskUseSet()) {
+				aggregateIterable = aggregateIterable.allowDiskUse(options.isAllowDiskUse());
+			}
 
 			if (options.getCursorBatchSize() != null) {
 				aggregateIterable = aggregateIterable.batchSize(options.getCursorBatchSize());
@@ -2255,8 +2258,11 @@ public class MongoTemplate
 
 			CollectionPreparerDelegate delegate = CollectionPreparerDelegate.of(options);
 
-			AggregateIterable<Document> cursor = delegate.prepare(collection).aggregate(pipeline, Document.class) //
-					.allowDiskUse(options.isAllowDiskUse());
+			AggregateIterable<Document> cursor = delegate.prepare(collection).aggregate(pipeline, Document.class);
+
+			if (options.isAllowDiskUseSet()) {
+				cursor = cursor.allowDiskUse(options.isAllowDiskUse());
+			}
 
 			if (options.getCursorBatchSize() != null) {
 				cursor = cursor.batchSize(options.getCursorBatchSize());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -1027,8 +1027,11 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 			@Nullable Class<?> inputType) {
 
 		ReactiveCollectionPreparerDelegate collectionPreparer = ReactiveCollectionPreparerDelegate.of(options);
-		AggregatePublisher<Document> cursor = collectionPreparer.prepare(collection).aggregate(pipeline, Document.class)
-				.allowDiskUse(options.isAllowDiskUse());
+		AggregatePublisher<Document> cursor = collectionPreparer.prepare(collection).aggregate(pipeline, Document.class);
+
+		if (options.isAllowDiskUseSet()) {
+			cursor = cursor.allowDiskUse(options.isAllowDiskUse());
+		}
 
 		if (options.getCursorBatchSize() != null) {
 			cursor = cursor.batchSize(options.getCursorBatchSize());

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOptionsTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOptionsTests.java
@@ -77,6 +77,22 @@ class AggregationOptionsTests {
 		assertThat(aggregationOptions.getHintObject()).contains(dummyHint);
 	}
 
+	@Test // GH-4664
+	void omitsAllowDiskUseByDefault() {
+
+		aggregationOptions = AggregationOptions.fromDocument(new Document());
+
+		assertThat(aggregationOptions.isAllowDiskUse()).isFalse();
+		assertThat(aggregationOptions.isAllowDiskUseSet()).isFalse();
+
+		assertThat(aggregationOptions.toDocument()).doesNotContainKey("allowDiskUse");
+
+		Document empty = new Document();
+		aggregationOptions.applyAndReturnPotentiallyChangedCommand(empty);
+
+		assertThat(empty).doesNotContainKey("allowDiskUse");
+	}
+
 	@Test // DATAMONGO-960, DATAMONGO-2153, DATAMONGO-1836
 	void aggregationOptionsToString() {
 


### PR DESCRIPTION
With MongoDB changing its default, we no longer set `allowDiskUse` to false if the value is not configured.

Closes #4664