### PR TITLE
Add logging a sort options for find queries

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -2595,10 +2595,11 @@ public class MongoTemplate
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
 		Document mappedFields = queryContext.getMappedFields(entity, EntityProjection.nonProjecting(entityClass));
 		Document mappedQuery = queryContext.getMappedQuery(entity);
+		Document mappedSort = getMappedSortObject(query, entityClass);
 
 		if (LOGGER.isDebugEnabled()) {
-			LOGGER.debug(String.format("find using query: %s fields: %s for class: %s in collection: %s",
-					serializeToJsonSafely(mappedQuery), mappedFields, entityClass, collectionName));
+			LOGGER.debug(String.format("find using query: %s fields: %s sort: %s for class: %s in collection: %s",
+					serializeToJsonSafely(mappedQuery), mappedSort, mappedFields, entityClass, collectionName));
 		}
 
 		return executeFindMultiInternal(new FindCallback(collectionPreparer, mappedQuery, mappedFields, null),
@@ -2620,10 +2621,11 @@ public class MongoTemplate
 		QueryContext queryContext = queryOperations.createQueryContext(new BasicQuery(query, fields));
 		Document mappedFields = queryContext.getMappedFields(entity, projection);
 		Document mappedQuery = queryContext.getMappedQuery(entity);
+		Document mappedSort = getMappedSortObject(query, sourceClass);
 
 		if (LOGGER.isDebugEnabled()) {
-			LOGGER.debug(String.format("find using query: %s fields: %s for class: %s in collection: %s",
-					serializeToJsonSafely(mappedQuery), mappedFields, sourceClass, collectionName));
+			LOGGER.debug(String.format("find using query: %s fields: %s sort: %s for class: %s in collection: %s",
+					serializeToJsonSafely(mappedQuery), mappedSort, mappedFields, sourceClass, collectionName));
 		}
 
 		return executeFindMultiInternal(new FindCallback(collectionPreparer, mappedQuery, mappedFields, null), preparer,


### PR DESCRIPTION
If use a querydsl with mongo such as
```
from(collection)
            .where(predicate)
            .orderBy(orderField.asc())
            .offset(pageable.offset)
            .limit(pageable.pageSize.toLong())
            .fetch()
```
and also log is enabled,

Then this query logs like
```
[C] 2024-04-04T16:06:13.855+09:00|DEBUG|pool-1-thread-1 @coroutine#3||MongoTemplate.java:2691|find using query: { "updatedAt" : { "$gte" : { "$date" : "2024-04-03T07:06:13.829Z"}, "$lte" : { "$date" : "2024-04-04T07:06:13.829Z"}}} fields: Document{{}} for class: class blahblah in collection: Collection
```

Thus it needs to be logged with sort query.

close https://github.com/spring-projects/spring-data-mongodb/issues/4686