### PR TITLE
Fix conversion of regular expression targeting id properties in queries 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4674-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4674-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4674-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4674-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -815,6 +815,11 @@ public class QueryMapper {
 	 */
 	@Nullable
 	public Object convertId(@Nullable Object id, Class<?> targetType) {
+
+		if (!SpecialTypeTreatment.INSTANCE.isConversionCandidate(id)) {
+			return id;
+		}
+
 		return converter.convertId(id, targetType);
 	}
 
@@ -876,8 +881,8 @@ public class QueryMapper {
 	private Object applyFieldTargetTypeHintToValue(Field documentField, @Nullable Object value) {
 
 		if (value == null || documentField.getProperty() == null || !documentField.getProperty().hasExplicitWriteTarget()
-				|| value instanceof Document || value instanceof DBObject || value instanceof Pattern
-				|| value instanceof BsonRegularExpression) {
+				|| value instanceof Document || value instanceof DBObject
+				|| !SpecialTypeTreatment.INSTANCE.isConversionCandidate(value)) {
 			return value;
 		}
 
@@ -1602,6 +1607,24 @@ public class QueryMapper {
 		@Override
 		public <T> T getPropertyValue(MongoPersistentProperty property) {
 			throw new IllegalStateException("No enclosing property source available");
+		}
+	}
+
+	/*
+	 * Types that must not be converted
+	 */
+	enum SpecialTypeTreatment {
+
+		INSTANCE;
+
+		private final Set<Class<?>> types = Set.of(Pattern.class, BsonRegularExpression.class);
+
+		boolean isConversionCandidate(@Nullable Object value) {
+			if (value == null) {
+				return false;
+			}
+
+			return !types.contains(value.getClass());
 		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1101,6 +1101,21 @@ public class QueryMapperUnitTests {
 		assertThat(document.get("text")).isInstanceOf(BsonRegularExpression.class);
 	}
 
+	@Test // GH-4674
+	void shouldRetainRegexPatternForIdProperty() {
+
+		org.bson.Document javaRegex = mapper.getMappedObject(query(where("id").regex("^1234$")).getQueryObject(),
+				context.getPersistentEntity(WithStringId.class));
+
+		assertThat(javaRegex.get("_id")).isInstanceOf(Pattern.class);
+
+		org.bson.Document bsonRegex = mapper.getMappedObject(
+				query(where("id").regex(new BsonRegularExpression("^1234$"))).getQueryObject(),
+				context.getPersistentEntity(WithStringId.class));
+
+		assertThat(bsonRegex.get("_id")).isInstanceOf(BsonRegularExpression.class);
+	}
+
 	@Test // DATAMONGO-2339
 	void findByIdUsesMappedIdFieldNameWithUnderscoreCorrectly() {
 


### PR DESCRIPTION
This commit fixes an issue where patterns targeting id properties might have been falsely converted into the properties type, turning a `Pattern` into its `String` representation.

Closes: #4674