### PR TITLE
Fix id conversion for fields of complex id. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4707-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4707-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4707-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4707-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -728,7 +728,12 @@ public class QueryMapper {
 			} else if (isKeyword(key)) {
 				resultDbo.put(key, convertIdField(documentField, entry.getValue()));
 			} else {
-				resultDbo.put(key, getMappedValue(documentField, entry.getValue()));
+				if(documentField.getProperty() != null && documentField.getProperty().isEntity()) {
+					Field propertyField = createPropertyField(documentField.getPropertyEntity(), key, mappingContext);
+					resultDbo.put(key, getMappedValue(propertyField, entry.getValue()));
+				} else {
+					resultDbo.put(key, getMappedValue(documentField, entry.getValue()));
+				}
 			}
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -1409,12 +1409,13 @@ public class MongoTemplateTests {
 		assertThat(result.get(0).field).isEqualTo("Beauford");
 	}
 
-	@Test // DATAMONGO-447
+	@Test // DATAMONGO-447, GH-4707
 	public void storesAndRemovesTypeWithComplexId() {
 
 		MyId id = new MyId();
 		id.first = "foo";
 		id.second = "bar";
+		id.time = Instant.now().minusSeconds(2);
 
 		TypeWithMyId source = new TypeWithMyId();
 		source.id = id;
@@ -4397,6 +4398,7 @@ public class MongoTemplateTests {
 
 		String first;
 		String second;
+		Instant time;
 	}
 
 	static class TypeWithMyId {


### PR DESCRIPTION
This PR fixes an issue where the property type for nested fields of an complex id is not handed over correctly leading to wrong conversion results eg. for Instant types that got then turned into ObjectIds.

Closes: #4707