### PR TITLE
Fix conversion of types when mapping Aggregation pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4722-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4722-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4722-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4722-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
@@ -15,18 +15,29 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
-import static org.mockito.Mockito.*;
-import static org.springframework.data.domain.Sort.Direction.*;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.project;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.sort;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 
+import org.assertj.core.api.Assertions;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.ConverterBuilder;
+import org.springframework.data.convert.CustomConversions;
+import org.springframework.data.convert.CustomConversions.StoreConversions;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
 
 /**
@@ -47,19 +58,8 @@ public class AggregationOperationRendererUnitTests {
 		verify(stage2).toPipelineStages(eq(rootContext));
 	}
 
-	record TestRecord(@Id String field1, String field2, LayerOne layerOne) {
-		record LayerOne(List<LayerTwo> layerTwo) {
-		}
-
-		record LayerTwo(LayerThree layerThree) {
-		}
-
-		record LayerThree(int fieldA, int fieldB)
-		{}
-	}
-
 	@Test
-	void xxx() {
+	void contextShouldCarryOnRelaxedFieldMapping() {
 
 		MongoTestMappingContext ctx = new MongoTestMappingContext(cfg -> {
 			cfg.initialEntitySet(TestRecord.class);
@@ -67,12 +67,47 @@ public class AggregationOperationRendererUnitTests {
 
 		MappingMongoConverter mongoConverter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, ctx);
 
-		Aggregation agg = Aggregation.newAggregation(
-			Aggregation.unwind("layerOne.layerTwo"),
-			project().and("layerOne.layerTwo.layerThree").as("layerOne.layerThree"),
-			sort(DESC, "layerOne.layerThree.fieldA")
+		Aggregation agg = Aggregation.newAggregation(Aggregation.unwind("layerOne.layerTwo"),
+				project().and("layerOne.layerTwo.layerThree").as("layerOne.layerThree"),
+				sort(DESC, "layerOne.layerThree.fieldA"));
+
+		AggregationOperationRenderer.toDocument(agg.getPipeline().getOperations(),
+				new RelaxedTypeBasedAggregationOperationContext(TestRecord.class, ctx, new QueryMapper(mongoConverter)));
+	}
+
+	@Test // GH-4722
+	void appliesConversionToValuesUsedInAggregation() {
+
+		MongoTestMappingContext ctx = new MongoTestMappingContext(cfg -> {
+			cfg.initialEntitySet(TestRecord.class);
+		});
+
+		MappingMongoConverter mongoConverter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, ctx);
+		mongoConverter.setCustomConversions(new CustomConversions(StoreConversions.NONE,
+				Set.copyOf(ConverterBuilder.writing(ZonedDateTime.class, String.class, ZonedDateTime::toString)
+						.andReading(it -> ZonedDateTime.parse(it)).getConverters())));
+		mongoConverter.afterPropertiesSet();
+
+		var agg = Aggregation.newAggregation(Aggregation.sort(Direction.DESC, "version"),
+				Aggregation.group("entityId").first(Aggregation.ROOT).as("value"), Aggregation.replaceRoot("value"),
+				Aggregation.match(Criteria.where("createdDate").lt(ZonedDateTime.now())) // here is the problem
 		);
 
-		AggregationOperationRenderer.toDocument(agg.getPipeline().getOperations(), new RelaxedTypeBasedAggregationOperationContext(TestRecord.class, ctx, new QueryMapper(mongoConverter)));
+		List<Document> document = AggregationOperationRenderer.toDocument(agg.getPipeline().getOperations(),
+				new RelaxedTypeBasedAggregationOperationContext(TestRecord.class, ctx, new QueryMapper(mongoConverter)));
+		Assertions.assertThat(document).last()
+				.extracting(it -> it.getEmbedded(List.of("$match", "createdDate", "$lt"), Object.class))
+				.isInstanceOf(String.class);
+	}
+
+	record TestRecord(@Id String field1, String field2, LayerOne layerOne) {
+		record LayerOne(List<LayerTwo> layerTwo) {
+		}
+
+		record LayerTwo(LayerThree layerThree) {
+		}
+
+		record LayerThree(int fieldA, int fieldB) {
+		}
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AggregationOperationRendererUnitTests.java
@@ -19,16 +19,21 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.project;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.sort;
 
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.convert.ConverterBuilder;
 import org.springframework.data.convert.CustomConversions;
@@ -37,6 +42,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.convert.QueryMapper;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.test.util.MongoTestMappingContext;
 
@@ -100,6 +106,37 @@ public class AggregationOperationRendererUnitTests {
 				.isInstanceOf(String.class);
 	}
 
+	@ParameterizedTest // GH-4722
+	@MethodSource("studentAggregationContexts")
+	void mapsOperationThatDoesNotExposeDedicatedFieldsCorrectly(AggregationOperationContext aggregationContext) {
+
+		var agg = newAggregation(Student.class, Aggregation.unwind("grades"), Aggregation.replaceRoot("grades"),
+				Aggregation.project("grades"));
+
+		List<Document> mappedPipeline = AggregationOperationRenderer.toDocument(agg.getPipeline().getOperations(),
+				aggregationContext);
+
+		Assertions.assertThat(mappedPipeline).last().isEqualTo(Document.parse("{\"$project\": {\"grades\": 1}}"));
+	}
+
+	private static Stream<Arguments> studentAggregationContexts() {
+
+		MongoTestMappingContext ctx = new MongoTestMappingContext(cfg -> {
+			cfg.initialEntitySet(Student.class);
+		});
+
+		MappingMongoConverter mongoConverter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, ctx);
+		mongoConverter.afterPropertiesSet();
+
+		QueryMapper queryMapper = new QueryMapper(mongoConverter);
+
+		return Stream.of(
+				Arguments
+						.of(new TypeBasedAggregationOperationContext(Student.class, ctx, queryMapper, FieldLookupPolicy.strict())),
+				Arguments.of(
+						new TypeBasedAggregationOperationContext(Student.class, ctx, queryMapper, FieldLookupPolicy.relaxed())));
+	}
+
 	record TestRecord(@Id String field1, String field2, LayerOne layerOne) {
 		record LayerOne(List<LayerTwo> layerTwo) {
 		}
@@ -110,4 +147,17 @@ public class AggregationOperationRendererUnitTests {
 		record LayerThree(int fieldA, int fieldB) {
 		}
 	}
+
+	static class Student {
+
+		@Field("mark") List<Grade> grades;
+
+	}
+
+	static class Grade {
+
+		int points;
+		String grades;
+	}
+
 }


### PR DESCRIPTION
This PR makes sure to apply conversion to non native mongo types when the context does not expose fields.

Resolves: #4722
