### PR TITLE
Consider null value settings for types with custom conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4710-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4710-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4710-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4710-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -92,6 +92,10 @@ class DocumentAccessor {
 
 		Assert.notNull(prop, "MongoPersistentProperty must not be null");
 
+		if (value == null && !prop.writeNullValues()) {
+			return;
+		}
+
 		Iterator<String> parts = Arrays.asList(prop.getMongoField().getName().parts()).iterator();
 		Bson document = this.document;
 
@@ -173,20 +177,4 @@ class DocumentAccessor {
 		return nested;
 	}
 
-	DocumentAccessor withCheckFieldMapping(boolean checkFieldMapping) {
-
-		if(!checkFieldMapping) {
-			return this;
-		}
-
-		return new DocumentAccessor(this.document) {
-				@Override
-				public void put(MongoPersistentProperty prop, @Nullable Object value) {
-					if(value != null || prop.writeNullValues()) {
-						super.put(prop, value);
-					}
-				}
-			};
-
-	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/DocumentAccessor.java
@@ -172,4 +172,21 @@ class DocumentAccessor {
 
 		return nested;
 	}
+
+	DocumentAccessor withCheckFieldMapping(boolean checkFieldMapping) {
+
+		if(!checkFieldMapping) {
+			return this;
+		}
+
+		return new DocumentAccessor(this.document) {
+				@Override
+				public void put(MongoPersistentProperty prop, @Nullable Object value) {
+					if(value != null || prop.writeNullValues()) {
+						super.put(prop, value);
+					}
+				}
+			};
+
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -987,6 +987,11 @@ public class MappingMongoConverter extends AbstractMongoConverter
 				dbRefObj = proxy.toDBRef();
 			}
 
+			if(obj !=null && conversions.hasCustomWriteTarget(obj.getClass())) {
+				accessor.withCheckFieldMapping(true).put(prop, doConvert(obj, conversions.getCustomWriteTarget(obj.getClass()).get()));
+				return;
+			}
+
 			dbRefObj = dbRefObj != null ? dbRefObj : createDBRef(obj, prop);
 
 			accessor.put(prop, dbRefObj);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -280,6 +280,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 		this.codecRegistryProvider = codecRegistryProvider;
 	}
 
+	@Override
 	public MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> getMappingContext() {
 		return mappingContext;
 	}
@@ -432,6 +433,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 		}
 	}
 
+	@Override
 	public <S extends Object> S read(Class<S> clazz, Bson bson) {
 		return read(TypeInformation.of(clazz), bson);
 	}
@@ -729,6 +731,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 		return null;
 	}
 
+	@Override
 	public DBRef toDBRef(Object object, @Nullable MongoPersistentProperty referringProperty) {
 
 		org.springframework.data.mongodb.core.mapping.DBRef annotation;
@@ -795,6 +798,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 	 *
 	 * @see org.springframework.data.mongodb.core.convert.MongoWriter#write(java.lang.Object, java.lang.Object)
 	 */
+	@Override
 	public void write(Object obj, Bson bson) {
 
 		if (null == obj) {
@@ -933,6 +937,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 		writePropertyInternal(value, dbObjectAccessor, inverseProp, accessor);
 	}
 
+	// TODO: Documentaccessor is package-private
 	@SuppressWarnings({ "unchecked" })
 	protected void writePropertyInternal(@Nullable Object obj, DocumentAccessor accessor, MongoPersistentProperty prop,
 			PersistentPropertyAccessor<?> persistentPropertyAccessor) {
@@ -1610,7 +1615,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 	}
 
 	@Override
-	public Object convertToMongoType(@Nullable Object obj, MongoPersistentEntity entity) {
+	public Object convertToMongoType(@Nullable Object obj, MongoPersistentEntity<?> entity) {
 		Document newDocument = new Document();
 		writeInternal(obj, newDocument, entity);
 		return newDocument;
@@ -1948,6 +1953,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 			this.spELContext = spELContext;
 		}
 
+		@Override
 		@Nullable
 		@SuppressWarnings("unchecked")
 		public <T> T getPropertyValue(MongoPersistentProperty property) {
@@ -2261,6 +2267,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 			return null;
 		}
 
+		// TODO: ObjectPath is package-private
 		ObjectPath getPath();
 
 		CustomConversions getCustomConversions();
@@ -2421,6 +2428,7 @@ public class MappingMongoConverter extends AbstractMongoConverter
 					collectionConverter, mapConverter, dbRefConverter, elementConverter);
 		}
 
+		// TODO: ObjectPath is package-private
 		@Override
 		public ObjectPath getPath() {
 			return path;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -1284,7 +1284,8 @@ public class MappingMongoConverter extends AbstractMongoConverter
 
 	private void writeSimpleInternal(@Nullable Object value, Bson bson, MongoPersistentProperty property,
 			PersistentPropertyAccessor<?> persistentPropertyAccessor) {
-		DocumentAccessor accessor = new DocumentAccessor(bson);
+
+		DocumentAccessor accessor = new DocumentAccessor(bson).withCheckFieldMapping(true);
 
 		if (conversions.hasValueConverter(property)) {
 			accessor.put(property, conversions.getPropertyValueConversions().getValueConverter(property).write(value,


### PR DESCRIPTION
This PR fixes an issue where settings regarding storage of `null` values had been ignored if a custom converter took care of the conversion.

Let's do an initial round of review and check how dbrefs should be treated when there's this kind of conversion. Also, if we decide to go for it, we need to update the documentation.