### PR TITLE
Fixed the bug, a null able list does not work

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -317,7 +317,7 @@ public class Criteria implements CriteriaDefinition {
 	public Criteria in(Object... values) {
 		if (values.length > 0 && values[0] instanceof Collection) {
 			throw new InvalidMongoDbApiUsageException(
-					"You can only pass in one argument of type " + values[1].getClass().getName());
+					"You can only pass in one argument of type " + values[0].getClass().getName());
 		}
 		criteria.put("$in", Arrays.asList(values));
 		return this;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -315,7 +315,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/in/">MongoDB Query operator: $in</a>
 	 */
 	public Criteria in(Object... values) {
-		if (values.length > 1 && values[1] instanceof Collection) {
+		if (values.length > 0 && values[1] instanceof Collection) {
 			throw new InvalidMongoDbApiUsageException(
 					"You can only pass in one argument of type " + values[1].getClass().getName());
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -315,7 +315,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @see <a href="https://docs.mongodb.com/manual/reference/operator/query/in/">MongoDB Query operator: $in</a>
 	 */
 	public Criteria in(Object... values) {
-		if (values.length > 0 && values[1] instanceof Collection) {
+		if (values.length > 0 && values[0] instanceof Collection) {
 			throw new InvalidMongoDbApiUsageException(
 					"You can only pass in one argument of type " + values[1].getClass().getName());
 		}


### PR DESCRIPTION
If there is a nullable list with values, the implementation should check it instead of wrapping the nullable list (even if it has values) into another newly created list by the Criteria class.

### Existing
Code: `if (!filter.ids.isNullOrEmpty()) criteria.and("id").`in`(filter.ids) `
Output: `{"id" : { "$in" : [["667e8b8af76f17213e4d4280"]]}}` **Wrong**

Code: `if (!filter.ids.isNullOrEmpty()) criteria.and("id").`in`(filter.ids!!)` **Required !!**
Output:` {"id" :{ "$in" : ["667e8b8af76f17213e4d4280"]}}` **Correct**

### After Fix
Code: `if (!filter.ids.isNullOrEmpty()) criteria.and("id").`in`(filter.ids) ` **With and Without !!**
Output: `{"id" : { "$in" : ["667e8b8af76f17213e4d4280"]}}` **Correct**

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
