### PR TITLE
Fix id mapping when using `$all` operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4736-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4736-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4736-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4736-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -719,7 +719,7 @@ public class QueryMapper {
 		for (Entry<String, Object> entry : valueDbo.entrySet()) {
 
 			String key = entry.getKey();
-			if ("$nin".equals(key) || "$in".equals(key)) {
+			if ("$nin".equals(key) || "$in".equals(key) || "$all".equals(key)) {
 				List<Object> ids = new ArrayList<>();
 				for (Object id : (Iterable<?>) valueDbo.get(key)) {
 					ids.add(convertId(id, getIdTypeForField(documentField)));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1684,6 +1684,18 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject).isEqualTo("{ 'text' : {  $gt : 'gnirps', $in : [ 'atad' ] } }");
 	}
 
+	@Test // GH-4736
+	void allOperatorShouldConvertIdCollection() {
+
+		ObjectId oid = ObjectId.get();
+		Criteria criteria = new Criteria().andOperator(where("name").isNull().and("id").all(List.of(oid.toString())));
+
+		org.bson.Document mappedObject = mapper.getMappedObject(criteria.getCriteriaObject(),
+			context.getPersistentEntity(Customer.class));
+
+		assertThat(mappedObject).containsEntry("$and.[0]._id.$all", List.of(oid));
+	}
+
 	class WithSimpleMap {
 		Map<String, String> simpleMap;
 	}


### PR DESCRIPTION
Fix the id mapping for queries using the `$all` operator. Prior to this change the collection nature of the _id_ values was not preserved leading to an invalid query.

Resolves: #4736 