### PR TITLE
Upgrade the mongoDB driver version to 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-mongodb</dist.id>
 		<springdata.commons>3.4.0-SNAPSHOT</springdata.commons>
-		<mongo>5.0.1</mongo>
+		<mongo>5.1.2</mongo>
 		<mongo.reactivestreams>${mongo}</mongo.reactivestreams>
 		<jmh.version>1.19</jmh.version>
 	</properties>


### PR DESCRIPTION
This pull request updates the MongoDB dependency from version 5.0.1 to 5.1.2.
- close #4741 