### PR TITLE
Generate proxy and register reflection for default sorting during AOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.x-GH-4744-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4744-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4744-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.x-GH-4744-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/aot/LazyLoadingProxyAotProcessor.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/aot/LazyLoadingProxyAotProcessor.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.aot.generate.GenerationContext;
-import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -77,8 +76,7 @@ public class LazyLoadingProxyAotProcessor {
 								LazyLoadingInterceptor::none);
 
 						// see: spring-projects/spring-framework/issues/29309
-						generationContext.getRuntimeHints().reflection().registerType(proxyClass,
-								MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS);
+						generationContext.getRuntimeHints().reflection().registerType(proxyClass, MongoAotReflectionHelper::cglibProxyReflectionMemberAccess);
 					}
 				});
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/aot/MongoAotReflectionHelper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/aot/MongoAotReflectionHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.aot;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.TypeHint.Builder;
+
+/**
+ * @author Christoph Strobl
+ */
+public final class MongoAotReflectionHelper {
+
+	public static void cglibProxyReflectionMemberAccess(Builder builder) {
+
+		builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS,
+				MemberCategory.DECLARED_FIELDS);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/BasicQuery.java
@@ -85,6 +85,20 @@ public class BasicQuery extends Query {
 		this.sortObject = new Document();
 	}
 
+	/**
+	 * Create a BasicQuery given a {@link Query}. The resulting query is a copy of {@link Query}.
+	 *
+	 * @param query
+	 */
+	public BasicQuery(Query query) {
+
+		super(query);
+		this.queryObject = query.getQueryObject();
+		this.setFieldsObject(query.getFieldsObject());
+		this.setSortObject(query.getSortObject());
+		this.setMeta(query.getMeta());
+	}
+
 	@Override
 	public Query addCriteria(CriteriaDefinition criteria) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Query.java
@@ -79,6 +79,20 @@ public class Query implements ReadConcernAware, ReadPreferenceAware {
 
 	private Optional<Collation> collation = Optional.empty();
 
+	Query(Query query) {
+		this.restrictedTypes = query.restrictedTypes;
+		this.fieldSpec = query.fieldSpec;
+		this.sort = query.sort;
+		this.limit = query.limit;
+		this.skip = query.skip;
+		this.keysetScrollPosition = query.keysetScrollPosition;
+		this.readConcern = query.readConcern;
+		this.readPreference = query.readPreference;
+		this.hint = query.hint;
+		this.meta = query.meta;
+		this.collation = query.collation;
+	}
+
 	/**
 	 * Static factory method to create a {@link Query} using the provided {@link CriteriaDefinition}.
 	 *

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/RepositoryRuntimeHints.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/RepositoryRuntimeHints.java
@@ -19,11 +19,15 @@ import static org.springframework.data.mongodb.aot.MongoAotPredicates.*;
 
 import java.util.List;
 
+import org.bson.Document;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.data.mongodb.aot.MongoAotPredicates;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.repository.query.QueryUtils;
 import org.springframework.data.mongodb.repository.support.CrudMethodMetadata;
 import org.springframework.data.mongodb.repository.support.QuerydslMongoPredicateExecutor;
 import org.springframework.data.mongodb.repository.support.ReactiveQuerydslMongoPredicateExecutor;
@@ -44,6 +48,18 @@ class RepositoryRuntimeHints implements RuntimeHintsRegistrar {
 				List.of(TypeReference.of("org.springframework.data.mongodb.repository.support.SimpleMongoRepository")),
 				builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
 						MemberCategory.INVOKE_PUBLIC_METHODS));
+
+		Query query = QueryUtils.decorateSort(new BasicQuery("{}", null), new Document("foo", "bar"));
+
+		hints.reflection()
+			.registerType(Query.class, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+				MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS);
+		hints.reflection()
+			.registerType(BasicQuery.class, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+				MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS);
+		hints.reflection()
+				.registerType(query.getClass(), MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+						MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS);
 
 		if (isAopPresent(classLoader)) {
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/RepositoryRuntimeHints.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/RepositoryRuntimeHints.java
@@ -24,10 +24,6 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.data.mongodb.aot.MongoAotPredicates;
-import org.springframework.data.mongodb.aot.MongoAotReflectionHelper;
-import org.springframework.data.mongodb.core.query.BasicQuery;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.repository.query.QueryUtils;
 import org.springframework.data.mongodb.repository.support.CrudMethodMetadata;
 import org.springframework.data.mongodb.repository.support.QuerydslMongoPredicateExecutor;
 import org.springframework.data.mongodb.repository.support.ReactiveQuerydslMongoPredicateExecutor;
@@ -48,8 +44,6 @@ class RepositoryRuntimeHints implements RuntimeHintsRegistrar {
 				List.of(TypeReference.of("org.springframework.data.mongodb.repository.support.SimpleMongoRepository")),
 				builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
 						MemberCategory.INVOKE_PUBLIC_METHODS));
-
-		registerHintsForDefaultSorting(hints, classLoader);
 
 		if (isAopPresent(classLoader)) {
 
@@ -99,13 +93,4 @@ class RepositoryRuntimeHints implements RuntimeHintsRegistrar {
 		return ClassUtils.isPresent("org.springframework.aop.Pointcut", classLoader);
 	}
 
-	private static void registerHintsForDefaultSorting(RuntimeHints hints, @Nullable ClassLoader classLoader) {
-
-		List<TypeReference> types = List.of(TypeReference.of(Query.class), //
-				TypeReference.of(QueryUtils.queryProxyType(Query.class, classLoader)), //
-				TypeReference.of(BasicQuery.class), //
-				TypeReference.of(QueryUtils.queryProxyType(BasicQuery.class, classLoader)));
-
-		hints.reflection().registerTypes(types, MongoAotReflectionHelper::cglibProxyReflectionMemberAccess);
-	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/query/AbstractMongoQuery.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+
 import org.springframework.data.mapping.model.SpELExpressionEvaluator;
 import org.springframework.data.mongodb.core.ExecutableFindOperation.ExecutableFind;
 import org.springframework.data.mongodb.core.ExecutableFindOperation.FindWithQuery;
@@ -155,7 +156,7 @@ public abstract class AbstractMongoQuery implements RepositoryQuery {
 	 * @since 4.2
 	 */
 	private Query applyAnnotatedReadPreferenceIfPresent(Query query) {
-		
+
 		if (!method.hasAnnotatedReadPreference()) {
 			return query;
 		}


### PR DESCRIPTION
This PR makes sure to generate required cglib proxies during AOT phase so they are ready to use within a native image. Prior to this change default sorting raised an error as class generation is not allowed in a GraalVM native image.

Resolves: #4744 