### PR TITLE
Fix missing query options when calling MongoTemplate#findAndModify

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1089,7 +1089,7 @@ public class MongoTemplate
 			operations.forType(entityClass).getCollation(query).ifPresent(optionsToUse::collation);
 		}
 
-		return doFindAndModify(createDelegate(query), collectionName, query, query.getFieldsObject(),
+		return doFindAndModify(createDelegate(query), collectionName, query,
 				getMappedSortObject(query, entityClass), entityClass, update, optionsToUse);
 	}
 
@@ -2720,8 +2720,7 @@ public class MongoTemplate
 
 	@SuppressWarnings("ConstantConditions")
 	protected <T> T doFindAndModify(CollectionPreparer collectionPreparer, String collectionName, Query query,
-			Document fields, Document sort, Class<T> entityClass, UpdateDefinition update,
-			@Nullable FindAndModifyOptions options) {
+			Document sort, Class<T> entityClass, UpdateDefinition update, @Nullable FindAndModifyOptions options) {
 
 		if (options == null) {
 			options = new FindAndModifyOptions();
@@ -2741,6 +2740,7 @@ public class MongoTemplate
 		if (options.isUpsert()) {
 			opts.upsert(true);
 		}
+		Document fields = query.getFieldsObject();
 		opts.projection(fields);
 		if (options.isReturnNew()) {
 			opts.returnDocument(ReturnDocument.AFTER);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -141,6 +141,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Roman Puchkovskiy
  * @author Yadhukrishna S Pai
  * @author Jakub Zurawa
+ * @author Kinjarapu Sriram
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
@@ -2534,6 +2535,16 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 				ReplaceOptions.replaceOptions().upsert());
 
 		verify(collection).withWriteConcern(eq(WriteConcern.UNACKNOWLEDGED));
+	}
+
+	@Test // GH-4776
+	void findAndModifyConsidersMaxTimeMs() {
+
+		template.findAndModify(new BasicQuery("{ 'spring' : 'data-mongodb' }").maxTimeMsec(5000), new Update(), Human.class);
+
+		ArgumentCaptor<FindOneAndUpdateOptions> options = ArgumentCaptor.forClass(FindOneAndUpdateOptions.class);
+		verify(collection).findOneAndUpdate(any(Bson.class), any(Bson.class), options.capture());
+		assertThat(options.getValue().getMaxTime(TimeUnit.MILLISECONDS)).isEqualTo(5000);
 	}
 
 	class AutogenerateableId {


### PR DESCRIPTION
Forward maxTimeMsec from `Query` to `FindOneAndUpdateOptions`.

Closes #4776