### PR TITLE
Retain Regex options from the parsed `JsonToken`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.4.0-SNAPSHOT</version>
+	<version>4.4.0-GH-4806-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-benchmarks/pom.xml
+++ b/spring-data-mongodb-benchmarks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.0-GH-4806-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.0-GH-4806-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.4.0-SNAPSHOT</version>
+		<version>4.4.0-GH-4806-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReader.java
@@ -461,7 +461,9 @@ public class ParameterBindingJsonReader extends AbstractBsonReader {
 
 		if (isRegularExpression) {
 
-			bindableValue.setValue(new BsonRegularExpression(computedValue));
+			BsonRegularExpression originalExpression = token.getValue(BsonRegularExpression.class);
+
+			bindableValue.setValue(new BsonRegularExpression(computedValue, originalExpression.getOptions()));
 			bindableValue.setType(BsonType.REGULAR_EXPRESSION);
 		} else {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/util/json/ParameterBindingJsonReaderUnitTests.java
@@ -26,12 +26,12 @@ import java.util.UUID;
 
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
+import org.bson.BsonRegularExpression;
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.expression.ValueExpressionParser;
-import org.springframework.data.mapping.model.ValueExpressionEvaluator;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
@@ -82,6 +82,26 @@ class ParameterBindingJsonReaderUnitTests {
 
 		Document target = parse("{ 'lastname' : '?0' }", 100);
 		assertThat(target).isEqualTo(new Document("lastname", "100"));
+	}
+
+	@Test // GH-4806
+	void regexConsidersOptions() {
+
+		Document target = parse("{ 'c': /^true$/i }");
+
+		BsonRegularExpression pattern = target.get("c", BsonRegularExpression.class);
+		assertThat(pattern.getPattern()).isEqualTo("^true$");
+		assertThat(pattern.getOptions()).isEqualTo("i");
+	}
+
+	@Test // GH-4806
+	void regexConsidersBindValueWithOptions() {
+
+		Document target = parse("{ 'c': /^?0$/i }", "foo");
+
+		BsonRegularExpression pattern = target.get("c", BsonRegularExpression.class);
+		assertThat(pattern.getPattern()).isEqualTo("^foo$");
+		assertThat(pattern.getOptions()).isEqualTo("i");
 	}
 
 	@Test


### PR DESCRIPTION
We now retain `BsonRegularExpression.options` when resolving bind values from the original `BsonRegularExpression`.

Closes #4806