### PR TITLE
Fix same hashCodes an different queries with include and exclude

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Field.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Field.java
@@ -37,6 +37,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  * @author Owen Q
  * @author Kirill Egorov
+ * @author GaEun Kim
  */
 public class Field {
 
@@ -286,7 +287,7 @@ public class Field {
 	@Override
 	public int hashCode() {
 
-		int result = ObjectUtils.nullSafeHashCode(criteria);
+		int result = ObjectUtils.nullSafeHashCode(criteria.toString());
 		result = 31 * result + ObjectUtils.nullSafeHashCode(slices);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(elemMatches);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(positionKey);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/FieldUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/FieldUnitTests.java
@@ -28,6 +28,7 @@ import java.util.List;
  * @author Owen Q
  * @author Mark Paluch
  * @author Kirill Egorov
+ * @author GaEun Kim
  */
 class FieldUnitTests {
 
@@ -84,5 +85,19 @@ class FieldUnitTests {
 		Field right = new Field().exclude(List.of("foo", "bar"));
 
 		assertThat(left).isEqualTo(right);
+	}
+
+	@Test
+	void assertDifferentHashCodesForExcludeAndIncludeQueries() {
+
+		Query queryWithExclude = new Query();
+		queryWithExclude.fields().exclude("key1");
+		queryWithExclude.fields().exclude("key2");
+
+		Query queryWithInclude = new Query();
+		queryWithInclude.fields().include("key1");
+		queryWithInclude.fields().include("key2");
+
+		assertThat(queryWithExclude.hashCode()).isNotEqualTo(queryWithInclude.hashCode());
 	}
 }


### PR DESCRIPTION
Closes #4032

There was a bug where the hashCodes of the exclude and include queries were identical.

The issue was caused by the hashCode calculation in HashMap, where the XOR operation between the hashCode of the key and the hashCode of the value (0 or 1) resulted in duplicate hashCodes.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/3353646b-8dff-4b03-bd62-33984531ffc3">


Since Exclude and Include are differentiated by 0 and 1 and are put into the hashMap, they were vulnerable to returning duplicate hashCodes.

To resolve this, the fix involved combining the key and value of the HashMap into a single String and calculating the hashCode based on that.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
