### PR TITLE
Update reactive `SimpleReactiveMongoRepository.saveAll` flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.x-GH-4838-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4838-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4838-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -17,7 +17,6 @@ package org.springframework.data.mongodb.repository.support;
 
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 
-import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -114,7 +113,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Streamable<S> source = Streamable.of(entities);
 
 		return source.stream().allMatch(entityInformation::isNew) ? //
-				insert(entities) : new AeonFlux<>(source).combatMap(this::save);
+				insert(entities) : doItSomewhatSequentially(source, this::save);
 	}
 
 	@Override
@@ -125,6 +124,20 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		return Flux.from(entityStream).concatMap(entity -> entityInformation.isNew(entity) ? //
 				mongoOperations.insert(entity, entityInformation.getCollectionName()) : //
 				mongoOperations.save(entity, entityInformation.getCollectionName()));
+	}
+
+	static <T> Flux<T> doItSomewhatSequentially/* how should we actually call this? */(Streamable<T> ts, Function<? super T, ? extends Publisher<? extends T>> mapper) {
+
+		List<T> list = ts.toList();
+		if (list.size() == 1) {
+			return Flux.just(list.iterator().next()).flatMap(mapper);
+		} else if (list.size() == 2) {
+			return Flux.fromIterable(list).concatMap(mapper);
+		}
+
+		Flux<T> first = Flux.just(list.get(0)).flatMap(mapper);
+		Flux<T> theRest = Flux.fromIterable(list.subList(1, list.size())).flatMapSequential(mapper);
+		return first.concatWith(theRest);
 	}
 
 	@Override
@@ -565,47 +578,5 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 					.as(getResultType()).matching(query);
 		}
 
-	}
-
-	static class AeonFlux<T> extends Flux<T> {
-
-		private final Streamable<T> source;
-		private final Flux<T> delegate;
-
-		AeonFlux(Streamable<T> source) {
-			this(source, Flux.fromIterable(source));
-		}
-
-		private AeonFlux(Streamable<T> source, Flux<T> delegate) {
-			this.source = source;
-			this.delegate = delegate;
-		}
-
-		@Override
-		public void subscribe(CoreSubscriber<? super T> actual) {
-			delegate.subscribe(actual);
-		}
-
-		Flux<T> combatMap(Function<? super T, ? extends Publisher<? extends T>> mapper) {
-			return new AeonFlux<>(source, combatMapList(source.toList(), mapper));
-		}
-
-		private static <T> Flux<T> combatMapList(List<T> list,
-				Function<? super T, ? extends Publisher<? extends T>> mapper) {
-
-			if (list.isEmpty()) {
-				return Flux.empty();
-			}
-			if (list.size() == 1) {
-				return Flux.just(list.iterator().next()).flatMap(mapper);
-			}
-			if (list.size() == 2) {
-				return Flux.fromIterable(list).concatMap(mapper);
-			}
-
-			Flux<T> first = Flux.just(list.get(0)).flatMap(mapper);
-			Flux<T> theRest = Flux.fromIterable(list.subList(1, list.size())).flatMapSequential(mapper);
-			return first.concatWith(theRest);
-		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -276,14 +276,10 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		Assert.notNull(entities, "The given Iterable of entities must not be null");
 
-		Collection<?> idCollection = StreamUtils.createStreamFromIterator(entities.iterator()).map(entityInformation::getId)
-				.collect(Collectors.toList());
+		Collection<? extends ID> ids = StreamUtils.createStreamFromIterator(entities.iterator())
+				.map(entityInformation::getId).collect(Collectors.toList());
 
-		Criteria idsInCriteria = where(entityInformation.getIdAttribute()).in(idCollection);
-
-		Query query = new Query(idsInCriteria);
-		getReadPreference().ifPresent(query::withReadPreference);
-		return mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName()).then();
+		return deleteAllById(ids);
 	}
 
 	@Override

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
 import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.data.util.StreamUtils;
-import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -110,10 +110,9 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		Assert.notNull(entities, "The given Iterable of entities must not be null");
 
-		Streamable<S> source = Streamable.of(entities);
-
+		List<S> source = toList(entities);
 		return source.stream().allMatch(entityInformation::isNew) ? //
-				insert(entities) : doItSomewhatSequentially(source, this::save);
+				insert(source) : concatMapSequentially(source, this::save);
 	}
 
 	@Override
@@ -124,20 +123,6 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		return Flux.from(entityStream).concatMap(entity -> entityInformation.isNew(entity) ? //
 				mongoOperations.insert(entity, entityInformation.getCollectionName()) : //
 				mongoOperations.save(entity, entityInformation.getCollectionName()));
-	}
-
-	static <T> Flux<T> doItSomewhatSequentially/* how should we actually call this? */(Streamable<T> ts, Function<? super T, ? extends Publisher<? extends T>> mapper) {
-
-		List<T> list = ts.toList();
-		if (list.size() == 1) {
-			return Flux.just(list.iterator().next()).flatMap(mapper);
-		} else if (list.size() == 2) {
-			return Flux.fromIterable(list).concatMap(mapper);
-		}
-
-		Flux<T> first = Flux.just(list.get(0)).flatMap(mapper);
-		Flux<T> theRest = Flux.fromIterable(list.subList(1, list.size())).flatMapSequential(mapper);
-		return first.concatWith(theRest);
 	}
 
 	@Override
@@ -349,8 +334,11 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		Assert.notNull(entities, "The given Iterable of entities must not be null");
 
-		Collection<S> source = toCollection(entities);
-		return source.isEmpty() ? Flux.empty() : mongoOperations.insert(source, entityInformation.getCollectionName());
+		return insert(toCollection(entities));
+	}
+
+	private <S extends T> Flux<S> insert(Collection<S> entities) {
+		return entities.isEmpty() ? Flux.empty() : mongoOperations.insert(entities, entityInformation.getCollectionName());
 	}
 
 	@Override
@@ -453,6 +441,12 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		this.crudMethodMetadata = crudMethodMetadata;
 	}
 
+	private Flux<T> findAll(Query query) {
+
+		getReadPreference().ifPresent(query::withReadPreference);
+		return mongoOperations.find(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
+	}
+
 	private Optional<ReadPreference> getReadPreference() {
 
 		if (crudMethodMetadata == null) {
@@ -474,15 +468,47 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		return new Query(where(entityInformation.getIdAttribute()).in(toCollection(ids)));
 	}
 
-	private static <E> Collection<E> toCollection(Iterable<E> ids) {
-		return ids instanceof Collection<E> collection ? collection
-				: StreamUtils.createStreamFromIterator(ids.iterator()).collect(Collectors.toList());
+	/**
+	 * Transform the elements emitted by this Flux into Publishers, then flatten these inner publishers into a single
+	 * Flux. The operation does not allow interleave between performing the map operation for the first and second source
+	 * element guaranteeing the mapping operation completed before subscribing to its following inners, that will then be
+	 * subscribed to eagerly emitting elements in order of their source.
+	 * 
+	 * <pre class="code">
+	 * Flux.just(first-element).flatMap(...)
+	 *     .concatWith(Flux.fromIterable(remaining-elements).flatMapSequential(...))
+	 * </pre>
+	 *
+	 * @param source the collection of elements to transform.
+	 * @param mapper the transformation {@link Function}. Must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @param <T> source type
+	 */
+	static <T> Flux<T> concatMapSequentially(List<T> source,
+			Function<? super T, ? extends Publisher<? extends T>> mapper) {
+
+		if (source.isEmpty()) {
+			return Flux.empty();
+		}
+		if (source.size() == 1) {
+			return Flux.just(source.iterator().next()).flatMap(mapper);
+		}
+		if (source.size() == 2) {
+			return Flux.fromIterable(source).concatMap(mapper);
+		}
+
+		Flux<T> first = Flux.just(source.get(0)).flatMap(mapper);
+		Flux<T> theRest = Flux.fromIterable(source.subList(1, source.size())).flatMapSequential(mapper);
+		return first.concatWith(theRest);
 	}
 
-	private Flux<T> findAll(Query query) {
+	private static <E> List<E> toList(Iterable<E> source) {
+		return source instanceof List<E> list ? list : new ArrayList<>(toCollection(source));
+	}
 
-		getReadPreference().ifPresent(query::withReadPreference);
-		return mongoOperations.find(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
+	private static <E> Collection<E> toCollection(Iterable<E> source) {
+		return source instanceof Collection<E> collection ? collection
+				: StreamUtils.createStreamFromIterator(source.iterator()).collect(Collectors.toList());
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/ReactiveTransactionIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/ReactiveTransactionIntegrationTests.java
@@ -467,7 +467,7 @@ public class ReactiveTransactionIntegrationTests {
 			TransactionalOperator transactionalOperator = TransactionalOperator.create(manager,
 					new DefaultTransactionDefinition());
 
-			return Flux.merge(operations.save(new EventLog(new ObjectId(), "beforeConvert")), //
+			return Flux.concat(operations.save(new EventLog(new ObjectId(), "beforeConvert")), //
 					operations.save(new EventLog(new ObjectId(), "afterConvert")), //
 					operations.save(new EventLog(new ObjectId(), "beforeInsert")), //
 					operations.save(person), //


### PR DESCRIPTION
This PR updates the reactive save all execution path for `save` operations using `Iterable` & `Publisher` in a way that makes sure the first element is completely processed before continuing with other server calls. In doing so we make sure a potential flag indicating transaction start is sent before continuing with the remaining server calls.