### PR TITLE
Align `@Indexed(expireAfter)` with `expireAfterSeconds`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.x-GH-4844-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4844-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4844-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
@@ -564,7 +564,7 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 
 			Duration timeout = computeIndexTimeout(index.expireAfter(),
 					() -> getEvaluationContextForProperty(persistentProperty.getOwner()));
-			if (!timeout.isZero() && !timeout.isNegative()) {
+			if (!timeout.isNegative()) {
 				indexDefinition.expire(timeout);
 			}
 		}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
@@ -222,6 +222,15 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 			assertThat(indexDefinitions.get(0).getIndexOptions()).containsEntry("expireAfterSeconds", 600L);
 		}
 
+		@Test // GH-4844
+		public void shouldResolveZeroTimeoutFromString() {
+
+			List<IndexDefinitionHolder> indexDefinitions = prepareMappingContextAndResolveIndexForType(
+				WithExpireAfterZeroSecondsAsPlainString.class);
+
+			assertThat(indexDefinitions.get(0).getIndexOptions()).containsEntry("expireAfterSeconds", 0L);
+		}
+
 		@Test // DATAMONGO-2112
 		public void shouldResolveTimeoutFromIso8601String() {
 
@@ -381,6 +390,11 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 		@Document
 		class WithExpireAfterAsPlainString {
 			@Indexed(expireAfter = "10m") String withTimeout;
+		}
+
+		@Document
+		class WithExpireAfterZeroSecondsAsPlainString {
+			@Indexed(expireAfter = "0s") String withTimeout;
 		}
 
 		@Document


### PR DESCRIPTION
This commit fixes an issue where `expireAfter=0s` behaves differently from `expireAfterSeconds=0` where the former would not be applied.

Resolves: #4844