### PR TITLE
Support Expressions in $slice operator. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.x-GH-4857-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4857-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4857-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
@@ -1033,34 +1033,67 @@ public class ArrayOperators {
 		}
 
 		/**
+		 * Slice the number of elements.
+		 *
+		 * @param nrElements An {@link AggregationExpression} that evaluates to a numeric value used as item count.
+		 * @return new instance of {@link Slice}.
+		 * @since 4.5
+		 */
+		public Slice itemCount(AggregationExpression nrElements) {
+			return new Slice(append(nrElements));
+		}
+
+		/**
 		 * Slice using offset and count.
 		 *
 		 * @param position the start position
 		 * @return new instance of {@link SliceElementsBuilder} to create {@link Slice}.
 		 */
-		public SliceElementsBuilder offset(final int position) {
+		public SliceElementsBuilder offset(int position) {
+			return new SliceElementsBuilder(position);
+		}
 
-			return new SliceElementsBuilder() {
-
-				@Override
-				public Slice itemCount(int nrElements) {
-					return new Slice(append(position)).itemCount(nrElements);
-				}
-			};
+		/**
+		 * Slice using offset and count.
+		 *
+		 * @param position the start position
+		 * @return new instance of {@link SliceElementsBuilder} to create {@link Slice}.
+		 */
+		public SliceElementsBuilder offset(AggregationExpression position) {
+			return new SliceElementsBuilder(position);
 		}
 
 		/**
 		 * @author Christoph Strobl
 		 */
-		public interface SliceElementsBuilder {
+		public class SliceElementsBuilder {
+
+			private final Object position;
+
+			SliceElementsBuilder(Object position) {
+				this.position = position;
+			}
 
 			/**
 			 * Set the number of elements given {@literal nrElements}.
 			 *
 			 * @param nrElements
-			 * @return
+			 * @return new instance of {@link Slice}.
 			 */
-			Slice itemCount(int nrElements);
+			public Slice itemCount(int nrElements) {
+				return new Slice(append(position)).itemCount(nrElements);
+			}
+
+			/**
+			 * Slice the number of elements.
+			 *
+			 * @param nrElements An {@link AggregationExpression} that evaluates to a numeric value used as item count.
+			 * @return new instance of {@link Slice}.
+			 * @since 4.5
+			 */
+			public Slice itemCount(AggregationExpression nrElements) {
+				return new Slice(append(position)).itemCount(nrElements);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR allows `AggregationExpressions` to be used for `itemCount` and `offset` of the `Slice` expression.

Closes: #4857 