### PR TITLE
Downport fix for CVE-2022-22980 to 3.2.x

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/EvaluationContextExpressionEvaluator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/json/EvaluationContextExpressionEvaluator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.util.json;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.springframework.data.mapping.model.SpELExpressionEvaluator;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.3.5
+ */
+class EvaluationContextExpressionEvaluator implements SpELExpressionEvaluator {
+
+	ValueProvider valueProvider;
+	ExpressionParser expressionParser;
+	Supplier<EvaluationContext> evaluationContext;
+
+	public EvaluationContextExpressionEvaluator(ValueProvider valueProvider, ExpressionParser expressionParser,
+			Supplier<EvaluationContext> evaluationContext) {
+
+		this.valueProvider = valueProvider;
+		this.expressionParser = expressionParser;
+		this.evaluationContext = evaluationContext;
+	}
+
+	@Nullable
+	@Override
+	public <T> T evaluate(String expression) {
+		return evaluateExpression(expression, Collections.emptyMap());
+	}
+
+	public EvaluationContext getEvaluationContext(String expressionString) {
+		return evaluationContext != null ? evaluationContext.get() : new StandardEvaluationContext();
+	}
+
+	public SpelExpression getParsedExpression(String expressionString) {
+		return (SpelExpression) (expressionParser != null ? expressionParser : new SpelExpressionParser())
+				.parseExpression(expressionString);
+	}
+
+	public <T> T evaluateExpression(String expressionString, Map<String, Object> variables) {
+
+		SpelExpression expression = getParsedExpression(expressionString);
+		EvaluationContext ctx = getEvaluationContext(expressionString);
+		variables.entrySet().forEach(entry -> ctx.setVariable(entry.getKey(), entry.getValue()));
+
+		Object result = expression.getValue(ctx, Object.class);
+		return (T) result;
+	}
+}


### PR DESCRIPTION
This is a downport of the fix for vulnerability CVE-2022-22980 to branch 3.2.x.

The patch is identical to the fix provided for 3.3.x and later versions, the respective commit [7c5ac76](https://github.com/spring-projects/spring-data-mongodb/commit/7c5ac764b343d45e5d0abbaba4e82395b471b4c4) has been cherry-picked.

It has been tested through the downported unit test included in the same commit.

Disclaimer and background:
- It is clear that the given version is EOL, i.e. the project may not release a new version containing the patch, and the project generally advises users to migrate to later, supported versions. However, this fix could be a temporary remedy for users struggling to perform this migration (whatever the reason).
- This fix is part of [Endor Labs](https://www.endorlabs.com/)' efforts to create minimal invasive, yet viable security fixes for older OSS versions, similar to the well-known and established approach followed by various Linux distributions.
- By sharing the patch with the project community, we also hope to receive input as to whether the proposal is viable. It is clear, however, that the time of open source maintainers is limited. Hence, we appreciate any feedback given, but also understand if you cannot find the time to comment on merge requests opened for EOL versions.
---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
