### PR TITLE
Fix basic update overriding values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.x-GH-4918-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.x-GH-4918-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -447,13 +447,11 @@ public class Update implements UpdateDefinition {
 		if (existingValue == null) {
 			keyValueMap = new Document();
 			this.modifierOps.put(operator, keyValueMap);
+		} else if (existingValue instanceof Document document) {
+			keyValueMap = document;
 		} else {
-			if (existingValue instanceof Document document) {
-				keyValueMap = document;
-			} else {
-				throw new InvalidDataAccessApiUsageException(
-						"Modifier Operations should be a LinkedHashMap but was " + existingValue.getClass());
-			}
+			throw new InvalidDataAccessApiUsageException(
+					"Modifier Operations should be a LinkedHashMap but was " + existingValue.getClass());
 		}
 
 		keyValueMap.put(key, value);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicUpdateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicUpdateUnitTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query;
+
+import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.bson.Document;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.data.mongodb.core.query.Update.Position;
+
+/**
+ * @author Christoph Strobl
+ */
+public class BasicUpdateUnitTests {
+
+	@ParameterizedTest // GH-4918
+	@MethodSource("args")
+	void updateOpsShouldNotOverrideExistingValues(String operator, Function<BasicUpdate, Update> updateFunction) {
+
+		Document source = Document.parse("{ '%s' : { 'key-1' : 'value-1' } }".formatted(operator));
+		Update update = updateFunction.apply(new BasicUpdate(source));
+
+		assertThat(update.getUpdateObject()).containsEntry("%s.key-1".formatted(operator), "value-1")
+				.containsKey("%s.key-2".formatted(operator));
+	}
+
+	static Stream<Arguments> args() {
+		return Stream.of( //
+				Arguments.of("$set", (Function<BasicUpdate, Update>) update -> update.set("key-2", "value-2")),
+				Arguments.of("$inc", (Function<BasicUpdate, Update>) update -> update.inc("key-2", 1)),
+				Arguments.of("$push", (Function<BasicUpdate, Update>) update -> update.push("key-2", "value-2")),
+				Arguments.of("$addToSet", (Function<BasicUpdate, Update>) update -> update.addToSet("key-2", "value-2")),
+				Arguments.of("$pop", (Function<BasicUpdate, Update>) update -> update.pop("key-2", Position.FIRST)),
+				Arguments.of("$pull", (Function<BasicUpdate, Update>) update -> update.pull("key-2", "value-2")),
+				Arguments.of("$rename", (Function<BasicUpdate, Update>) update -> update.rename("key-2", "value-2")));
+	};
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicUpdateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/BasicUpdateUnitTests.java
@@ -15,14 +15,17 @@
  */
 package org.springframework.data.mongodb.core.query;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.bson.Document;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.data.mongodb.core.query.Update.Position;
 
@@ -31,8 +34,43 @@ import org.springframework.data.mongodb.core.query.Update.Position;
  */
 public class BasicUpdateUnitTests {
 
+	@Test // GH-4918
+	void setOperationValueShouldAppendsOpsCorrectly() {
+
+		BasicUpdate basicUpdate = new BasicUpdate("{}");
+		basicUpdate.setOperationValue("$set", "key1", "alt");
+		basicUpdate.setOperationValue("$set", "key2", "nps");
+		basicUpdate.setOperationValue("$unset", "key3", "x");
+
+		assertThat(basicUpdate.getUpdateObject())
+				.isEqualTo("{ '$set' : { 'key1' : 'alt', 'key2' : 'nps' }, '$unset' : { 'key3' : 'x' } }");
+	}
+
+	@Test // GH-4918
+	void setOperationErrorsOnNonMapType() {
+
+		BasicUpdate basicUpdate = new BasicUpdate("{ '$set' : 1 }");
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> basicUpdate.setOperationValue("$set", "k", "v"));
+	}
+
 	@ParameterizedTest // GH-4918
-	@MethodSource("args")
+	@CsvSource({ //
+			"{ }, k1, false", //
+			"{ '$set' : { 'k1' : 'v1' } }, k1, true", //
+			"{ '$set' : { 'k1' : 'v1' } }, k2, false", //
+			"{ '$set' : { 'k1.k2' : 'v1' } }, k1, false", //
+			"{ '$set' : { 'k1.k2' : 'v1' } }, k1.k2, true", //
+			"{ '$set' : { 'k1' : 'v1' } }, '', false", //
+			"{ '$inc' : { 'k1' : 1 } }, k1, true" })
+	void modifiesLooksUpKeyCorrectly(String source, String key, boolean modified) {
+
+		BasicUpdate basicUpdate = new BasicUpdate(source);
+		assertThat(basicUpdate.modifies(key)).isEqualTo(modified);
+	}
+
+	@ParameterizedTest // GH-4918
+	@MethodSource("updateOpArgs")
 	void updateOpsShouldNotOverrideExistingValues(String operator, Function<BasicUpdate, Update> updateFunction) {
 
 		Document source = Document.parse("{ '%s' : { 'key-1' : 'value-1' } }".formatted(operator));
@@ -42,14 +80,18 @@ public class BasicUpdateUnitTests {
 				.containsKey("%s.key-2".formatted(operator));
 	}
 
-	static Stream<Arguments> args() {
+	static Stream<Arguments> updateOpArgs() {
+
 		return Stream.of( //
 				Arguments.of("$set", (Function<BasicUpdate, Update>) update -> update.set("key-2", "value-2")),
+				Arguments.of("$unset", (Function<BasicUpdate, Update>) update -> update.unset("key-2")),
 				Arguments.of("$inc", (Function<BasicUpdate, Update>) update -> update.inc("key-2", 1)),
 				Arguments.of("$push", (Function<BasicUpdate, Update>) update -> update.push("key-2", "value-2")),
 				Arguments.of("$addToSet", (Function<BasicUpdate, Update>) update -> update.addToSet("key-2", "value-2")),
 				Arguments.of("$pop", (Function<BasicUpdate, Update>) update -> update.pop("key-2", Position.FIRST)),
 				Arguments.of("$pull", (Function<BasicUpdate, Update>) update -> update.pull("key-2", "value-2")),
+				Arguments.of("$pullAll",
+						(Function<BasicUpdate, Update>) update -> update.pullAll("key-2", new String[] { "value-2" })),
 				Arguments.of("$rename", (Function<BasicUpdate, Update>) update -> update.rename("key-2", "value-2")));
 	};
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/VersionedPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/VersionedPersonRepositoryIntegrationTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.test.util.Client;
+import org.springframework.data.mongodb.test.util.MongoClientExtension;
+import org.springframework.data.mongodb.test.util.MongoTestUtils;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.mongodb.client.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ * @since 2025/03
+ */
+@ExtendWith({ MongoClientExtension.class, SpringExtension.class })
+@ContextConfiguration
+public class VersionedPersonRepositoryIntegrationTests {
+
+	static @Client MongoClient mongoClient;
+
+	@Autowired VersionedPersonRepository versionedPersonRepository;
+	@Autowired MongoTemplate template;
+
+	@Configuration
+	@EnableMongoRepositories(considerNestedRepositories = true,
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = VersionedPersonRepository.class))
+	static class Config extends AbstractMongoClientConfiguration {
+
+		@Override
+		protected String getDatabaseName() {
+			return "versioned-person-tests";
+		}
+
+		@Override
+		public MongoClient mongoClient() {
+			return mongoClient;
+		}
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		MongoTestUtils.flushCollection("versioned-person-tests", template.getCollectionName(VersionedPersonWithCounter.class),
+				mongoClient);
+	}
+
+	@Test // GH-4918
+	void updatesVersionedTypeCorrectly() {
+
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+
+		int updateCount = versionedPersonRepository.findAndSetFirstnameToLastnameByLastname(person.getLastname());
+
+		assertThat(updateCount).isOne();
+
+		Document document = template.execute(VersionedPersonWithCounter.class, collection -> {
+			return collection.find(new Document("_id", new ObjectId(person.getId()))).first();
+		});
+
+		assertThat(document).containsEntry("firstname", "Duckling").containsEntry("version", 1L);
+	}
+
+	@Test // GH-4918
+	void updatesVersionedTypeCorrectlyWhenUpdateIsUsingInc() {
+
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+
+		int updateCount = versionedPersonRepository.findAndIncCounterByLastname(person.getLastname());
+
+		assertThat(updateCount).isOne();
+
+		Document document = template.execute(VersionedPersonWithCounter.class, collection -> {
+			return collection.find(new Document("_id", new ObjectId(person.getId()))).first();
+		});
+
+		assertThat(document).containsEntry("lastname", "Duckling").containsEntry("version", 1L).containsEntry("counter", 42);
+	}
+
+	@Test // GH-4918
+	void updatesVersionedTypeCorrectlyWhenUpdateCoversVersionBump() {
+
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+
+		int updateCount = versionedPersonRepository.findAndSetFirstnameToLastnameIncVersionByLastname(person.getLastname(),
+				10);
+
+		assertThat(updateCount).isOne();
+
+		Document document = template.execute(VersionedPersonWithCounter.class, collection -> {
+			return collection.find(new Document("_id", new ObjectId(person.getId()))).first();
+		});
+
+		assertThat(document).containsEntry("firstname", "Duckling").containsEntry("version", 10L);
+	}
+
+	public interface VersionedPersonRepository extends CrudRepository<VersionedPersonWithCounter, String> {
+
+		@Update("{ '$set': { 'firstname' : ?0 } }")
+		int findAndSetFirstnameToLastnameByLastname(String lastname);
+
+		@Update("{ '$inc': { 'counter' : 42 } }")
+		int findAndIncCounterByLastname(String lastname);
+
+		@Update("""
+				{
+					'$set': { 'firstname' : ?0 },
+					'$inc': { 'version' : ?1 }
+				}""")
+		int findAndSetFirstnameToLastnameIncVersionByLastname(String lastname, int incVersion);
+
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document("versioned-person")
+	static class VersionedPersonWithCounter extends VersionedPerson {
+
+		int counter;
+
+		public VersionedPersonWithCounter(String firstname, @Nullable String lastname) {
+			super(firstname, lastname);
+		}
+
+		public int getCounter() {
+			return counter;
+		}
+
+		public void setCounter(int counter) {
+			this.counter = counter;
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/VersionedPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/VersionedPersonRepositoryIntegrationTests.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.data.mongodb.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
@@ -40,12 +41,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.mongodb.client.MongoClient;
 
 /**
+ * Integration tests for Repositories using optimistic locking.
+ *
  * @author Christoph Strobl
- * @since 2025/03
  */
 @ExtendWith({ MongoClientExtension.class, SpringExtension.class })
 @ContextConfiguration
-public class VersionedPersonRepositoryIntegrationTests {
+class VersionedPersonRepositoryIntegrationTests {
 
 	static @Client MongoClient mongoClient;
 
@@ -70,14 +72,15 @@ public class VersionedPersonRepositoryIntegrationTests {
 
 	@BeforeEach
 	void beforeEach() {
-		MongoTestUtils.flushCollection("versioned-person-tests", template.getCollectionName(VersionedPersonWithCounter.class),
-				mongoClient);
+		MongoTestUtils.flushCollection("versioned-person-tests",
+				template.getCollectionName(VersionedPersonWithCounter.class), mongoClient);
 	}
 
 	@Test // GH-4918
 	void updatesVersionedTypeCorrectly() {
 
-		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class)
+				.one(new VersionedPersonWithCounter("Donald", "Duckling"));
 
 		int updateCount = versionedPersonRepository.findAndSetFirstnameToLastnameByLastname(person.getLastname());
 
@@ -93,7 +96,8 @@ public class VersionedPersonRepositoryIntegrationTests {
 	@Test // GH-4918
 	void updatesVersionedTypeCorrectlyWhenUpdateIsUsingInc() {
 
-		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class)
+				.one(new VersionedPersonWithCounter("Donald", "Duckling"));
 
 		int updateCount = versionedPersonRepository.findAndIncCounterByLastname(person.getLastname());
 
@@ -103,13 +107,15 @@ public class VersionedPersonRepositoryIntegrationTests {
 			return collection.find(new Document("_id", new ObjectId(person.getId()))).first();
 		});
 
-		assertThat(document).containsEntry("lastname", "Duckling").containsEntry("version", 1L).containsEntry("counter", 42);
+		assertThat(document).containsEntry("lastname", "Duckling").containsEntry("version", 1L).containsEntry("counter",
+				42);
 	}
 
 	@Test // GH-4918
 	void updatesVersionedTypeCorrectlyWhenUpdateCoversVersionBump() {
 
-		VersionedPerson person = template.insert(VersionedPersonWithCounter.class).one(new VersionedPersonWithCounter("Donald", "Duckling"));
+		VersionedPerson person = template.insert(VersionedPersonWithCounter.class)
+				.one(new VersionedPersonWithCounter("Donald", "Duckling"));
 
 		int updateCount = versionedPersonRepository.findAndSetFirstnameToLastnameIncVersionByLastname(person.getLastname(),
 				10);
@@ -123,7 +129,7 @@ public class VersionedPersonRepositoryIntegrationTests {
 		assertThat(document).containsEntry("firstname", "Duckling").containsEntry("version", 10L);
 	}
 
-	public interface VersionedPersonRepository extends CrudRepository<VersionedPersonWithCounter, String> {
+	interface VersionedPersonRepository extends CrudRepository<VersionedPersonWithCounter, String> {
 
 		@Update("{ '$set': { 'firstname' : ?0 } }")
 		int findAndSetFirstnameToLastnameByLastname(String lastname);
@@ -156,5 +162,7 @@ public class VersionedPersonRepositoryIntegrationTests {
 		public void setCounter(int counter) {
 			this.counter = counter;
 		}
+
 	}
+
 }


### PR DESCRIPTION
This change makes sure `BasicUpdate` appends values to operations instead of overriding them. This change aligns the behaviour with `Update` and fixes issues where using the `@Update` annotation with versioned entities can lead to loss of update information.

Closes: #4918 