### PR TITLE
GH-4139 add support for $sortArray direction sort

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ArrayOperators.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.bson.Document;
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.aggregation.ArrayOperators.Filter.AsBuilder;
 import org.springframework.data.mongodb.core.aggregation.ArrayOperators.Reduce.PropertyExpression;
 import org.springframework.data.mongodb.core.aggregation.ExposedFields.ExposedField;
@@ -334,6 +335,22 @@ public class ArrayOperators {
 			}
 
 			return (usesExpression() ? SortArray.sortArrayOf(expression) : SortArray.sortArray(values)).by(sort);
+		}
+
+		/**
+		 * Creates new {@link AggregationExpression} that takes the associated array and sorts it by the given {@link Sort
+		 * order}.
+		 *
+		 * @return new instance of {@link SortArray}.
+		 * @since 4.0
+		 */
+		public SortArray sort(Direction direction) {
+
+			if (usesFieldRef()) {
+				return SortArray.sortArrayOf(fieldReference).by(direction);
+			}
+
+			return (usesExpression() ? SortArray.sortArrayOf(expression) : SortArray.sortArray(values)).by(direction);
 		}
 
 		/**
@@ -2057,6 +2074,16 @@ public class ArrayOperators {
 		 */
 		public SortArray by(Sort sort) {
 			return new SortArray(append("sortBy", sort));
+		}
+
+		/**
+		 * Set the order to put elements in.
+		 *
+		 * @param direction must not be {@literal null}.
+		 * @return new instance of {@link SortArray}.
+		 */
+		public SortArray by(Direction direction) {
+			return new SortArray(append("sortBy", direction.isAscending() ? 1 : -1));
 		}
 
 		/*

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ArrayOperatorsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ArrayOperatorsUnitTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.aggregation.ArrayOperators.ArrayToObject;
 
 /**
@@ -178,5 +179,12 @@ public class ArrayOperatorsUnitTests {
 
 		assertThat(ArrayOperators.arrayOf("team").sort(Sort.by("name")).toDocument(Aggregation.DEFAULT_CONTEXT))
 				.isEqualTo("{ $sortArray: { input: \"$team\", sortBy: { name: 1 } } }");
+	}
+
+	@Test // GH-4929
+	void sortByWithDirection() {
+
+		assertThat(ArrayOperators.arrayOf(List.of("a", "b", "d", "c")).sort(Direction.DESC).toDocument(Aggregation.DEFAULT_CONTEXT))
+			.isEqualTo("{ $sortArray: { input: [\"a\", \"b\", \"d\", \"c\"], sortBy: -1 } }");
 	}
 }


### PR DESCRIPTION
for simple arrays of literals, there is no field to sort on, just have to provide direction.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
