### PR TITLE
Fix MongoId mapping for insertAll.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.0-GH-4944-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.0-GH-4944-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.0-GH-4944-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1433,7 +1433,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			maybeEmitEvent(new BeforeSaveEvent<>(initialized, document, collectionName));
 			initialized = maybeCallBeforeSave(initialized, document, collectionName);
 
-			documentList.add(document);
+			MappedDocument mappedDocument = queryOperations.createInsertContext(MappedDocument.of(document))
+				.prepareId(uninitialized.getClass());
+
+			documentList.add(mappedDocument.getDocument());
 			initializedBatchToSave.add(initialized);
 		}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -3108,6 +3109,18 @@ public class MongoTemplateTests {
 		assertThat(result).hasSize(2);
 		assertThat(walter.getId()).isNotNull();
 		assertThat(jesse.getId()).isNotNull();
+	}
+
+	@Test // GH-4944
+	public void insertAllShouldConvertIdToTargetTypeBeforeSave() {
+
+		RawStringId walter = new RawStringId();
+		walter.value = "walter";
+
+		RawStringId returned = template.insertAll(List.of(walter)).iterator().next();
+		org.bson.Document document = template.execute(RawStringId.class, collection -> collection.find().first());
+
+		assertThat(returned.id).isEqualTo(document.get("_id"));
 	}
 
 	@Test // DATAMONGO-1208


### PR DESCRIPTION
This PR fixes an issue where id properties annotated with `@MongoId` had not been converted into the desired target type when inserting a collection of objects instead a single one.

Closes: #4944