### PR TITLE
Add support for fluent `QueryResultConverter`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>4.5.0-SNAPSHOT</version>
+	<version>4.5.0-QRC-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.0-QRC-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>4.5.0-SNAPSHOT</version>
+		<version>4.5.0-QRC-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.2</version>
+			<version>${awaitility}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.bson.conversions.Bson;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
@@ -41,6 +42,7 @@ import com.mongodb.client.model.ValidationLevel;
  * @author Mark Paluch
  * @author Andreas Zink
  * @author Ben Foster
+ * @author Ross Lawley
  */
 public class CollectionOptions {
 
@@ -51,10 +53,11 @@ public class CollectionOptions {
 	private ValidationOptions validationOptions;
 	private @Nullable TimeSeriesOptions timeSeriesOptions;
 	private @Nullable CollectionChangeStreamOptions changeStreamOptions;
+	private @Nullable Bson encryptedFields;
 
 	private CollectionOptions(@Nullable Long size, @Nullable Long maxDocuments, @Nullable Boolean capped,
 			@Nullable Collation collation, ValidationOptions validationOptions, @Nullable TimeSeriesOptions timeSeriesOptions,
-			@Nullable CollectionChangeStreamOptions changeStreamOptions) {
+			@Nullable CollectionChangeStreamOptions changeStreamOptions,  @Nullable  Bson encryptedFields) {
 
 		this.maxDocuments = maxDocuments;
 		this.size = size;
@@ -63,6 +66,7 @@ public class CollectionOptions {
 		this.validationOptions = validationOptions;
 		this.timeSeriesOptions = timeSeriesOptions;
 		this.changeStreamOptions = changeStreamOptions;
+		this.encryptedFields = encryptedFields;
 	}
 
 	/**
@@ -76,7 +80,7 @@ public class CollectionOptions {
 
 		Assert.notNull(collation, "Collation must not be null");
 
-		return new CollectionOptions(null, null, null, collation, ValidationOptions.none(), null, null);
+		return new CollectionOptions(null, null, null, collation, ValidationOptions.none(), null, null, null);
 	}
 
 	/**
@@ -86,7 +90,7 @@ public class CollectionOptions {
 	 * @since 2.0
 	 */
 	public static CollectionOptions empty() {
-		return new CollectionOptions(null, null, null, null, ValidationOptions.none(), null, null);
+		return new CollectionOptions(null, null, null, null, ValidationOptions.none(), null, null, null);
 	}
 
 	/**
@@ -136,7 +140,7 @@ public class CollectionOptions {
 	 */
 	public CollectionOptions capped() {
 		return new CollectionOptions(size, maxDocuments, true, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -148,7 +152,7 @@ public class CollectionOptions {
 	 */
 	public CollectionOptions maxDocuments(long maxDocuments) {
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -160,7 +164,7 @@ public class CollectionOptions {
 	 */
 	public CollectionOptions size(long size) {
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -172,7 +176,7 @@ public class CollectionOptions {
 	 */
 	public CollectionOptions collation(@Nullable Collation collation) {
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -293,7 +297,7 @@ public class CollectionOptions {
 
 		Assert.notNull(validationOptions, "ValidationOptions must not be null");
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -307,7 +311,7 @@ public class CollectionOptions {
 
 		Assert.notNull(timeSeriesOptions, "TimeSeriesOptions must not be null");
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -321,7 +325,19 @@ public class CollectionOptions {
 
 		Assert.notNull(changeStreamOptions, "ChangeStreamOptions must not be null");
 		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
-				changeStreamOptions);
+				changeStreamOptions, encryptedFields);
+	}
+
+	/**
+	 * Create new {@link CollectionOptions} with the given {@code encryptedFields}.
+	 *
+	 * @param encryptedFields can be null
+	 * @return new instance of {@link CollectionOptions}.
+	 * @since 4.5.0
+	 */
+	public CollectionOptions encryptedFields(@Nullable Bson encryptedFields) {
+		return new CollectionOptions(size, maxDocuments, capped, collation, validationOptions, timeSeriesOptions,
+				changeStreamOptions, encryptedFields);
 	}
 
 	/**
@@ -392,12 +408,22 @@ public class CollectionOptions {
 		return Optional.ofNullable(changeStreamOptions);
 	}
 
+	/**
+	 * Get the {@code encryptedFields} if available.
+	 *
+	 * @return {@link Optional#empty()} if not specified.
+	 * @since 4.5.0
+	 */
+	public Optional<Bson> getEncryptedFields() {
+		return Optional.ofNullable(encryptedFields);
+	}
+
 	@Override
 	public String toString() {
 		return "CollectionOptions{" + "maxDocuments=" + maxDocuments + ", size=" + size + ", capped=" + capped
 				+ ", collation=" + collation + ", validationOptions=" + validationOptions + ", timeSeriesOptions="
-				+ timeSeriesOptions + ", changeStreamOptions=" + changeStreamOptions + ", disableValidation="
-				+ disableValidation() + ", strictValidation=" + strictValidation() + ", moderateValidation="
+				+ timeSeriesOptions + ", changeStreamOptions=" + changeStreamOptions + ", encryptedFields=" + encryptedFields
+				+ ", disableValidation=" + disableValidation() + ", strictValidation=" + strictValidation() + ", moderateValidation="
 				+ moderateValidation() + ", warnOnValidationError=" + warnOnValidationError() + ", failOnValidationError="
 				+ failOnValidationError() + '}';
 	}
@@ -431,7 +457,10 @@ public class CollectionOptions {
 		if (!ObjectUtils.nullSafeEquals(timeSeriesOptions, that.timeSeriesOptions)) {
 			return false;
 		}
-		return ObjectUtils.nullSafeEquals(changeStreamOptions, that.changeStreamOptions);
+		if (!ObjectUtils.nullSafeEquals(changeStreamOptions, that.changeStreamOptions)) {
+			return false;
+		}
+		return ObjectUtils.nullSafeEquals(encryptedFields, that.encryptedFields);
 	}
 
 	@Override
@@ -443,6 +472,7 @@ public class CollectionOptions {
 		result = 31 * result + ObjectUtils.nullSafeHashCode(validationOptions);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(timeSeriesOptions);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(changeStreamOptions);
+		result = 31 * result + ObjectUtils.nullSafeHashCode(encryptedFields);
 		return result;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/CollectionOptions.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.StreamSupport;
 
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
 import org.bson.BsonNull;
 import org.bson.Document;
-
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty;
@@ -778,7 +778,8 @@ public class CollectionOptions {
 					}
 				}
 
-				field.append("queries", property.getCharacteristics().map(QueryCharacteristic::toDocument).toList());
+				field.append("queries", StreamSupport.stream(property.getCharacteristics().spliterator(), false)
+						.map(QueryCharacteristic::toDocument).toList());
 
 				if (!field.containsKey("keyId")) {
 					field.append("keyId", BsonNull.VALUE);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EncryptionAlgorithms.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EncryptionAlgorithms.java
@@ -19,11 +19,13 @@ package org.springframework.data.mongodb.core;
  * Encryption algorithms supported by MongoDB Client Side Field Level Encryption.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 3.3
  */
 public final class EncryptionAlgorithms {
 
 	public static final String AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic";
 	public static final String AEAD_AES_256_CBC_HMAC_SHA_512_Random = "AEAD_AES_256_CBC_HMAC_SHA_512-Random";
+	public static final String RANGE = "Range";
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -39,6 +39,7 @@ import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
+import org.springframework.data.mongodb.core.CollectionOptions.EncryptedFieldsOptions;
 import org.springframework.data.mongodb.core.CollectionOptions.TimeSeriesOptions;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoJsonSchemaMapper;
@@ -379,7 +380,11 @@ class EntityOperations {
 		collectionOptions.getChangeStreamOptions().ifPresent(it -> result
 				.changeStreamPreAndPostImagesOptions(new ChangeStreamPreAndPostImagesOptions(it.getPreAndPostImages())));
 
-		collectionOptions.getEncryptedFields().ifPresent(result::encryptedFields);
+		collectionOptions.getEncryptedFieldsOptions().map(EncryptedFieldsOptions::toDocument).ifPresent(encryptedFields -> {
+			if (!encryptedFields.isEmpty()) {
+				result.encryptedFields(encryptedFields);
+			}
+		});
 		return result;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.bson.BsonNull;
 import org.bson.Document;
@@ -377,14 +378,16 @@ class EntityOperations {
 			result.timeSeriesOptions(options);
 		});
 
-		collectionOptions.getChangeStreamOptions().ifPresent(it -> result
-				.changeStreamPreAndPostImagesOptions(new ChangeStreamPreAndPostImagesOptions(it.getPreAndPostImages())));
+		collectionOptions.getChangeStreamOptions() //
+				.map(CollectionOptions.CollectionChangeStreamOptions::getPreAndPostImages) //
+				.map(ChangeStreamPreAndPostImagesOptions::new) //
+				.ifPresent(result::changeStreamPreAndPostImagesOptions);
 
-		collectionOptions.getEncryptedFieldsOptions().map(EncryptedFieldsOptions::toDocument).ifPresent(encryptedFields -> {
-			if (!encryptedFields.isEmpty()) {
-				result.encryptedFields(encryptedFields);
-			}
-		});
+		collectionOptions.getEncryptedFieldsOptions() //
+				.map(EncryptedFieldsOptions::toDocument) //
+				.filter(Predicate.not(Document::isEmpty)) //
+				.ifPresent(result::encryptedFields);
+
 		return result;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityOperations.java
@@ -83,6 +83,7 @@ import com.mongodb.client.model.ValidationOptions;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Ben Foster
+ * @author Ross Lawley
  * @since 2.1
  * @see MongoTemplate
  * @see ReactiveMongoTemplate
@@ -378,6 +379,7 @@ class EntityOperations {
 		collectionOptions.getChangeStreamOptions().ifPresent(it -> result
 				.changeStreamPreAndPostImagesOptions(new ChangeStreamPreAndPostImagesOptions(it.getPreAndPostImages())));
 
+		collectionOptions.getEncryptedFields().ifPresent(result::encryptedFields);
 		return result;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityResultConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/EntityResultConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.bson.Document;
+
+enum EntityResultConverter implements QueryResultConverter<Object, Object> {
+
+	INSTANCE;
+
+	@Override
+	public Object mapDocument(Document document, ConversionResultSupplier<Object> reader) {
+		return reader.get();
+	}
+
+	@Override
+	public <V> QueryResultConverter<Object, V> andThen(QueryResultConverter<? super Object, ? extends V> after) {
+		return (QueryResultConverter) after;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableAggregationOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableAggregationOperation.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.lang.Contract;
 
 /**
  * {@link ExecutableAggregationOperation} allows creation and execution of MongoDB aggregation operations in a fluent
@@ -45,7 +46,7 @@ public interface ExecutableAggregationOperation {
 	/**
 	 * Start creating an aggregation operation that returns results mapped to the given domain type. <br />
 	 * Use {@link org.springframework.data.mongodb.core.aggregation.TypedAggregation} to specify a potentially different
-	 * input type for he aggregation.
+	 * input type for the aggregation.
 	 *
 	 * @param domainType must not be {@literal null}.
 	 * @return new instance of {@link ExecutableAggregation}.
@@ -76,9 +77,22 @@ public interface ExecutableAggregationOperation {
 	 * Trigger execution by calling one of the terminating methods.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 2.0
 	 */
 	interface TerminatingAggregation<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link TerminatingAggregation}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingAggregation<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Apply pipeline operations as specified and get all matching elements.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ExecutableFindOperation.java
@@ -27,6 +27,7 @@ import org.springframework.data.geo.GeoResults;
 import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.lang.Contract;
 import org.springframework.lang.Nullable;
 
 import com.mongodb.client.MongoCollection;
@@ -71,9 +72,33 @@ public interface ExecutableFindOperation {
 	 * Trigger find execution by calling one of the terminating methods.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 2.0
 	 */
-	interface TerminatingFind<T> {
+	interface TerminatingFind<T> extends TerminatingResults<T>, TerminatingProjection {
+
+	}
+
+	/**
+	 * Trigger find execution by calling one of the terminating methods.
+	 *
+	 * @author Christoph Strobl
+	 * @author Mark Paluch
+	 * @since x.y
+	 */
+	interface TerminatingResults<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link TerminatingResults}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingResults<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Get exactly zero or one result.
@@ -142,6 +167,16 @@ public interface ExecutableFindOperation {
 		 */
 		Window<T> scroll(ScrollPosition scrollPosition);
 
+	}
+
+	/**
+	 * Trigger find execution by calling one of the terminating methods.
+	 *
+	 * @author Christoph Strobl
+	 * @since x.y
+	 */
+	interface TerminatingProjection {
+
 		/**
 		 * Get the number of matching elements. <br />
 		 * This method uses an
@@ -160,15 +195,29 @@ public interface ExecutableFindOperation {
 		 * @return {@literal true} if at least one matching element exists.
 		 */
 		boolean exists();
+
 	}
 
 	/**
-	 * Trigger geonear execution by calling one of the terminating methods.
+	 * Trigger {@code geoNear} execution by calling one of the terminating methods.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 2.0
 	 */
 	interface TerminatingFindNear<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link TerminatingFindNear}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingFindNear<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Find all matching elements and return them as {@link org.springframework.data.geo.GeoResult}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -1433,7 +1433,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			maybeEmitEvent(new BeforeSaveEvent<>(initialized, document, collectionName));
 			initialized = maybeCallBeforeSave(initialized, document, collectionName);
 
-			documentList.add(document);
+			MappedDocument mappedDocument = queryOperations.createInsertContext(MappedDocument.of(document))
+				.prepareId(uninitialized.getClass());
+
+			documentList.add(mappedDocument.getDocument());
 			initializedBatchToSave.add(initialized);
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryResultConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/QueryResultConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core;
+
+import org.bson.Document;
+
+/**
+ * Converter for MongoDB query results.
+ * <p>
+ * This is a functional interface that allows for mapping a {@link Document} to a result type.
+ * {@link #mapDocument(Document, ConversionResultSupplier) row mapping} can obtain upstream a
+ * {@link ConversionResultSupplier upstream converter} to enrich the final result object. This is useful when e.g.
+ * wrapping result objects where the wrapper needs to obtain information from the actual {@link Document}.
+ *
+ * @param <T> object type accepted by this converter.
+ * @param <R> the returned result type.
+ * @author Mark Paluch
+ * @since x.x
+ */
+@FunctionalInterface
+public interface QueryResultConverter<T, R> {
+
+	/**
+	 * Returns a function that returns the materialized entity.
+	 *
+	 * @param <T> the type of the input and output entity to the function.
+	 * @return a function that returns the materialized entity.
+	 */
+	@SuppressWarnings("unchecked")
+	static <T> QueryResultConverter<T, T> entity() {
+		return (QueryResultConverter<T, T>) EntityResultConverter.INSTANCE;
+	}
+
+	/**
+	 * Map a {@link Document} that is read from the MongoDB query/aggregation operation to a query result.
+	 *
+	 * @param document the raw document from the MongoDB query/aggregation result.
+	 * @param reader reader object that supplies an upstream result from an earlier converter.
+	 * @return the mapped result.
+	 */
+	R mapDocument(Document document, ConversionResultSupplier<T> reader);
+
+	/**
+	 * Returns a composed function that first applies this function to its input, and then applies the {@code after}
+	 * function to the result. If evaluation of either function throws an exception, it is relayed to the caller of the
+	 * composed function.
+	 *
+	 * @param <V> the type of output of the {@code after} function, and of the composed function.
+	 * @param after the function to apply after this function is applied.
+	 * @return a composed function that first applies this function and then applies the {@code after} function.
+	 */
+	default <V> QueryResultConverter<T, V> andThen(QueryResultConverter<? super R, ? extends V> after) {
+		return (row, reader) -> after.mapDocument(row, () -> mapDocument(row, reader));
+	}
+
+	/**
+	 * A supplier that converts a {@link Document} into {@code T}. Allows for lazy reading of query results.
+	 *
+	 * @param <T> type of the returned result.
+	 */
+	interface ConversionResultSupplier<T> {
+
+		/**
+		 * Obtain the upstream conversion result.
+		 *
+		 * @return the upstream conversion result.
+		 */
+		T get();
+
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveAggregationOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveAggregationOperation.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import reactor.core.publisher.Flux;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.lang.Contract;
 
 /**
  * {@link ReactiveAggregationOperation} allows creation and execution of reactive MongoDB aggregation operations in a
@@ -44,7 +45,7 @@ public interface ReactiveAggregationOperation {
 	/**
 	 * Start creating an aggregation operation that returns results mapped to the given domain type. <br />
 	 * Use {@link org.springframework.data.mongodb.core.aggregation.TypedAggregation} to specify a potentially different
-	 * input type for he aggregation.
+	 * input type for the aggregation.
 	 *
 	 * @param domainType must not be {@literal null}.
 	 * @return new instance of {@link ReactiveAggregation}. Never {@literal null}.
@@ -72,6 +73,18 @@ public interface ReactiveAggregationOperation {
 	 * Trigger execution by calling one of the terminating methods.
 	 */
 	interface TerminatingAggregationOperation<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link ExecutableFindOperation.TerminatingFindNear}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingAggregationOperation<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Apply pipeline operations as specified and stream all matching elements. <br />

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveAggregationOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveAggregationOperationSupport.java
@@ -51,22 +51,25 @@ class ReactiveAggregationOperationSupport implements ReactiveAggregationOperatio
 
 		Assert.notNull(domainType, "DomainType must not be null");
 
-		return new ReactiveAggregationSupport<>(template, domainType, null, null);
+		return new ReactiveAggregationSupport<>(template, domainType, QueryResultConverter.entity(), null, null);
 	}
 
-	static class ReactiveAggregationSupport<T>
+	static class ReactiveAggregationSupport<S, T>
 			implements AggregationOperationWithAggregation<T>, ReactiveAggregation<T>, TerminatingAggregationOperation<T> {
 
 		private final ReactiveMongoTemplate template;
-		private final Class<T> domainType;
+		private final Class<S> domainType;
+		private final QueryResultConverter<? super S, ? extends T> resultConverter;
 		private final Aggregation aggregation;
 		private final String collection;
 
-		ReactiveAggregationSupport(ReactiveMongoTemplate template, Class<T> domainType, Aggregation aggregation,
+		ReactiveAggregationSupport(ReactiveMongoTemplate template, Class<S> domainType,
+				QueryResultConverter<? super S, ? extends T> resultConverter, Aggregation aggregation,
 				String collection) {
 
 			this.template = template;
 			this.domainType = domainType;
+			this.resultConverter = resultConverter;
 			this.aggregation = aggregation;
 			this.collection = collection;
 		}
@@ -76,7 +79,7 @@ class ReactiveAggregationOperationSupport implements ReactiveAggregationOperatio
 
 			Assert.hasText(collection, "Collection must not be null nor empty");
 
-			return new ReactiveAggregationSupport<>(template, domainType, aggregation, collection);
+			return new ReactiveAggregationSupport<>(template, domainType, resultConverter, aggregation, collection);
 		}
 
 		@Override
@@ -84,12 +87,21 @@ class ReactiveAggregationOperationSupport implements ReactiveAggregationOperatio
 
 			Assert.notNull(aggregation, "Aggregation must not be null");
 
-			return new ReactiveAggregationSupport<>(template, domainType, aggregation, collection);
+			return new ReactiveAggregationSupport<>(template, domainType, resultConverter, aggregation, collection);
+		}
+
+		@Override
+		public <R> TerminatingAggregationOperation<R> map(QueryResultConverter<? super T, ? extends R> converter) {
+
+			Assert.notNull(converter, "QueryResultConverter must not be null");
+
+			return new ReactiveAggregationSupport<>(template, domainType, resultConverter.andThen(converter), aggregation,
+					collection);
 		}
 
 		@Override
 		public Flux<T> all() {
-			return template.aggregate(aggregation, getCollectionName(aggregation), domainType);
+			return template.doAggregate(aggregation, getCollectionName(aggregation), domainType, domainType, resultConverter);
 		}
 
 		private String getCollectionName(Aggregation aggregation) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveFindOperation.java
@@ -25,6 +25,7 @@ import org.springframework.data.geo.GeoResult;
 import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.lang.Contract;
 
 /**
  * {@link ReactiveFindOperation} allows creation and execution of reactive MongoDB find operations in a fluent API
@@ -66,7 +67,28 @@ public interface ReactiveFindOperation {
 	/**
 	 * Compose find execution by calling one of the terminating methods.
 	 */
-	interface TerminatingFind<T> {
+	interface TerminatingFind<T> extends TerminatingResults<T>, TerminatingProjection {
+
+	}
+
+	/**
+	 * Compose find execution by calling one of the terminating methods.
+	 *
+	 * @since x.y
+	 */
+	interface TerminatingResults<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link TerminatingResults}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingResults<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Get exactly zero or one result.
@@ -120,6 +142,15 @@ public interface ReactiveFindOperation {
 		 */
 		Flux<T> tail();
 
+	}
+
+	/**
+	 * Compose find execution by calling one of the terminating methods.
+	 *
+	 * @since x.y
+	 */
+	interface TerminatingProjection {
+
 		/**
 		 * Get the number of matching elements. <br />
 		 * This method uses an
@@ -144,6 +175,18 @@ public interface ReactiveFindOperation {
 	 * Compose geonear execution by calling one of the terminating methods.
 	 */
 	interface TerminatingFindNear<T> {
+
+		/**
+		 * Map the query result to a different type using {@link QueryResultConverter}.
+		 *
+		 * @param <R> {@link Class type} of the result.
+		 * @param converter the converter, must not be {@literal null}.
+		 * @return new instance of {@link ExecutableFindOperation.TerminatingFindNear}.
+		 * @throws IllegalArgumentException if {@link QueryResultConverter converter} is {@literal null}.
+		 * @since x.y
+		 */
+		@Contract("_ -> new")
+		<R> TerminatingFindNear<R> map(QueryResultConverter<? super T, ? extends R> converter);
 
 		/**
 		 * Find all matching elements and return them as {@link org.springframework.data.geo.GeoResult}.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -1434,11 +1434,16 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 						entity.assertUpdateableIdIfNotSet();
 
 						T initialized = entity.initializeVersionProperty();
-						Document dbDoc = entity.toMappedDocument(writer).getDocument();
+						MappedDocument mapped = entity.toMappedDocument(writer);
 
-						maybeEmitEvent(new BeforeSaveEvent<>(initialized, dbDoc, collectionName));
+						maybeEmitEvent(new BeforeSaveEvent<>(initialized, mapped.getDocument(), collectionName));
+						return maybeCallBeforeSave(initialized, mapped.getDocument(), collectionName).map(toSave -> {
 
-						return maybeCallBeforeSave(initialized, dbDoc, collectionName).thenReturn(Tuples.of(entity, dbDoc));
+							MappedDocument mappedDocument = queryOperations.createInsertContext(mapped)
+									.prepareId(uninitialized.getClass());
+
+							return Tuples.of(entity, mappedDocument.getDocument());
+						});
 					});
 				}).collectList();
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConversionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConversionContext.java
@@ -28,29 +28,44 @@ import org.springframework.lang.Nullable;
  * {@link ValueConversionContext} that allows to delegate read/write to an underlying {@link MongoConverter}.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 3.4
  */
 public class MongoConversionContext implements ValueConversionContext<MongoPersistentProperty> {
 
 	private final PropertyValueProvider<MongoPersistentProperty> accessor; // TODO: generics
-	private final @Nullable MongoPersistentProperty persistentProperty;
 	private final MongoConverter mongoConverter;
 
+	@Nullable private final MongoPersistentProperty persistentProperty;
 	@Nullable private final SpELContext spELContext;
+	@Nullable private final String fieldNameAndQueryOperator;
 
 	public MongoConversionContext(PropertyValueProvider<MongoPersistentProperty> accessor,
 			@Nullable MongoPersistentProperty persistentProperty, MongoConverter mongoConverter) {
-		this(accessor, persistentProperty, mongoConverter, null);
+		this(accessor, persistentProperty, mongoConverter, null, null);
 	}
 
 	public MongoConversionContext(PropertyValueProvider<MongoPersistentProperty> accessor,
 			@Nullable MongoPersistentProperty persistentProperty, MongoConverter mongoConverter,
 			@Nullable SpELContext spELContext) {
+		this(accessor, persistentProperty, mongoConverter, spELContext, null);
+	}
+
+	public MongoConversionContext(PropertyValueProvider<MongoPersistentProperty> accessor,
+			@Nullable MongoPersistentProperty persistentProperty, MongoConverter mongoConverter,
+			@Nullable String fieldNameAndQueryOperator) {
+		this(accessor, persistentProperty, mongoConverter, null, fieldNameAndQueryOperator);
+	}
+
+	public MongoConversionContext(PropertyValueProvider<MongoPersistentProperty> accessor,
+			@Nullable MongoPersistentProperty persistentProperty, MongoConverter mongoConverter,
+			@Nullable SpELContext spELContext, @Nullable String fieldNameAndQueryOperator) {
 
 		this.accessor = accessor;
 		this.persistentProperty = persistentProperty;
 		this.mongoConverter = mongoConverter;
 		this.spELContext = spELContext;
+		this.fieldNameAndQueryOperator = fieldNameAndQueryOperator;
 	}
 
 	@Override
@@ -83,5 +98,10 @@ public class MongoConversionContext implements ValueConversionContext<MongoPersi
 	@Nullable
 	public SpELContext getSpELContext() {
 		return spELContext;
+	}
+
+	@Nullable
+	public String getFieldNameAndQueryOperator() {
+		return fieldNameAndQueryOperator;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConversionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoConversionContext.java
@@ -79,7 +79,6 @@ public class MongoConversionContext implements ValueConversionContext<MongoPersi
 	}
 
 	/**
-	 *
 	 * @param operatorContext
 	 * @return new instance of {@link MongoConversionContext}.
 	 * @since 4.5
@@ -119,42 +118,34 @@ public class MongoConversionContext implements ValueConversionContext<MongoPersi
 	/**
 	 * The {@link OperatorContext} provides access to the actual conversion intent like a write operation or a query
 	 * operator such as {@literal $gte}.
-	 * 
+	 *
 	 * @since 4.5
 	 */
 	public interface OperatorContext {
 
 		/**
 		 * The operator the conversion is used in.
+		 *
 		 * @return {@literal write} for simple write operations during save, or a query operator.
 		 */
-		String getOperator();
+		String operator();
 
 		/**
 		 * The context path the operator is used in.
+		 *
 		 * @return never {@literal null}.
 		 */
-		String getPath();
+		String path();
 
 		boolean isWriteOperation();
+
 	}
 
-	public static class WriteOperatorContext implements OperatorContext {
-
-		private final String path;
-
-		public WriteOperatorContext(String path) {
-			this.path = path;
-		}
+	record WriteOperatorContext(String path) implements OperatorContext {
 
 		@Override
-		public String getOperator() {
+		public String operator() {
 			return "write";
-		}
-
-		@Override
-		public String getPath() {
-			return path;
 		}
 
 		@Override
@@ -163,22 +154,11 @@ public class MongoConversionContext implements ValueConversionContext<MongoPersi
 		}
 	}
 
-	public static class QueryOperatorContext implements OperatorContext {
-
-		private final String operator;
-		private final String path;
+	record QueryOperatorContext(String operator, String path) implements OperatorContext {
 
 		public QueryOperatorContext(@Nullable String operator, String path) {
 			this.operator = operator != null ? operator : "$eq";
 			this.path = path;
-		}
-
-		public String getOperator() {
-			return operator;
-		}
-
-		public String getPath() {
-			return path;
 		}
 
 		@Override
@@ -186,4 +166,5 @@ public class MongoConversionContext implements ValueConversionContext<MongoPersi
 			return false;
 		}
 	}
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -711,7 +711,8 @@ public class QueryMapper {
 
 			return BsonUtils.mapValues(document, (key, val) -> {
 				if (isKeyword(key)) {
-					return convertValueWithConversionContext(documentField, val, val, valueConverter, conversionContext.forOperator(new QueryOperatorContext(key, conversionContext.getOperatorContext().getPath())));
+					return convertValueWithConversionContext(documentField, val, val, valueConverter, conversionContext
+							.forOperator(new QueryOperatorContext(key, conversionContext.getOperatorContext().path())));
 				}
 				return val;
 			});

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -24,10 +24,13 @@ import java.util.Map.Entry;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.PropertyValueConverter;
+import org.springframework.data.convert.ValueConversionContext;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.core.convert.MongoConversionContext.WriteOperatorContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.Query;
@@ -158,6 +161,13 @@ public class UpdateMapper extends QueryMapper {
 		}
 
 		return super.getMappedObjectForField(field, rawValue);
+	}
+
+	protected Object convertValueWithConversionContext(Field documentField, Object sourceValue, Object value,
+		PropertyValueConverter<Object, Object, ValueConversionContext<MongoPersistentProperty>> valueConverter,
+		MongoConversionContext conversionContext) {
+
+		return super.convertValueWithConversionContext(documentField, sourceValue, value, valueConverter, conversionContext.forOperator(new WriteOperatorContext(documentField.name)));
 	}
 
 	private Entry<String, Object> getMappedUpdateModifier(Field field, Object rawValue) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/encryption/ExplicitEncryptionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/encryption/ExplicitEncryptionContext.java
@@ -26,6 +26,7 @@ import org.springframework.lang.Nullable;
  * Default {@link EncryptionContext} implementation.
  * 
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  */
 class ExplicitEncryptionContext implements EncryptionContext {
@@ -65,5 +66,11 @@ class ExplicitEncryptionContext implements EncryptionContext {
 	@Override
 	public <T> T write(@Nullable Object value, TypeInformation<T> target) {
 		return conversionContext.write(value, target);
+	}
+
+	@Override
+	@Nullable
+	public String getFieldNameAndQueryOperator() {
+		return conversionContext.getFieldNameAndQueryOperator();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/encryption/ExplicitEncryptionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/encryption/ExplicitEncryptionContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.convert.encryption;
 
 import org.springframework.data.mongodb.core.convert.MongoConversionContext;
+import org.springframework.data.mongodb.core.convert.MongoConversionContext.OperatorContext;
 import org.springframework.data.mongodb.core.encryption.EncryptionContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.util.TypeInformation;
@@ -70,7 +71,7 @@ class ExplicitEncryptionContext implements EncryptionContext {
 
 	@Override
 	@Nullable
-	public String getFieldNameAndQueryOperator() {
-		return conversionContext.getFieldNameAndQueryOperator();
+	public OperatorContext getOperatorContext() {
+		return conversionContext.getOperatorContext();
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/Encryption.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/Encryption.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.data.mongodb.core.encryption;
 
+import org.bson.BsonDocument;
+
 /**
  * Component responsible for encrypting and decrypting values.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  */
 public interface Encryption<S, T> {
@@ -39,5 +42,17 @@ public interface Encryption<S, T> {
 	 * @return the decrypted value.
 	 */
 	S decrypt(T value);
+
+	/**
+	 * Encrypt the given expression.
+	 *
+	 * @param value must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return the encrypted expression.
+	 * @since 4.5.0
+	 */
+	default BsonDocument encryptExpression(BsonDocument value, EncryptionOptions options) {
+		throw new UnsupportedOperationException("Unsupported encryption method");
+	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/Encryption.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/Encryption.java
@@ -20,11 +20,13 @@ import org.bson.BsonDocument;
 /**
  * Component responsible for encrypting and decrypting values.
  *
+ * @param <P> plaintext type.
+ * @param <C> ciphertext type.
  * @author Christoph Strobl
  * @author Ross Lawley
  * @since 4.1
  */
-public interface Encryption<S, T> {
+public interface Encryption<P, C> {
 
 	/**
 	 * Encrypt the given value.
@@ -33,7 +35,7 @@ public interface Encryption<S, T> {
 	 * @param options must not be {@literal null}.
 	 * @return the encrypted value.
 	 */
-	T encrypt(S value, EncryptionOptions options);
+	C encrypt(P value, EncryptionOptions options);
 
 	/**
 	 * Decrypt the given value.
@@ -41,7 +43,7 @@ public interface Encryption<S, T> {
 	 * @param value must not be {@literal null}.
 	 * @return the decrypted value.
 	 */
-	S decrypt(T value);
+	P decrypt(C value);
 
 	/**
 	 * Encrypt the given expression.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionContext.java
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
  * Context to encapsulate encryption for a specific {@link MongoPersistentProperty}.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  */
 public interface EncryptionContext {
@@ -128,4 +129,13 @@ public interface EncryptionContext {
 
 	EvaluationContext getEvaluationContext(Object source);
 
+	/**
+	 * The field name and field query operator
+	 *
+	 * @return can be {@literal null}.
+	 */
+	@Nullable
+	default String getFieldNameAndQueryOperator() {
+		return null;
+	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionContext.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mongodb.core.encryption;
 
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mongodb.core.convert.MongoConversionContext.OperatorContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.EvaluationContext;
@@ -135,7 +136,7 @@ public interface EncryptionContext {
 	 * @return can be {@literal null}.
 	 */
 	@Nullable
-	default String getFieldNameAndQueryOperator() {
+	default OperatorContext getOperatorContext() {
 		return null;
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/EncryptionOptions.java
@@ -15,6 +15,15 @@
  */
 package org.springframework.data.mongodb.core.encryption;
 
+import java.util.Objects;
+import java.util.Optional;
+
+import com.mongodb.client.model.vault.RangeOptions;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
+import org.springframework.data.mongodb.util.BsonUtils;
+import org.springframework.data.util.Optionals;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -22,20 +31,27 @@ import org.springframework.util.ObjectUtils;
  * Options, like the {@link #algorithm()}, to apply when encrypting values.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  */
 public class EncryptionOptions {
 
 	private final String algorithm;
 	private final EncryptionKey key;
+	private final QueryableEncryptionOptions queryableEncryptionOptions;
 
 	public EncryptionOptions(String algorithm, EncryptionKey key) {
+		this(algorithm, key, QueryableEncryptionOptions.NONE);
+	}
 
+	public EncryptionOptions(String algorithm, EncryptionKey key, QueryableEncryptionOptions queryableEncryptionOptions) {
 		Assert.hasText(algorithm, "Algorithm must not be empty");
 		Assert.notNull(key, "EncryptionKey must not be empty");
+		Assert.notNull(key, "QueryableEncryptionOptions must not be empty");
 
 		this.key = key;
 		this.algorithm = algorithm;
+		this.queryableEncryptionOptions = queryableEncryptionOptions;
 	}
 
 	public EncryptionKey key() {
@@ -44,6 +60,10 @@ public class EncryptionOptions {
 
 	public String algorithm() {
 		return algorithm;
+	}
+
+	public QueryableEncryptionOptions queryableEncryptionOptions() {
+		return queryableEncryptionOptions;
 	}
 
 	@Override
@@ -61,7 +81,11 @@ public class EncryptionOptions {
 		if (!ObjectUtils.nullSafeEquals(algorithm, that.algorithm)) {
 			return false;
 		}
-		return ObjectUtils.nullSafeEquals(key, that.key);
+		if (!ObjectUtils.nullSafeEquals(key, that.key)) {
+			return false;
+		}
+
+		return ObjectUtils.nullSafeEquals(queryableEncryptionOptions, that.queryableEncryptionOptions);
 	}
 
 	@Override
@@ -69,11 +93,170 @@ public class EncryptionOptions {
 
 		int result = ObjectUtils.nullSafeHashCode(algorithm);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(key);
+		result = 31 * result + ObjectUtils.nullSafeHashCode(queryableEncryptionOptions);
 		return result;
 	}
 
 	@Override
 	public String toString() {
-		return "EncryptionOptions{" + "algorithm='" + algorithm + '\'' + ", key=" + key + '}';
+		return "EncryptionOptions{" + "algorithm='" + algorithm + '\'' + ", key=" + key + ", queryableEncryptionOptions='"
+				+ queryableEncryptionOptions + "'}";
+	}
+
+	/**
+	 * Options, like the {@link #getQueryType()}, to apply when encrypting queryable values.
+	 *
+	 * @author Ross Lawley
+	 */
+	public static class QueryableEncryptionOptions {
+
+		private static final QueryableEncryptionOptions NONE = new QueryableEncryptionOptions(null, null, null);
+
+		private final @Nullable String queryType;
+		private final @Nullable Long contentionFactor;
+		private final @Nullable Document rangeOptions;
+
+		private QueryableEncryptionOptions(@Nullable String queryType, @Nullable Long contentionFactor,
+				@Nullable Document rangeOptions) {
+			this.queryType = queryType;
+			this.contentionFactor = contentionFactor;
+			this.rangeOptions = rangeOptions;
+		}
+
+		/**
+		 * Create an empty {@link QueryableEncryptionOptions}.
+		 *
+		 * @return unmodifiable {@link QueryableEncryptionOptions} instance.
+		 */
+		public static QueryableEncryptionOptions none() {
+			return NONE;
+		}
+
+		/**
+		 * Define the {@code queryType} to be used for queryable document encryption.
+		 *
+		 * @param queryType can be {@literal null}.
+		 * @return new instance of {@link QueryableEncryptionOptions}.
+		 */
+		public QueryableEncryptionOptions queryType(@Nullable String queryType) {
+			return new QueryableEncryptionOptions(queryType, contentionFactor, rangeOptions);
+		}
+
+		/**
+		 * Define the {@code contentionFactor} to be used for queryable document encryption.
+		 *
+		 * @param contentionFactor can be {@literal null}.
+		 * @return new instance of {@link QueryableEncryptionOptions}.
+		 */
+		public QueryableEncryptionOptions contentionFactor(@Nullable Long contentionFactor) {
+			return new QueryableEncryptionOptions(queryType, contentionFactor, rangeOptions);
+		}
+
+		/**
+		 * Define the {@code rangeOptions} to be used for queryable document encryption.
+		 *
+		 * @param rangeOptions can be {@literal null}.
+		 * @return new instance of {@link QueryableEncryptionOptions}.
+		 */
+		public QueryableEncryptionOptions rangeOptions(@Nullable Document rangeOptions) {
+			return new QueryableEncryptionOptions(queryType, contentionFactor, rangeOptions);
+		}
+
+		/**
+		 * Get the {@code queryType} to apply.
+		 *
+		 * @return {@link Optional#empty()} if not set.
+		 */
+		public Optional<String> getQueryType() {
+			return Optional.ofNullable(queryType);
+		}
+
+		/**
+		 * Get the {@code contentionFactor} to apply.
+		 *
+		 * @return {@link Optional#empty()} if not set.
+		 */
+		public Optional<Long> getContentionFactor() {
+			return Optional.ofNullable(contentionFactor);
+		}
+
+		/**
+		 * Get the {@code rangeOptions} to apply.
+		 *
+		 * @return {@link Optional#empty()} if not set.
+		 */
+		public Optional<RangeOptions> getRangeOptions() {
+			if (rangeOptions == null) {
+				return Optional.empty();
+			}
+			RangeOptions encryptionRangeOptions = new RangeOptions();
+
+			if (rangeOptions.containsKey("min")) {
+				encryptionRangeOptions.min(BsonUtils.simpleToBsonValue(rangeOptions.get("min")));
+			}
+			if (rangeOptions.containsKey("max")) {
+				encryptionRangeOptions.max(BsonUtils.simpleToBsonValue(rangeOptions.get("max")));
+			}
+			if (rangeOptions.containsKey("trimFactor")) {
+				Object trimFactor = rangeOptions.get("trimFactor");
+				Assert.isInstanceOf(Integer.class, trimFactor, () -> String
+						.format("Expected to find a %s but it turned out to be %s.", Integer.class, trimFactor.getClass()));
+
+				encryptionRangeOptions.trimFactor((Integer) trimFactor);
+			}
+
+			if (rangeOptions.containsKey("sparsity")) {
+				Object sparsity = rangeOptions.get("sparsity");
+				Assert.isInstanceOf(Number.class, sparsity,
+						() -> String.format("Expected to find a %s but it turned out to be %s.", Long.class, sparsity.getClass()));
+				encryptionRangeOptions.sparsity(((Number) sparsity).longValue());
+			}
+
+			if (rangeOptions.containsKey("precision")) {
+				Object precision = rangeOptions.get("precision");
+				Assert.isInstanceOf(Number.class, precision, () -> String
+						.format("Expected to find a %s but it turned out to be %s.", Integer.class, precision.getClass()));
+				encryptionRangeOptions.precision(((Number) precision).intValue());
+			}
+			return Optional.of(encryptionRangeOptions);
+		}
+
+		/**
+		 * @return {@literal true} if no arguments set.
+		 */
+		boolean isEmpty() {
+			return !Optionals.isAnyPresent(getQueryType(), getContentionFactor(), getRangeOptions());
+		}
+
+		@Override
+		public String toString() {
+			return "QueryableEncryptionOptions{" + "queryType='" + queryType + '\'' + ", contentionFactor=" + contentionFactor
+					+ ", rangeOptions=" + rangeOptions + '}';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			QueryableEncryptionOptions that = (QueryableEncryptionOptions) o;
+
+			if (!ObjectUtils.nullSafeEquals(queryType, that.queryType)) {
+				return false;
+			}
+
+			if (!ObjectUtils.nullSafeEquals(contentionFactor, that.contentionFactor)) {
+				return false;
+			}
+			return ObjectUtils.nullSafeEquals(rangeOptions, that.rangeOptions);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(queryType, contentionFactor, rangeOptions);
+		}
 	}
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/MongoClientEncryption.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/MongoClientEncryption.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core.encryption;
 import java.util.function.Supplier;
 
 import org.bson.BsonBinary;
+import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.springframework.data.mongodb.core.encryption.EncryptionKey.Type;
 import org.springframework.util.Assert;
@@ -29,6 +30,7 @@ import com.mongodb.client.vault.ClientEncryption;
  * {@link ClientEncryption} based {@link Encryption} implementation.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  */
 public class MongoClientEncryption implements Encryption<BsonValue, BsonBinary> {
@@ -59,7 +61,19 @@ public class MongoClientEncryption implements Encryption<BsonValue, BsonBinary> 
 
 	@Override
 	public BsonBinary encrypt(BsonValue value, EncryptionOptions options) {
+		return getClientEncryption().encrypt(value, createEncryptOptions(options));
+	}
 
+	@Override
+	public BsonDocument encryptExpression(BsonDocument value, EncryptionOptions options) {
+		return getClientEncryption().encryptExpression(value, createEncryptOptions(options));
+	}
+
+	public ClientEncryption getClientEncryption() {
+		return source.get();
+	}
+
+	private EncryptOptions createEncryptOptions(EncryptionOptions options) {
 		EncryptOptions encryptOptions = new EncryptOptions(options.algorithm());
 
 		if (Type.ALT.equals(options.key().type())) {
@@ -68,11 +82,10 @@ public class MongoClientEncryption implements Encryption<BsonValue, BsonBinary> 
 			encryptOptions = encryptOptions.keyId((BsonBinary) options.key().value());
 		}
 
-		return getClientEncryption().encrypt(value, encryptOptions);
-	}
-
-	public ClientEncryption getClientEncryption() {
-		return source.get();
+		options.queryableEncryptionOptions().getQueryType().map(encryptOptions::queryType);
+		options.queryableEncryptionOptions().getContentionFactor().map(encryptOptions::contentionFactor);
+		options.queryableEncryptionOptions().getRangeOptions().map(encryptOptions::rangeOptions);
+		return encryptOptions;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/MongoClientEncryption.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/encryption/MongoClientEncryption.java
@@ -15,15 +15,21 @@
  */
 package org.springframework.data.mongodb.core.encryption;
 
+import static org.springframework.data.mongodb.util.MongoCompatibilityAdapter.rangeOptionsAdapter;
+
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.springframework.data.mongodb.core.encryption.EncryptionKey.Type;
+import org.springframework.data.mongodb.core.encryption.EncryptionOptions.QueryableEncryptionOptions;
+import org.springframework.data.mongodb.util.BsonUtils;
 import org.springframework.util.Assert;
 
 import com.mongodb.client.model.vault.EncryptOptions;
+import com.mongodb.client.model.vault.RangeOptions;
 import com.mongodb.client.vault.ClientEncryption;
 
 /**
@@ -74,6 +80,7 @@ public class MongoClientEncryption implements Encryption<BsonValue, BsonBinary> 
 	}
 
 	private EncryptOptions createEncryptOptions(EncryptionOptions options) {
+
 		EncryptOptions encryptOptions = new EncryptOptions(options.algorithm());
 
 		if (Type.ALT.equals(options.key().type())) {
@@ -82,10 +89,58 @@ public class MongoClientEncryption implements Encryption<BsonValue, BsonBinary> 
 			encryptOptions = encryptOptions.keyId((BsonBinary) options.key().value());
 		}
 
-		options.queryableEncryptionOptions().getQueryType().map(encryptOptions::queryType);
-		options.queryableEncryptionOptions().getContentionFactor().map(encryptOptions::contentionFactor);
-		options.queryableEncryptionOptions().getRangeOptions().map(encryptOptions::rangeOptions);
+		if (options.queryableEncryptionOptions() == null) {
+			return encryptOptions;
+		}
+
+		QueryableEncryptionOptions qeOptions = options.queryableEncryptionOptions();
+		if (qeOptions.getQueryType() != null) {
+			encryptOptions.queryType(qeOptions.getQueryType());
+		}
+		if (qeOptions.getContentionFactor() != null) {
+			encryptOptions.contentionFactor(qeOptions.getContentionFactor());
+		}
+		if (!qeOptions.getAttributes().isEmpty()) {
+			encryptOptions.rangeOptions(rangeOptions(qeOptions.getAttributes()));
+		}
 		return encryptOptions;
+	}
+
+	protected RangeOptions rangeOptions(Map<String, Object> attributes) {
+
+		RangeOptions encryptionRangeOptions = new RangeOptions();
+		if (attributes.isEmpty()) {
+			return encryptionRangeOptions;
+		}
+
+		if (attributes.containsKey("min")) {
+			encryptionRangeOptions.min(BsonUtils.simpleToBsonValue(attributes.get("min")));
+		}
+		if (attributes.containsKey("max")) {
+			encryptionRangeOptions.max(BsonUtils.simpleToBsonValue(attributes.get("max")));
+		}
+		if (attributes.containsKey("trimFactor")) {
+			Object trimFactor = attributes.get("trimFactor");
+			Assert.isInstanceOf(Integer.class, trimFactor, () -> String
+					.format("Expected to find a %s but it turned out to be %s.", Integer.class, trimFactor.getClass()));
+
+			rangeOptionsAdapter(encryptionRangeOptions).trimFactor((Integer) trimFactor);
+		}
+
+		if (attributes.containsKey("sparsity")) {
+			Object sparsity = attributes.get("sparsity");
+			Assert.isInstanceOf(Number.class, sparsity,
+					() -> String.format("Expected to find a %s but it turned out to be %s.", Long.class, sparsity.getClass()));
+			encryptionRangeOptions.sparsity(((Number) sparsity).longValue());
+		}
+
+		if (attributes.containsKey("precision")) {
+			Object precision = attributes.get("precision");
+			Assert.isInstanceOf(Number.class, precision, () -> String
+					.format("Expected to find a %s but it turned out to be %s.", Integer.class, precision.getClass()));
+			encryptionRangeOptions.precision(((Number) precision).intValue());
+		}
+		return encryptionRangeOptions;
 	}
 
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/ExplicitEncrypted.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/ExplicitEncrypted.java
@@ -47,6 +47,7 @@ import org.springframework.data.mongodb.core.convert.encryption.MongoEncryptionC
  * </pre>
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.1
  * @see ValueConverter
  */
@@ -60,7 +61,8 @@ public @interface ExplicitEncrypted {
 	 * Define the algorithm to use.
 	 * <p>
 	 * A {@literal Deterministic} algorithm ensures that a given input value always encrypts to the same output while a
-	 * {@literal randomized} one will produce different results every time.
+	 * {@literal randomized} one will produce different results every time.  A {@literal range} algorithm allows for
+	 * the value to be queried whilst encrypted.
 	 * <p>
 	 * Please make sure to use an algorithm that is in line with MongoDB's encryption rules for simple types, complex
 	 * objects and arrays as well as the query limitations that come with each of them.
@@ -85,10 +87,29 @@ public @interface ExplicitEncrypted {
 	String keyAltName() default "";
 
 	/**
+	 * Set the contention factor
+	 * <p>
+	 * Only required when using {@literal range} encryption.
+	 * @return the contention factor
+	 */
+	long contentionFactor() default -1;
+
+	/**
+	 * Set the {@literal range} options
+	 * <p>
+	 * Should be valid extended json representing the range options and including the following values:
+	 * {@code min}, {@code max}, {@code trimFactor} and {@code sparsity}.
+	 *
+	 * @return the json representation of range options
+	 */
+	String rangeOptions() default "";
+
+	/**
 	 * The {@link EncryptingConverter} type handling the {@literal en-/decryption} of the annotated property.
 	 *
 	 * @return the configured {@link EncryptingConverter}. A {@link MongoEncryptionConverter} by default.
 	 */
 	@AliasFor(annotation = ValueConverter.class, value = "value")
 	Class<? extends PropertyValueConverter> value() default MongoEncryptionConverter.class;
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/ExplicitEncrypted.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/ExplicitEncrypted.java
@@ -87,24 +87,6 @@ public @interface ExplicitEncrypted {
 	String keyAltName() default "";
 
 	/**
-	 * Set the contention factor
-	 * <p>
-	 * Only required when using {@literal range} encryption.
-	 * @return the contention factor
-	 */
-	long contentionFactor() default -1;
-
-	/**
-	 * Set the {@literal range} options
-	 * <p>
-	 * Should be valid extended json representing the range options and including the following values:
-	 * {@code min}, {@code max}, {@code trimFactor} and {@code sparsity}.
-	 *
-	 * @return the json representation of range options
-	 */
-	String rangeOptions() default "";
-
-	/**
 	 * The {@link EncryptingConverter} type handling the {@literal en-/decryption} of the annotated property.
 	 *
 	 * @return the configured {@link EncryptingConverter}. A {@link MongoEncryptionConverter} by default.

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Queryable.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Queryable.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Christoph Strobl
+ * @since 4.5
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+public @interface Queryable {
+
+	/**
+	 * @return empty {@link String} if not set.
+	 * @since 4.5
+	 */
+	String queryType() default "";
+
+	/**
+	 * @return empty {@link String} if not set.
+	 * @since 4.5
+	 */
+	String queryAttributes() default "";
+
+	/**
+	 * Set the contention factor
+	 *
+	 * @return the contention factor
+	 */
+	long contentionFactor() default -1;
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Queryable.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/Queryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025. the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,13 +30,11 @@ public @interface Queryable {
 
 	/**
 	 * @return empty {@link String} if not set.
-	 * @since 4.5
 	 */
 	String queryType() default "";
 
 	/**
 	 * @return empty {@link String} if not set.
-	 * @since 4.5
 	 */
 	String queryAttributes() default "";
 
@@ -46,4 +44,5 @@ public @interface Queryable {
 	 * @return the contention factor
 	 */
 	long contentionFactor() default -1;
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/RangeEncrypted.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/RangeEncrypted.java
@@ -34,7 +34,7 @@ import org.springframework.core.annotation.AliasFor;
 public @interface RangeEncrypted {
 
 	/**
-	 * Set the contention factor
+	 * Set the contention factor.
 	 *
 	 * @return the contention factor
 	 */
@@ -42,15 +42,16 @@ public @interface RangeEncrypted {
 	long contentionFactor() default -1;
 
 	/**
-	 * Set the {@literal range} options
+	 * Set the {@literal range} options.
 	 * <p>
-	 * Should be valid extended json representing the range options and including the following values: {@code min},
-	 * {@code max}, {@code trimFactor} and {@code sparsity}.
+	 * Should be valid extended {@link org.bson.Document#parse(String) JSON} representing the range options and including
+	 * the following values: {@code min}, {@code max}, {@code trimFactor} and {@code sparsity}.
 	 * <p>
 	 * Please note that values are data type sensitive and may require proper identification via eg. {@code $numberLong}.
 	 *
-	 * @return the json representation of range options
+	 * @return the {@link org.bson.Document#parse(String) JSON} representation of range options.
 	 */
 	@AliasFor(annotation = Queryable.class, value = "queryAttributes")
 	String rangeOptions() default "";
+
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/RangeEncrypted.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/RangeEncrypted.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * @author Christoph Strobl
+ * @author Ross Lawley
+ * @since 4.5
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Encrypted(algorithm = "Range")
+@Queryable(queryType = "range")
+public @interface RangeEncrypted {
+
+	/**
+	 * Set the contention factor
+	 *
+	 * @return the contention factor
+	 */
+	@AliasFor(annotation = Queryable.class, value = "contentionFactor")
+	long contentionFactor() default -1;
+
+	/**
+	 * Set the {@literal range} options
+	 * <p>
+	 * Should be valid extended json representing the range options and including the following values: {@code min},
+	 * {@code max}, {@code trimFactor} and {@code sparsity}.
+	 * <p>
+	 * Please note that values are data type sensitive and may require proper identification via eg. {@code $numberLong}.
+	 *
+	 * @return the json representation of range options
+	 */
+	@AliasFor(annotation = Queryable.class, value = "queryAttributes")
+	String rangeOptions() default "";
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/IdentifiableJsonSchemaProperty.java
@@ -1205,8 +1205,8 @@ public class IdentifiableJsonSchemaProperty<T extends JsonSchemaObject> implemen
 	}
 
 	/**
-	 * {@link JsonSchemaProperty} implementation typically wrapping {@link EncryptedJsonSchemaProperty encrypted
-	 * properties} to mark them as queryable.
+	 * {@link JsonSchemaProperty} implementation typically wrapping an {@link EncryptedJsonSchemaProperty encrypted
+	 * property} to mark it as queryable.
 	 *
 	 * @author Christoph Strobl
 	 * @since 4.5

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/JsonSchemaProperty.java
@@ -16,10 +16,22 @@
 package org.springframework.data.mongodb.core.schema;
 
 import java.util.Collection;
+import java.util.List;
 
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.ArrayJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.BooleanJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.DateJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.EncryptedJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.NullJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.NumericJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.ObjectJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.QueryableJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.RequiredJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.StringJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.TimestampJsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.UntypedJsonSchemaProperty;
 import org.springframework.data.mongodb.core.schema.TypedJsonSchemaObject.NumericJsonSchemaObject;
 import org.springframework.data.mongodb.core.schema.TypedJsonSchemaObject.ObjectJsonSchemaObject;
-import org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.*;
 import org.springframework.lang.Nullable;
 
 /**
@@ -67,6 +79,18 @@ public interface JsonSchemaProperty extends JsonSchemaObject {
 	 */
 	static EncryptedJsonSchemaProperty encrypted(JsonSchemaProperty property) {
 		return EncryptedJsonSchemaProperty.encrypted(property);
+	}
+
+	/**
+	 * Turns the given target property into a {@link QueryableJsonSchemaProperty queryable} one, eg. for {@literal range}
+	 * encrypted properties.
+	 * 
+	 * @param property the queryable property. Must not be {@literal null}.
+	 * @param queries predefined query characteristics.
+	 * @since 4.5
+	 */
+	static QueryableJsonSchemaProperty queryable(JsonSchemaProperty property, List<QueryCharacteristic> queries) {
+		return new QueryableJsonSchemaProperty(property, new QueryCharacteristics(queries));
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/MergedJsonSchema.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/MergedJsonSchema.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import org.bson.Document;
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristic.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristic.java
@@ -18,6 +18,9 @@ package org.springframework.data.mongodb.core.schema;
 import org.bson.Document;
 
 /**
+ * Defines the specific character of a query that can be executed. Mainly used to define the characteristic of queryable
+ * encrypted fields.
+ * 
  * @author Christoph Strobl
  * @since 4.5
  */
@@ -28,6 +31,9 @@ public interface QueryCharacteristic {
 	 */
 	String queryType();
 
+	/**
+	 * @return the raw {@link Document} representation of the instance.
+	 */
 	default Document toDocument() {
 		return new Document("queryType", queryType());
 	}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristic.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristic.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.schema;
+
+import org.bson.Document;
+
+/**
+ * @author Christoph Strobl
+ * @since 4.5
+ */
+public interface QueryCharacteristic {
+
+	/**
+	 * @return the query type, eg. {@literal range}.
+	 */
+	String queryType();
+
+	default Document toDocument() {
+		return new Document("queryType", queryType());
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
@@ -16,21 +16,25 @@
 package org.springframework.data.mongodb.core.schema;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import org.bson.BsonNull;
 import org.bson.Document;
+
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Range.Bound;
+import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 
 /**
  * @author Christoph Strobl
  * @since 4.5
  */
-public class QueryCharacteristics {
+public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
 
-	private static final QueryCharacteristics NONE = new QueryCharacteristics(List.of());
+	private static final QueryCharacteristics NONE = new QueryCharacteristics(Collections.emptyList());
 
 	private final List<QueryCharacteristic> characteristics;
 
@@ -46,12 +50,17 @@ public class QueryCharacteristics {
 		return new QueryCharacteristics(List.copyOf(characteristics));
 	}
 
-	QueryCharacteristics(QueryCharacteristic... characteristics) {
-		this.characteristics = Arrays.asList(characteristics);
+	public static QueryCharacteristics of(QueryCharacteristic... characteristics) {
+		return new QueryCharacteristics(Arrays.asList(characteristics));
 	}
 
 	public List<QueryCharacteristic> getCharacteristics() {
 		return characteristics;
+	}
+
+	@Override
+	public Iterator<QueryCharacteristic> iterator() {
+		return this.characteristics.iterator();
 	}
 
 	public static <T> RangeQuery<T> range() {
@@ -96,7 +105,8 @@ public class QueryCharacteristics {
 			this(Range.unbounded(), null, null, null);
 		}
 
-		public RangeQuery(Range<T> valueRange, Integer trimFactor, Long sparsity, Long contention) {
+		public RangeQuery(@Nullable Range<T> valueRange, @Nullable Integer trimFactor, @Nullable Long sparsity,
+				@Nullable Long contention) {
 			this.valueRange = valueRange;
 			this.trimFactor = trimFactor;
 			this.sparsity = sparsity;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
@@ -22,18 +22,22 @@ import java.util.List;
 
 import org.bson.BsonNull;
 import org.bson.Document;
-
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Range.Bound;
-import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 
 /**
+ * Encapsulation of individual {@link QueryCharacteristic query characteristics} used to define queries that can be
+ * executed when using queryable encryption.
+ *
  * @author Christoph Strobl
  * @since 4.5
  */
-public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
+public class QueryCharacteristics implements Iterable<QueryCharacteristic> {
 
+	/**
+	 * instance indicating none
+	 */
 	private static final QueryCharacteristics NONE = new QueryCharacteristics(Collections.emptyList());
 
 	private final List<QueryCharacteristic> characteristics;
@@ -42,18 +46,36 @@ public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
 		this.characteristics = characteristics;
 	}
 
+	/**
+	 * @return marker instance indicating no characteristics have been defined.
+	 */
 	public static QueryCharacteristics none() {
 		return NONE;
 	}
 
+	/**
+	 * Create new {@link QueryCharacteristics} from given list of {@link QueryCharacteristic characteristics}.
+	 *
+	 * @param characteristics must not be {@literal null}.
+	 * @return new instance of {@link QueryCharacteristics}.
+	 */
 	public static QueryCharacteristics of(List<QueryCharacteristic> characteristics) {
 		return new QueryCharacteristics(List.copyOf(characteristics));
 	}
 
+	/**
+	 * Create new {@link QueryCharacteristics} from given {@link QueryCharacteristic characteristics}.
+	 *
+	 * @param characteristics must not be {@literal null}.
+	 * @return new instance of {@link QueryCharacteristics}.
+	 */
 	public static QueryCharacteristics of(QueryCharacteristic... characteristics) {
 		return new QueryCharacteristics(Arrays.asList(characteristics));
 	}
 
+	/**
+	 * @return the list of {@link QueryCharacteristic characteristics}.
+	 */
 	public List<QueryCharacteristic> getCharacteristics() {
 		return characteristics;
 	}
@@ -63,22 +85,50 @@ public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
 		return this.characteristics.iterator();
 	}
 
+	/**
+	 * Create a new {@link RangeQuery range query characteristic} used to define range queries against an encrypted field.
+	 *
+	 * @param <T> targeted field type
+	 * @return new instance of {@link RangeQuery}.
+	 */
 	public static <T> RangeQuery<T> range() {
 		return new RangeQuery<>();
 	}
 
+	/**
+	 * Create a new {@link EqualityQuery equality query characteristic} used to define equality queries against an
+	 * encrypted field.
+	 *
+	 * @param <T> targeted field type
+	 * @return new instance of {@link EqualityQuery}.
+	 */
 	public static <T> EqualityQuery<T> equality() {
 		return new EqualityQuery<>(null);
 	}
 
+	/**
+	 * {@link QueryCharacteristic} for equality comparison.
+	 *
+	 * @param <T>
+	 * @since 4.5
+	 */
 	public static class EqualityQuery<T> implements QueryCharacteristic {
 
 		private final @Nullable Long contention;
 
+		/**
+		 * Create new instance of {@link EqualityQuery}.
+		 *
+		 * @param contention can be {@literal null}.
+		 */
 		public EqualityQuery(@Nullable Long contention) {
 			this.contention = contention;
 		}
 
+		/**
+		 * @param contention concurrent counter partition factor.
+		 * @return new instance of {@link EqualityQuery}.
+		 */
 		public EqualityQuery<T> contention(long contention) {
 			return new EqualityQuery<>(contention);
 		}
@@ -94,23 +144,93 @@ public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
 		}
 	}
 
+	/**
+	 * {@link QueryCharacteristic} for range comparison.
+	 *
+	 * @param <T>
+	 * @since 4.5
+	 */
 	public static class RangeQuery<T> implements QueryCharacteristic {
 
 		private final @Nullable Range<T> valueRange;
 		private final @Nullable Integer trimFactor;
 		private final @Nullable Long sparsity;
+		private final @Nullable Long precision;
 		private final @Nullable Long contention;
 
 		private RangeQuery() {
-			this(Range.unbounded(), null, null, null);
+			this(Range.unbounded(), null, null, null, null);
 		}
 
+		/**
+		 * Create new instance of {@link RangeQuery}.
+		 *
+		 * @param valueRange
+		 * @param trimFactor
+		 * @param sparsity
+		 * @param contention
+		 */
 		public RangeQuery(@Nullable Range<T> valueRange, @Nullable Integer trimFactor, @Nullable Long sparsity,
-				@Nullable Long contention) {
+				@Nullable Long precision, @Nullable Long contention) {
 			this.valueRange = valueRange;
 			this.trimFactor = trimFactor;
 			this.sparsity = sparsity;
+			this.precision = precision;
 			this.contention = contention;
+		}
+
+		/**
+		 * @param lower the lower value range boundary for the queryable field.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> min(T lower) {
+
+			Range<T> range = Range.of(Bound.inclusive(lower),
+					valueRange != null ? valueRange.getUpperBound() : Bound.unbounded());
+			return new RangeQuery<>(range, trimFactor, sparsity, precision, contention);
+		}
+
+		/**
+		 * @param upper the upper value range boundary for the queryable field.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> max(T upper) {
+
+			Range<T> range = Range.of(valueRange != null ? valueRange.getLowerBound() : Bound.unbounded(),
+					Bound.inclusive(upper));
+			return new RangeQuery<>(range, trimFactor, sparsity, precision, contention);
+		}
+
+		/**
+		 * @param trimFactor value to control the throughput of concurrent inserts and updates.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> trimFactor(int trimFactor) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, precision, contention);
+		}
+
+		/**
+		 * @param sparsity value to control the value density within the index.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> sparsity(long sparsity) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, precision, contention);
+		}
+
+		/**
+		 * @param contention concurrent counter partition factor.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> contention(long contention) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, precision, contention);
+		}
+
+		/**
+		 * @param precision digits considered comparing floating point numbers.
+		 * @return new instance of {@link RangeQuery}.
+		 */
+		public RangeQuery<T> precision(long precision) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, precision, contention);
 		}
 
 		@Override
@@ -118,40 +238,26 @@ public class QueryCharacteristics implements Streamable<QueryCharacteristic> {
 			return "range";
 		}
 
-		public RangeQuery<T> min(T lower) {
-
-			Range<T> range = Range.of(Bound.inclusive(lower),
-					valueRange != null ? valueRange.getUpperBound() : Bound.unbounded());
-			return new RangeQuery<>(range, trimFactor, sparsity, contention);
-		}
-
-		public RangeQuery<T> max(T upper) {
-
-			Range<T> range = Range.of(valueRange != null ? valueRange.getLowerBound() : Bound.unbounded(),
-					Bound.inclusive(upper));
-			return new RangeQuery<>(range, trimFactor, sparsity, contention);
-		}
-
-		public RangeQuery<T> trimFactor(int trimFactor) {
-			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
-		}
-
-		public RangeQuery<T> sparsity(long sparsity) {
-			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
-		}
-
-		public RangeQuery<T> contention(long contention) {
-			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
-		}
-
 		@Override
 		@SuppressWarnings("unchecked")
 		public Document toDocument() {
 
-			return QueryCharacteristic.super.toDocument().append("contention", contention).append("trimFactor", trimFactor)
-					.append("sparsity", sparsity).append("min", valueRange.getLowerBound().getValue().orElse((T) BsonNull.VALUE))
-					.append("max", valueRange.getUpperBound().getValue().orElse((T) BsonNull.VALUE));
+			Document target = QueryCharacteristic.super.toDocument();
+			if (contention != null) {
+				target.append("contention", contention);
+			}
+			if (trimFactor != null) {
+				target.append("trimFactor", trimFactor);
+			}
+			if (valueRange != null) {
+				target.append("min", valueRange.getLowerBound().getValue().orElse((T) BsonNull.VALUE)).append("max",
+						valueRange.getUpperBound().getValue().orElse((T) BsonNull.VALUE));
+			}
+			if (sparsity != null) {
+				target.append("sparsity", sparsity);
+			}
+
+			return target;
 		}
 	}
-
 }

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/schema/QueryCharacteristics.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.schema;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bson.BsonNull;
+import org.bson.Document;
+import org.springframework.data.domain.Range;
+import org.springframework.data.domain.Range.Bound;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Christoph Strobl
+ * @since 4.5
+ */
+public class QueryCharacteristics {
+
+	private static final QueryCharacteristics NONE = new QueryCharacteristics(List.of());
+
+	private final List<QueryCharacteristic> characteristics;
+
+	QueryCharacteristics(List<QueryCharacteristic> characteristics) {
+		this.characteristics = characteristics;
+	}
+
+	public static QueryCharacteristics none() {
+		return NONE;
+	}
+
+	public static QueryCharacteristics of(List<QueryCharacteristic> characteristics) {
+		return new QueryCharacteristics(List.copyOf(characteristics));
+	}
+
+	QueryCharacteristics(QueryCharacteristic... characteristics) {
+		this.characteristics = Arrays.asList(characteristics);
+	}
+
+	public List<QueryCharacteristic> getCharacteristics() {
+		return characteristics;
+	}
+
+	public static <T> RangeQuery<T> range() {
+		return new RangeQuery<>();
+	}
+
+	public static <T> EqualityQuery<T> equality() {
+		return new EqualityQuery<>(null);
+	}
+
+	public static class EqualityQuery<T> implements QueryCharacteristic {
+
+		private final @Nullable Long contention;
+
+		public EqualityQuery(@Nullable Long contention) {
+			this.contention = contention;
+		}
+
+		public EqualityQuery<T> contention(long contention) {
+			return new EqualityQuery<>(contention);
+		}
+
+		@Override
+		public String queryType() {
+			return "equality";
+		}
+
+		@Override
+		public Document toDocument() {
+			return QueryCharacteristic.super.toDocument().append("contention", contention);
+		}
+	}
+
+	public static class RangeQuery<T> implements QueryCharacteristic {
+
+		private final @Nullable Range<T> valueRange;
+		private final @Nullable Integer trimFactor;
+		private final @Nullable Long sparsity;
+		private final @Nullable Long contention;
+
+		private RangeQuery() {
+			this(Range.unbounded(), null, null, null);
+		}
+
+		public RangeQuery(Range<T> valueRange, Integer trimFactor, Long sparsity, Long contention) {
+			this.valueRange = valueRange;
+			this.trimFactor = trimFactor;
+			this.sparsity = sparsity;
+			this.contention = contention;
+		}
+
+		@Override
+		public String queryType() {
+			return "range";
+		}
+
+		public RangeQuery<T> min(T lower) {
+
+			Range<T> range = Range.of(Bound.inclusive(lower),
+					valueRange != null ? valueRange.getUpperBound() : Bound.unbounded());
+			return new RangeQuery<>(range, trimFactor, sparsity, contention);
+		}
+
+		public RangeQuery<T> max(T upper) {
+
+			Range<T> range = Range.of(valueRange != null ? valueRange.getLowerBound() : Bound.unbounded(),
+					Bound.inclusive(upper));
+			return new RangeQuery<>(range, trimFactor, sparsity, contention);
+		}
+
+		public RangeQuery<T> trimFactor(int trimFactor) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
+		}
+
+		public RangeQuery<T> sparsity(long sparsity) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
+		}
+
+		public RangeQuery<T> contention(long contention) {
+			return new RangeQuery<>(valueRange, trimFactor, sparsity, contention);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Document toDocument() {
+
+			return QueryCharacteristic.super.toDocument().append("contention", contention).append("trimFactor", trimFactor)
+					.append("sparsity", sparsity).append("min", valueRange.getLowerBound().getValue().orElse((T) BsonNull.VALUE))
+					.append("max", valueRange.getUpperBound().getValue().orElse((T) BsonNull.VALUE));
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoCompatibilityAdapter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoCompatibilityAdapter.java
@@ -61,7 +61,7 @@ public class MongoCompatibilityAdapter {
 
 	static {
 
-		// method name changed in between 
+		// method name changed in between
 		Method trimFactor = ReflectionUtils.findMethod(RangeOptions.class, "setTrimFactor", Integer.class);
 		if (trimFactor != null) {
 			setTrimFactor = trimFactor;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoCompatibilityAdapter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/MongoCompatibilityAdapter.java
@@ -34,6 +34,7 @@ import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.vault.RangeOptions;
 import com.mongodb.reactivestreams.client.MapReducePublisher;
 
 /**
@@ -42,17 +43,22 @@ import com.mongodb.reactivestreams.client.MapReducePublisher;
  * This class is for internal use within the framework and should not be used by applications.
  *
  * @author Christoph Strobl
+ * @author Ross Lawley
  * @since 4.3
  */
 public class MongoCompatibilityAdapter {
 
 	private static final String NO_LONGER_SUPPORTED = "%s is no longer supported on Mongo Client 5 or newer";
+	private static final String NOT_SUPPORTED_ON_4 = "%s is not supported on Mongo Client 4";
 
 	private static final @Nullable Method getStreamFactoryFactory = ReflectionUtils.findMethod(MongoClientSettings.class,
 			"getStreamFactoryFactory");
 
 	private static final @Nullable Method setBucketSize = ReflectionUtils.findMethod(IndexOptions.class, "bucketSize",
 			Double.class);
+
+	private static final @Nullable Method setTrimFactor = ReflectionUtils.findMethod(RangeOptions.class, "setTrimFactor",
+			Integer.class);
 
 	/**
 	 * Return a compatibility adapter for {@link MongoClientSettings.Builder}.
@@ -197,6 +203,10 @@ public class MongoCompatibilityAdapter {
 
 	public interface MongoDatabaseAdapterBuilder {
 		MongoDatabaseAdapter forDb(com.mongodb.client.MongoDatabase db);
+	}
+
+	public interface RangeOptionsAdapter {
+		void trimFactor(Integer trimFactor);
 	}
 
 	@SuppressWarnings({ "unchecked", "DataFlowIssue" })

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollectionOptionsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/CollectionOptionsUnitTests.java
@@ -15,12 +15,24 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.mongodb.core.CollectionOptions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.mongodb.core.CollectionOptions.EncryptedFieldsOptions;
+import static org.springframework.data.mongodb.core.CollectionOptions.TimeSeriesOptions;
+import static org.springframework.data.mongodb.core.CollectionOptions.emitChangedRevisions;
+import static org.springframework.data.mongodb.core.CollectionOptions.empty;
+import static org.springframework.data.mongodb.core.CollectionOptions.encryptedCollection;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.int32;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.queryable;
 
+import java.util.List;
+
+import org.bson.BsonNull;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.data.mongodb.core.schema.JsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
+import org.springframework.data.mongodb.core.schema.QueryCharacteristics;
 import org.springframework.data.mongodb.core.validation.Validator;
 
 /**
@@ -75,5 +87,94 @@ class CollectionOptionsUnitTests {
 				.isNotEqualTo(empty()) //
 				.isNotEqualTo(empty().validator(Validator.document(new Document("three", "four"))))
 				.isNotEqualTo(empty().validator(Validator.document(new Document("one", "two"))).moderateValidation());
+	}
+
+	@Test // GH-4185
+	@SuppressWarnings("unchecked")
+	void queryableEncryptionOptionsFromSchemaRenderCorrectly() {
+
+		MongoJsonSchema schema = MongoJsonSchema.builder()
+				.property(JsonSchemaProperty.object("spring")
+						.properties(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int32("data")), List.of())))
+				.property(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("mongodb")), List.of())).build();
+
+		EncryptedFieldsOptions encryptionOptions = EncryptedFieldsOptions.fromSchema(schema);
+
+		assertThat(encryptionOptions.toDocument().get("fields", List.class)).hasSize(2)
+				.contains(new Document("path", "mongodb").append("bsonType", "long").append("queries", List.of())
+						.append("keyId", BsonNull.VALUE))
+				.contains(new Document("path", "spring.data").append("bsonType", "int").append("queries", List.of())
+						.append("keyId", BsonNull.VALUE));
+	}
+
+	@Test // GH-4185
+	@SuppressWarnings("unchecked")
+	void queryableEncryptionPropertiesOverrideByPath() {
+
+		CollectionOptions collectionOptions = encryptedCollection(options -> options //
+				.queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int32("spring")))
+				.queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("data")))
+
+				// override first with data type long
+				.queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("spring"))));
+
+		assertThat(collectionOptions.getEncryptedFieldsOptions()).map(EncryptedFieldsOptions::toDocument)
+				.hasValueSatisfying(it -> {
+					assertThat(it.get("fields", List.class)).hasSize(2).contains(new Document("path", "spring")
+							.append("bsonType", "long").append("queries", List.of()).append("keyId", BsonNull.VALUE));
+				});
+	}
+
+	@Test // GH-4185
+	@SuppressWarnings("unchecked")
+	void queryableEncryptionPropertiesOverridesPathFromSchema() {
+
+		EncryptedFieldsOptions encryptionOptions = EncryptedFieldsOptions.fromSchema(MongoJsonSchema.builder()
+				.property(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int32("spring")), List.of()))
+				.property(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("data")), List.of())).build());
+
+		// override spring from schema with data type long
+		CollectionOptions collectionOptions = CollectionOptions.encryptedCollection(
+				encryptionOptions.queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("spring"))));
+
+		assertThat(collectionOptions.getEncryptedFieldsOptions()).map(EncryptedFieldsOptions::toDocument)
+				.hasValueSatisfying(it -> {
+					assertThat(it.get("fields", List.class)).hasSize(2).contains(new Document("path", "spring")
+							.append("bsonType", "long").append("queries", List.of()).append("keyId", BsonNull.VALUE));
+				});
+	}
+
+	@Test // GH-4185
+	void encryptionOptionsAreImmutable() {
+
+		EncryptedFieldsOptions source = EncryptedFieldsOptions
+				.fromProperties(List.of(queryable(int32("spring.data"), List.of(QueryCharacteristics.range().min(1)))));
+
+		assertThat(source.queryable(queryable(int32("mongodb"), List.of(QueryCharacteristics.range().min(1)))))
+				.isNotSameAs(source).satisfies(it -> {
+					assertThat(it.toDocument().get("fields", List.class)).hasSize(2);
+				});
+
+		assertThat(source.toDocument().get("fields", List.class)).hasSize(1);
+	}
+
+	@Test // GH-4185
+	@SuppressWarnings("unchecked")
+	void queryableEncryptionPropertiesOverridesNestedPathFromSchema() {
+
+		EncryptedFieldsOptions encryptionOptions = EncryptedFieldsOptions.fromSchema(MongoJsonSchema.builder()
+				.property(JsonSchemaProperty.object("spring")
+						.properties(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int32("data")), List.of())))
+				.property(queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("mongodb")), List.of())).build());
+
+		// override spring from schema with data type long
+		CollectionOptions collectionOptions = CollectionOptions.encryptedCollection(
+				encryptionOptions.queryable(JsonSchemaProperty.encrypted(JsonSchemaProperty.int64("spring.data"))));
+
+		assertThat(collectionOptions.getEncryptedFieldsOptions()).map(EncryptedFieldsOptions::toDocument)
+				.hasValueSatisfying(it -> {
+					assertThat(it.get("fields", List.class)).hasSize(2).contains(new Document("path", "spring.data")
+							.append("bsonType", "long").append("queries", List.of()).append("keyId", BsonNull.VALUE));
+				});
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/DefaultIndexOperationsIntegrationTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.data.mongodb.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.mongodb.core.index.PartialIndexFilter.*;
-import static org.springframework.data.mongodb.core.query.Criteria.*;
+import static org.springframework.data.mongodb.core.index.PartialIndexFilter.of;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
 
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -79,7 +79,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		IndexDefinition id = new Index().named("partial-with-criteria").on("k3y", Direction.ASC)
 				.partial(of(where("q-t-y").gte(10)));
 
-		indexOps.ensureIndex(id);
+		indexOps.createIndex(id);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "partial-with-criteria");
 		assertThat(Document.parse(info.getPartialFilterExpression()))
@@ -92,7 +92,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		IndexDefinition id = new Index().named("partial-with-mapped-criteria").on("k3y", Direction.ASC)
 				.partial(of(where("quantity").gte(10)));
 
-		template.indexOps(DefaultIndexOperationsIntegrationTestsSample.class).ensureIndex(id);
+		template.indexOps(DefaultIndexOperationsIntegrationTestsSample.class).createIndex(id);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "partial-with-mapped-criteria");
 		assertThat(Document.parse(info.getPartialFilterExpression()))
@@ -105,7 +105,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		IndexDefinition id = new Index().named("partial-with-dbo").on("k3y", Direction.ASC)
 				.partial(of(new org.bson.Document("qty", new org.bson.Document("$gte", 10))));
 
-		indexOps.ensureIndex(id);
+		indexOps.createIndex(id);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "partial-with-dbo");
 		assertThat(Document.parse(info.getPartialFilterExpression()))
@@ -120,7 +120,7 @@ public class DefaultIndexOperationsIntegrationTests {
 
 		indexOps = new DefaultIndexOperations(template, COLLECTION_NAME, MappingToSameCollection.class);
 
-		indexOps.ensureIndex(id);
+		indexOps.createIndex(id);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "partial-with-inheritance");
 		assertThat(Document.parse(info.getPartialFilterExpression()))
@@ -150,7 +150,7 @@ public class DefaultIndexOperationsIntegrationTests {
 
 		new DefaultIndexOperations(template, COLLECTION_NAME, MappingToSameCollection.class);
 
-		indexOps.ensureIndex(id);
+		indexOps.createIndex(id);
 
 		Document expected = new Document("locale", "de_AT") //
 				.append("caseLevel", false) //
@@ -179,7 +179,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		IndexDefinition index = new Index().named("my-index").on("a", Direction.ASC);
 
 		indexOps = new DefaultIndexOperations(template, COLLECTION_NAME, MappingToSameCollection.class);
-		indexOps.ensureIndex(index);
+		indexOps.createIndex(index);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "my-index");
 		assertThat(info.isHidden()).isFalse();
@@ -191,7 +191,7 @@ public class DefaultIndexOperationsIntegrationTests {
 		IndexDefinition index = new Index().named("my-hidden-index").on("a", Direction.ASC).hidden();
 
 		indexOps = new DefaultIndexOperations(template, COLLECTION_NAME, MappingToSameCollection.class);
-		indexOps.ensureIndex(index);
+		indexOps.createIndex(index);
 
 		IndexInfo info = findAndReturnIndexInfo(indexOps.getIndexInfo(), "my-hidden-index");
 		assertThat(info.isHidden()).isTrue();

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableAggregationOperationSupportUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ExecutableAggregationOperationSupportUnitTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
  * Unit tests for {@link ExecutableAggregationOperationSupport}.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @ExtendWith(MockitoExtension.class)
 public class ExecutableAggregationOperationSupportUnitTests {
@@ -72,7 +73,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		opSupport.aggregateAndReturn(Person.class).inCollection("star-wars").by(newAggregation(project("foo"))).all();
 
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
-		verify(template).aggregate(any(Aggregation.class), eq("star-wars"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("star-wars"), captor.capture(),
+				eq(QueryResultConverter.entity()));
 		assertThat(captor.getValue()).isEqualTo(Person.class);
 	}
 
@@ -86,7 +88,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregate(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("person"), captor.capture(),
+				eq(QueryResultConverter.entity()));
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Person.class);
 	}
@@ -101,7 +104,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregate(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("person"), captor.capture(),
+				eq(QueryResultConverter.entity()));
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Jedi.class);
 	}
@@ -112,7 +116,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		opSupport.aggregateAndReturn(Person.class).inCollection("star-wars").by(newAggregation(project("foo"))).stream();
 
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
-		verify(template).aggregateStream(any(Aggregation.class), eq("star-wars"), captor.capture());
+		verify(template).doAggregateStream(any(Aggregation.class), eq("star-wars"), captor.capture(),
+				eq(QueryResultConverter.entity()), any());
 		assertThat(captor.getValue()).isEqualTo(Person.class);
 	}
 
@@ -126,7 +131,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregateStream(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregateStream(any(Aggregation.class), eq("person"), captor.capture(),
+				eq(QueryResultConverter.entity()), any());
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Person.class);
 	}
@@ -141,7 +147,8 @@ public class ExecutableAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregateStream(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregateStream(any(Aggregation.class), eq("person"), captor.capture(),
+				eq(QueryResultConverter.entity()), any());
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Jedi.class);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -3108,6 +3109,18 @@ public class MongoTemplateTests {
 		assertThat(result).hasSize(2);
 		assertThat(walter.getId()).isNotNull();
 		assertThat(jesse.getId()).isNotNull();
+	}
+
+	@Test // GH-4944
+	public void insertAllShouldConvertIdToTargetTypeBeforeSave() {
+
+		RawStringId walter = new RawStringId();
+		walter.value = "walter";
+
+		RawStringId returned = template.insertAll(List.of(walter)).iterator().next();
+		org.bson.Document document = template.execute(RawStringId.class, collection -> collection.find().first());
+
+		assertThat(returned.id).isEqualTo(document.get("_id"));
 	}
 
 	@Test // DATAMONGO-1208

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateUnitTests.java
@@ -1156,7 +1156,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void appliesFieldsWhenInterfaceProjectionIsClosedAndQueryDoesNotDefineFields() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document(), Person.class,
-				PersonProjection.class, CursorPreparer.NO_OP_PREPARER);
+				PersonProjection.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("firstname", 1)));
 	}
@@ -1165,7 +1165,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void doesNotApplyFieldsWhenInterfaceProjectionIsClosedAndQueryDefinesFields() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document("bar", 1), Person.class,
-				PersonProjection.class, CursorPreparer.NO_OP_PREPARER);
+				PersonProjection.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("bar", 1)));
 	}
@@ -1174,7 +1174,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void doesNotApplyFieldsWhenInterfaceProjectionIsOpen() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document(), Person.class,
-				PersonSpELProjection.class, CursorPreparer.NO_OP_PREPARER);
+				PersonSpELProjection.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(BsonUtils.EMPTY_DOCUMENT));
 	}
@@ -1183,7 +1183,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void appliesFieldsToDtoProjection() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document(), Person.class,
-				Jedi.class, CursorPreparer.NO_OP_PREPARER);
+				Jedi.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("firstname", 1)));
 	}
@@ -1192,7 +1192,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void doesNotApplyFieldsToDtoProjectionWhenQueryDefinesFields() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document("bar", 1), Person.class,
-				Jedi.class, CursorPreparer.NO_OP_PREPARER);
+				Jedi.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(new Document("bar", 1)));
 	}
@@ -1201,7 +1201,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void doesNotApplyFieldsWhenTargetIsNotAProjection() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document(), Person.class,
-				Person.class, CursorPreparer.NO_OP_PREPARER);
+				Person.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(BsonUtils.EMPTY_DOCUMENT));
 	}
@@ -1210,7 +1210,7 @@ public class MongoTemplateUnitTests extends MongoOperationsUnitTests {
 	void doesNotApplyFieldsWhenTargetExtendsDomainType() {
 
 		template.doFind(CollectionPreparer.identity(), "star-wars", new Document(), new Document(), Person.class,
-				PersonExtended.class, CursorPreparer.NO_OP_PREPARER);
+				PersonExtended.class, QueryResultConverter.entity(), CursorPreparer.NO_OP_PREPARER);
 
 		verify(findIterable).projection(eq(BsonUtils.EMPTY_DOCUMENT));
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveAggregationOperationSupportUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveAggregationOperationSupportUnitTests.java
@@ -72,7 +72,8 @@ public class ReactiveAggregationOperationSupportUnitTests {
 		opSupport.aggregateAndReturn(Person.class).inCollection("star-wars").by(newAggregation(project("foo"))).all();
 
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
-		verify(template).aggregate(any(Aggregation.class), eq("star-wars"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("star-wars"), captor.capture(), any(Class.class),
+				eq(QueryResultConverter.entity()));
 		assertThat(captor.getValue()).isEqualTo(Person.class);
 	}
 
@@ -86,7 +87,8 @@ public class ReactiveAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregate(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("person"), captor.capture(), any(Class.class),
+				eq(QueryResultConverter.entity()));
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Person.class);
 	}
@@ -101,7 +103,8 @@ public class ReactiveAggregationOperationSupportUnitTests {
 		ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
 
 		verify(template).getCollectionName(captor.capture());
-		verify(template).aggregate(any(Aggregation.class), eq("person"), captor.capture());
+		verify(template).doAggregate(any(Aggregation.class), eq("person"), captor.capture(), any(Class.class),
+				eq(QueryResultConverter.entity()));
 
 		assertThat(captor.getAllValues()).containsExactly(Person.class, Jedi.class);
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+import static org.springframework.data.mongodb.test.util.Assertions.*;
 import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
 
 import reactor.core.publisher.Flux;
@@ -53,6 +54,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -437,7 +439,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void appliesFieldsWhenInterfaceProjectionIsClosedAndQueryDoesNotDefineFields() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document(), Person.class,
-				PersonProjection.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				PersonProjection.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("firstname", 1)));
 	}
@@ -446,7 +448,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void doesNotApplyFieldsWhenInterfaceProjectionIsClosedAndQueryDefinesFields() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document("bar", 1), Person.class,
-				PersonProjection.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				PersonProjection.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("bar", 1)));
 	}
@@ -455,7 +457,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void doesNotApplyFieldsWhenInterfaceProjectionIsOpen() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document(), Person.class,
-				PersonSpELProjection.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				PersonSpELProjection.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher, never()).projection(any());
 	}
@@ -464,7 +466,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void appliesFieldsToDtoProjection() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document(), Person.class,
-				Jedi.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				Jedi.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("firstname", 1)));
 	}
@@ -473,7 +475,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void doesNotApplyFieldsToDtoProjectionWhenQueryDefinesFields() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document("bar", 1), Person.class,
-				Jedi.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				Jedi.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher).projection(eq(new Document("bar", 1)));
 	}
@@ -482,7 +484,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void doesNotApplyFieldsWhenTargetIsNotAProjection() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document(), Person.class,
-				Person.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				Person.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher, never()).projection(any());
 	}
@@ -491,7 +493,7 @@ public class ReactiveMongoTemplateUnitTests {
 	void doesNotApplyFieldsWhenTargetExtendsDomainType() {
 
 		template.doFind("star-wars", CollectionPreparer.identity(), new Document(), new Document(), Person.class,
-				PersonExtended.class, FindPublisherPreparer.NO_OP_PREPARER).subscribe();
+				PersonExtended.class, QueryResultConverter.entity(), FindPublisherPreparer.NO_OP_PREPARER).subscribe();
 
 		verify(findPublisher, never()).projection(any());
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/MongoQueryableEncryptionCollectionCreationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/MongoQueryableEncryptionCollectionCreationTests.java
@@ -15,12 +15,9 @@
  */
 package org.springframework.data.mongodb.core.encryption;
 
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.encrypted;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.int32;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.int64;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.queryable;
-import static org.springframework.data.mongodb.core.schema.QueryCharacteristics.range;
-import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.*;
+import static org.springframework.data.mongodb.core.schema.QueryCharacteristics.*;
+import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -34,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
@@ -42,6 +40,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.schema.JsonSchemaProperty;
 import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
 import org.springframework.data.mongodb.test.util.Client;
+import org.springframework.data.mongodb.test.util.EnableIfMongoServerVersion;
 import org.springframework.data.mongodb.test.util.MongoClientExtension;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -49,9 +48,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.mongodb.client.MongoClient;
 
 /**
+ * Integration tests for creating collections with encrypted fields.
+ *
  * @author Christoph Strobl
  */
 @ExtendWith({ MongoClientExtension.class, SpringExtension.class })
+@EnableIfMongoServerVersion(isGreaterThanEqual = "8.0")
 @ContextConfiguration
 public class MongoQueryableEncryptionCollectionCreationTests {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/MongoQueryableEncryptionCollectionCreationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/MongoQueryableEncryptionCollectionCreationTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.encryption;
+
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.encrypted;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.int32;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.int64;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.queryable;
+import static org.springframework.data.mongodb.core.schema.QueryCharacteristics.range;
+import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.bson.BsonBinary;
+import org.bson.Document;
+import org.bson.UuidRepresentation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.CollectionOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.schema.JsonSchemaProperty;
+import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
+import org.springframework.data.mongodb.test.util.Client;
+import org.springframework.data.mongodb.test.util.MongoClientExtension;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.mongodb.client.MongoClient;
+
+/**
+ * @author Christoph Strobl
+ */
+@ExtendWith({ MongoClientExtension.class, SpringExtension.class })
+@ContextConfiguration
+public class MongoQueryableEncryptionCollectionCreationTests {
+
+	public static final String COLLECTION_NAME = "enc-collection";
+	static @Client MongoClient mongoClient;
+
+	@Configuration
+	static class Config extends AbstractMongoClientConfiguration {
+
+		@Override
+		public MongoClient mongoClient() {
+			return mongoClient;
+		}
+
+		@Override
+		protected String getDatabaseName() {
+			return "encryption-schema-tests";
+		}
+
+	}
+
+	@Autowired MongoTemplate template;
+
+	@BeforeEach
+	void beforeEach() {
+		template.dropCollection(COLLECTION_NAME);
+	}
+
+	@ParameterizedTest // GH-4185
+	@MethodSource("collectionOptions")
+	public void createsCollectionWithEncryptedFieldsCorrectly(CollectionOptions collectionOptions) {
+
+		template.createCollection(COLLECTION_NAME, collectionOptions);
+
+		Document encryptedFields = readEncryptedFieldsFromDatabase(COLLECTION_NAME);
+		assertThat(encryptedFields).containsKey("fields");
+
+		List<Document> fields = encryptedFields.get("fields", List.of());
+		assertThat(fields.get(0)).containsEntry("path", "encryptedInt") //
+				.containsEntry("bsonType", "int") //
+				.containsEntry("queries", List
+						.of(Document.parse("{'queryType': 'range', 'contention': { '$numberLong' : '1' }, 'min': 5, 'max': 100}")));
+
+		assertThat(fields.get(1)).containsEntry("path", "nested.encryptedLong") //
+				.containsEntry("bsonType", "long") //
+				.containsEntry("queries", List.of(Document.parse(
+						"{'queryType': 'range', 'contention': { '$numberLong' : '0' }, 'min': { '$numberLong' : '-1' }, 'max': { '$numberLong' : '1' }}")));
+	}
+
+	private static Stream<Arguments> collectionOptions() {
+
+		BsonBinary key1 = new BsonBinary(UUID.randomUUID(), UuidRepresentation.STANDARD);
+		BsonBinary key2 = new BsonBinary(UUID.randomUUID(), UuidRepresentation.STANDARD);
+
+		CollectionOptions manualOptions = CollectionOptions.encryptedCollection(options -> options //
+				.queryable(encrypted(int32("encryptedInt")).keys(key1), range().min(5).max(100).contention(1)) //
+				.queryable(encrypted(JsonSchemaProperty.int64("nested.encryptedLong")).keys(key2),
+						range().min(-1L).max(1L).contention(0)));
+
+		CollectionOptions schemaOptions = CollectionOptions.encryptedCollection(MongoJsonSchema.builder()
+				.property(
+						queryable(encrypted(int32("encryptedInt")).keyId(key1), List.of(range().min(5).max(100).contention(1))))
+				.property(queryable(encrypted(int64("nested.encryptedLong")).keyId(key2),
+						List.of(range().min(-1L).max(1L).contention(0))))
+				.build());
+
+		return Stream.of(Arguments.of(manualOptions), Arguments.of(schemaOptions));
+	}
+
+	Document readEncryptedFieldsFromDatabase(String collectionName) {
+
+		Document collectionInfo = template
+				.executeCommand(new Document("listCollections", 1).append("filter", new Document("name", collectionName)));
+
+		if (collectionInfo.containsKey("cursor")) {
+			collectionInfo = (Document) collectionInfo.get("cursor", Document.class).get("firstBatch", List.class).iterator()
+					.next();
+		}
+
+		if (!collectionInfo.containsKey("options")) {
+			return new Document();
+		}
+
+		return collectionInfo.get("options", Document.class).get("encryptedFields", Document.class);
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/RangeEncryptionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/RangeEncryptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  */
 package org.springframework.data.mongodb.core.encryption;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
 
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -369,7 +369,7 @@ class RangeEncryptionTests {
 					path = StringUtils.arrayToDelimitedString(ctx.getProperty().getMongoField().getName().parts(), ".");
 				}
 				if (ctx.getOperatorContext() != null) {
-					path = ctx.getOperatorContext().getPath();
+					path = ctx.getOperatorContext().path();
 				}
 				return EncryptionKey.keyId(keyHolder.getEncryptionKey(path));
 			}));

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/RangeEncryptionTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/encryption/RangeEncryptionTests.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.encryption;
+
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.mongodb.core.EncryptionAlgorithms.*;
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.CreateEncryptedCollectionParams;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.client.vault.ClientEncryptions;
+
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.convert.PropertyValueConverterFactory;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions.MongoConverterConfigurationAdapter;
+import org.springframework.data.mongodb.core.convert.encryption.MongoEncryptionConverter;
+import org.springframework.data.mongodb.core.mapping.ExplicitEncrypted;
+import org.springframework.data.mongodb.test.util.EnableIfMongoServerVersion;
+import org.springframework.data.mongodb.test.util.EnableIfReplicaSetAvailable;
+import org.springframework.data.mongodb.test.util.MongoClientExtension;
+import org.springframework.data.util.Lazy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Ross Lawley
+ */
+@ExtendWith({ MongoClientExtension.class, SpringExtension.class })
+@EnableIfMongoServerVersion(isGreaterThanEqual = "8.0")
+@EnableIfReplicaSetAvailable
+@ContextConfiguration(classes = RangeEncryptionTests.EncryptionConfig.class)
+class RangeEncryptionTests {
+
+	@Autowired MongoTemplate template;
+
+	@AfterEach
+	void tearDown() {
+		template.getDb().getCollection("test").deleteMany(new BsonDocument());
+	}
+
+	@Test
+	void canGreaterThanEqualMatchRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		Person loaded = template.query(Person.class).matching(where("encryptedInt").gte(source.encryptedInt)).firstValue();
+		assertThat(loaded).isEqualTo(source);
+	}
+
+	@Test
+	void canLesserThanEqualMatchRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		Person loaded = template.query(Person.class).matching(where("encryptedInt").lte(source.encryptedInt)).firstValue();
+		assertThat(loaded).isEqualTo(source);
+	}
+
+	@Test
+	void canRangeMatchRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		Person loaded = template.query(Person.class).matching(where("encryptedLong").lte(1001L).gte(1001L)).firstValue();
+		assertThat(loaded).isEqualTo(source);
+	}
+
+	@Test
+	void canUpdateRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		source.encryptedInt = 123;
+		source.encryptedLong = 9999L;
+		template.save(source);
+
+		Person loaded = template.query(Person.class).matching(where("id").is(source.id)).firstValue();
+		assertThat(loaded).isEqualTo(source);
+	}
+
+	@Test
+	void errorsWhenUsingNonRangeOperatorEqOnRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		assertThatThrownBy(
+				() -> template.query(Person.class).matching(where("encryptedInt").is(source.encryptedInt)).firstValue())
+				.isInstanceOf(AssertionError.class)
+				.hasMessageStartingWith("Not a valid range query. Querying a range encrypted field but "
+						+ "the query operator '$eq' for field path 'encryptedInt' is not a range query.");
+
+	}
+
+	@Test
+	void errorsWhenUsingNonRangeOperatorInOnRangeEncryptedField() {
+		Person source = createPerson();
+		template.insert(source);
+
+		assertThatThrownBy(
+				() -> template.query(Person.class).matching(where("encryptedLong").in(1001L, 9999L)).firstValue())
+				.isInstanceOf(AssertionError.class)
+				.hasMessageStartingWith("Not a valid range query. Querying a range encrypted field but "
+						+ "the query operator '$in' for field path 'encryptedLong' is not a range query.");
+
+	}
+
+	private Person createPerson() {
+		Person source = new Person();
+		source.id = "id-1";
+		source.encryptedInt = 101;
+		source.encryptedLong = 1001L;
+		return source;
+	}
+
+	protected static class EncryptionConfig extends AbstractMongoClientConfiguration {
+
+		private static final String LOCAL_KMS_PROVIDER = "local";
+
+		private static final Lazy<Map<String, Map<String, Object>>> LAZY_KMS_PROVIDERS = Lazy.of(() -> {
+			byte[] localMasterKey = new byte[96];
+			new SecureRandom().nextBytes(localMasterKey);
+			return Map.of(LOCAL_KMS_PROVIDER, Map.of("key", localMasterKey));
+		});
+
+		@Autowired ApplicationContext applicationContext;
+
+		@Override
+		protected String getDatabaseName() {
+			return "qe-test";
+		}
+
+		@Bean
+		public MongoClient mongoClient() {
+			return super.mongoClient();
+		}
+
+		@Override
+		protected void configureConverters(MongoConverterConfigurationAdapter converterConfigurationAdapter) {
+			converterConfigurationAdapter
+					.registerPropertyValueConverterFactory(PropertyValueConverterFactory.beanFactoryAware(applicationContext))
+					.useNativeDriverJavaTimeCodecs();
+		}
+
+		@Bean
+		MongoEncryptionConverter encryptingConverter(MongoClientEncryption mongoClientEncryption) {
+			Lazy<Map<String, BsonBinary>> lazyDataKeyMap = Lazy.of(() -> {
+				try (MongoClient client = mongoClient()) {
+					MongoDatabase database = client.getDatabase(getDatabaseName());
+					database.getCollection("test").drop();
+
+					ClientEncryption clientEncryption = mongoClientEncryption.getClientEncryption();
+					BsonDocument encryptedFields = new BsonDocument().append("fields",
+							new BsonArray(asList(
+									new BsonDocument("keyId", BsonNull.VALUE).append("path", new BsonString("encryptedInt"))
+											.append("bsonType", new BsonString("int"))
+											.append("queries",
+													new BsonDocument("queryType", new BsonString("range")).append("contention", new BsonInt64(0L))
+															.append("trimFactor", new BsonInt32(1)).append("sparsity", new BsonInt64(1))
+															.append("min", new BsonInt32(0)).append("max", new BsonInt32(200))),
+									new BsonDocument("keyId", BsonNull.VALUE).append("path", new BsonString("encryptedLong"))
+											.append("bsonType", new BsonString("long")).append("queries",
+													new BsonDocument("queryType", new BsonString("range")).append("contention", new BsonInt64(0L))
+															.append("trimFactor", new BsonInt32(1)).append("sparsity", new BsonInt64(1))
+															.append("min", new BsonInt64(1000)).append("max", new BsonInt64(9999))))));
+
+					BsonDocument local = clientEncryption.createEncryptedCollection(database, "test",
+							new CreateCollectionOptions().encryptedFields(encryptedFields),
+							new CreateEncryptedCollectionParams(LOCAL_KMS_PROVIDER));
+
+					return local.getArray("fields").stream().map(BsonValue::asDocument).collect(
+							Collectors.toMap(field -> field.getString("path").getValue(), field -> field.getBinary("keyId")));
+				}
+			});
+			return new MongoEncryptionConverter(mongoClientEncryption, EncryptionKeyResolver
+					.annotated((ctx) -> EncryptionKey.keyId(lazyDataKeyMap.get().get(ctx.getProperty().getFieldName()))));
+		}
+
+		@Bean
+		CachingMongoClientEncryption clientEncryption(ClientEncryptionSettings encryptionSettings) {
+			return new CachingMongoClientEncryption(() -> ClientEncryptions.create(encryptionSettings));
+		}
+
+		@Override
+		protected void configureClientSettings(MongoClientSettings.Builder builder) {
+			try (MongoClient client = MongoClients.create()) {
+				ClientEncryptionSettings clientEncryptionSettings = encryptionSettings(client);
+
+				builder.autoEncryptionSettings(AutoEncryptionSettings.builder() //
+						.kmsProviders(clientEncryptionSettings.getKmsProviders()) //
+						.keyVaultNamespace(clientEncryptionSettings.getKeyVaultNamespace()) //
+						.bypassQueryAnalysis(true).build());
+			}
+		}
+
+		@Bean
+		ClientEncryptionSettings encryptionSettings(MongoClient mongoClient) {
+			MongoNamespace keyVaultNamespace = new MongoNamespace("encryption.testKeyVault");
+			MongoCollection<Document> keyVaultCollection = mongoClient.getDatabase(keyVaultNamespace.getDatabaseName())
+					.getCollection(keyVaultNamespace.getCollectionName());
+			keyVaultCollection.drop();
+			// Ensure that two data keys cannot share the same keyAltName.
+			keyVaultCollection.createIndex(Indexes.ascending("keyAltNames"),
+					new IndexOptions().unique(true).partialFilterExpression(Filters.exists("keyAltNames")));
+
+			mongoClient.getDatabase(getDatabaseName()).getCollection("test").drop(); // Clear old data
+
+			// Create the ClientEncryption instance
+			return ClientEncryptionSettings.builder() //
+					.keyVaultMongoClientSettings(
+							MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb://localhost")).build()) //
+					.keyVaultNamespace(keyVaultNamespace.getFullName()) //
+					.kmsProviders(LAZY_KMS_PROVIDERS.get()) //
+					.build();
+		}
+	}
+
+	static class CachingMongoClientEncryption extends MongoClientEncryption implements DisposableBean {
+
+		static final AtomicReference<ClientEncryption> cache = new AtomicReference<>();
+
+		CachingMongoClientEncryption(Supplier<ClientEncryption> source) {
+			super(() -> {
+				ClientEncryption clientEncryption = cache.get();
+				if (clientEncryption == null) {
+					clientEncryption = source.get();
+					cache.set(clientEncryption);
+				}
+
+				return clientEncryption;
+			});
+		}
+
+		@Override
+		public void destroy() {
+			ClientEncryption clientEncryption = cache.get();
+			if (clientEncryption != null) {
+				clientEncryption.close();
+				cache.set(null);
+			}
+		}
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document("test")
+	static class Person {
+
+		String id;
+		String name;
+
+		@ExplicitEncrypted(algorithm = RANGE, contentionFactor = 0L,
+				rangeOptions = "{\"min\": 0, \"max\": 200, \"trimFactor\": 1, \"sparsity\": 1}") Integer encryptedInt;
+		@ExplicitEncrypted(algorithm = RANGE, contentionFactor = 0L,
+				rangeOptions = "{\"min\": {\"$numberLong\": \"1000\"}, \"max\": {\"$numberLong\": \"9999\"}, \"trimFactor\": 1, \"sparsity\": 1}") Long encryptedLong;
+
+		public String getId() {
+			return this.id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Integer getEncryptedInt() {
+			return this.encryptedInt;
+		}
+
+		public void setEncryptedInt(Integer encryptedInt) {
+			this.encryptedInt = encryptedInt;
+		}
+
+		public Long getEncryptedLong() {
+			return this.encryptedLong;
+		}
+
+		public void setEncryptedLong(Long encryptedLong) {
+			this.encryptedLong = encryptedLong;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+
+			Person person = (Person) o;
+			return Objects.equals(id, person.id) && Objects.equals(name, person.name)
+					&& Objects.equals(encryptedInt, person.encryptedInt) && Objects.equals(encryptedLong, person.encryptedLong);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hashCode(id);
+			result = 31 * result + Objects.hashCode(name);
+			result = 31 * result + Objects.hashCode(encryptedInt);
+			result = 31 * result + Objects.hashCode(encryptedLong);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "Person{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", encryptedInt=" + encryptedInt
+					+ ", encryptedLong=" + encryptedLong + '}';
+		}
+	}
+
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/schema/MongoJsonSchemaUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/schema/MongoJsonSchemaUnitTests.java
@@ -15,13 +15,10 @@
  */
 package org.springframework.data.mongodb.core.schema;
 
-import static org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.EncryptedJsonSchemaProperty.rangeEncrypted;
+import static org.springframework.data.mongodb.core.schema.IdentifiableJsonSchemaProperty.EncryptedJsonSchemaProperty.*;
+import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.*;
 import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.encrypted;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.number;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.queryable;
-import static org.springframework.data.mongodb.core.schema.JsonSchemaProperty.string;
-import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
-import static org.springframework.data.mongodb.test.util.Assertions.assertThatIllegalArgumentException;
+import static org.springframework.data.mongodb.test.util.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -119,13 +116,27 @@ class MongoJsonSchemaUnitTests {
 						List.of(QueryCharacteristics.range().contention(0).trimFactor(1).sparsity(1).min(0).max(200))))
 				.build();
 
-		assertThat(schema.toDocument()).isEqualTo(new Document("$jsonSchema",
-				new Document("type", "object").append("properties",
-						new Document("ssn",
-								new Document("encrypt",
-										new Document("bsonType", "long").append("algorithm", "Range").append("queries",
-												List.of(new Document("contention", 0L).append("trimFactor", 1).append("sparsity", 1L)
-														.append("queryType", "range").append("min", 0).append("max", 200))))))));
+		assertThat(schema.toDocument().get("$jsonSchema", Document.class)).isEqualTo("""
+				{
+					"type": "object",
+					"properties": {
+						"ssn": {
+							"encrypt": {
+								"bsonType": "long",
+								"algorithm": "Range",
+								"queries": [{
+									"queryType": "range",
+									"contention": {$numberLong: "0"},
+									"trimFactor": 1,
+									"sparsity": {$numberLong: "1"},
+									"min": 0,
+									"max": 200
+									}]
+							}
+						}
+					}
+				}
+				""");
 	}
 
 	@Test // DATAMONGO-1835

--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
@@ -254,7 +254,7 @@ Explicit encryption uses the MongoDB driver's encryption library (`org.mongodb:m
 [NOTE]
 ====
 There is no official support for using Explicit Queryable Encryption.
-The audacious user may combine `@Encyrpted` and `@Queryable` with `@ValueConverter(MongoEncryptionConverter.class)` at their own risk.
+The audacious user may combine `@Encrypted` and `@Queryable` with `@ValueConverter(MongoEncryptionConverter.class)` at their own risk.
 ====
 
 [[mongo.encryption.explicit-setup]]

--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
@@ -1,8 +1,8 @@
 [[mongo.encryption]]
-= Encryption (CSFLE)
+= Encryption
 
 Client Side Encryption is a feature that encrypts data in your application before it is sent to MongoDB.
-We recommend you get familiar with the concepts, ideally from the https://www.mongodb.com/docs/manual/core/csfle/[MongoDB Documentation] to learn more about its capabilities and restrictions before you continue applying Encryption through Spring Data.
+We recommend you get familiar with the concepts, ideally from the https://www.mongodb.com/docs/manual/core/security-in-use-encryption/[MongoDB Documentation] to learn more about its capabilities and restrictions before you continue applying Encryption through Spring Data.
 
 [NOTE]
 ====
@@ -11,8 +11,13 @@ MongoDB does not support encryption for all field types.
 Specific data types require deterministic encryption to preserve equality comparison functionality.
 ====
 
+== Client Side Field Level Encryption (CSFLE)
+
+Choosing CSFLE gives you full flexibility and allows you to use different keys for a single field, eg. in a one key per tenant scenario. +
+Please make sure to consult the https://www.mongodb.com/docs/manual/core/csfle/[MongoDB CSFLE Documentation] before you continue reading.
+
 [[mongo.encryption.automatic]]
-== Automatic Encryption
+=== Automatic Encryption (CSFLE)
 
 MongoDB supports https://www.mongodb.com/docs/manual/core/csfle/[Client-Side Field Level Encryption] out of the box using the MongoDB driver with its Automatic Encryption feature.
 Automatic Encryption requires a xref:mongodb/mapping/mapping-schema.adoc[JSON Schema] that allows to perform encrypted read and write operations without the need to provide an explicit en-/decryption step.
@@ -47,7 +52,7 @@ MongoClientSettingsBuilderCustomizer customizer(MappingContext mappingContext) {
 ----
 
 [[mongo.encryption.explicit]]
-== Explicit Encryption
+=== Explicit Encryption (CSFLE)
 
 Explicit encryption uses the MongoDB driver's encryption library (`org.mongodb:mongodb-crypt`) to perform encryption and decryption tasks.
 The `@ExplicitEncrypted` annotation is a combination of the `@Encrypted` annotation used for xref:mongodb/mapping/mapping-schema.adoc#mongo.jsonSchema.encrypted-fields[JSON Schema creation] and a xref:mongodb/mapping/property-converters.adoc[Property Converter].
@@ -114,8 +119,147 @@ By default, the `@ExplicitEncrypted(value=…)` attribute references a `MongoEnc
 It is possible to change the default implementation and exchange it with any `PropertyValueConverter` implementation by providing the according type reference.
 To learn more about custom `PropertyValueConverters` and the required configuration, please refer to the xref:mongodb/mapping/property-converters.adoc[Property Converters - Mapping specific fields] section.
 
+[[mongo.encryption.queryable]]
+== Queryable Encryption (QE)
+
+Choosing QE enables you to run different types of queries, like _range_ or _equality_, against encrypted fields. +
+Please make sure to consult the https://www.mongodb.com/docs/manual/core/queryable-encryption/[MongoDB QE Documentation] before you continue reading to learn more about QE features and limitations.
+
+=== Collection Setup
+
+Queryable Encryption requires upfront declaration of certain aspects allowed within an actual query against an encrypted field.
+The information covers the algorithm in use as well as allowed query types along with their attributes and must be provided when creating the collection.
+
+`MongoOperations#createCollection(...)` can be used to do the initial setup for collections utilizing QE.
+The configuration for QE via Spring Data uses the same building blocks (a xref:mongodb/mapping/mapping-schema.adoc#mongo.jsonSchema.encrypted-fields[JSON Schema creation]) as CSFLE, converting the schema/properties into the configuration format required by MongoDB.
+
+[tabs]
+======
+Manual Collection Setup::
++
+====
+[source,java,indent=0,subs="verbatim,quotes",role="primary"]
+----
+CollectionOptions collectionOptions = CollectionOptions.encryptedCollection(options -> options
+	.queryable(encrypted(string("ssn")).algorithm("Indexed"), equality().contention(0))
+	.queryable(encrypted(int32("age")).algorithm("Range"), range().contention(8).min(0).max(150))
+	.queryable(encrypted(int64("address.sign")).algorithm("Range"), range().contention(2).min(-10L).max(10L))
+);
+
+mongoTemplate.createCollection(Patient.class, collectionOptions); <1>
+----
+<1> Using the template to create the collection may prevent capturing generated keyIds. In this case render the `Document` from the options and use the `createEncryptedCollection(...)` method via the encryption library.
+====
+
+Derived Collection Setup::
++
+====
+[source,java,indent=0,subs="verbatim,quotes",role="secondary"]
+----
+class Patient {
+
+    @Id String id;
+
+    @Encrypted(algorithm = "Indexed") //
+    @Queryable(queryType = "equality", contentionFactor = 0)
+    String ssn;
+
+    @RangeEncrypted(contentionFactor = 8, rangeOptions = "{ 'min' : 0, 'max' : 150 }")
+    Integer age;
+
+    Address address;
+}
+
+MongoJsonSchema patientSchema = MongoJsonSchemaCreator.create(mappingContext)
+    .filter(MongoJsonSchemaCreator.encryptedOnly())
+    .createSchemaFor(Patient.class);
+
+CollectionOptions collectionOptions = CollectionOptions.encryptedCollection(patientSchema);
+
+mongoTemplate.createCollection(Patient.class, collectionOptions); <1>
+----
+<1> Using the template to create the collection may prevent capturing generated keyIds. In this case render the `Document` from the options and use the `createEncryptedCollection(...)` method via the encryption library.
+
+The `Queryable` annotation allows to define allowed query types for encrypted fields.
+`@RangeEncrypted` is a combination of `@Encrypted` and `@Queryable` for fields allowing `range` queries.
+It is possible to create custom annotations out of the provided ones.
+====
+
+MongoDB Collection Info::
++
+====
+[source,java,indent=0,subs="verbatim,quotes",role="thrid"]
+----
+{
+    name: 'patient',
+    type: 'collection',
+    options: {
+      encryptedFields: {
+        escCollection: 'enxcol_.test.esc',
+        ecocCollection: 'enxcol_.test.ecoc',
+        fields: [
+          {
+            keyId: ...,
+            path: 'ssn',
+            bsonType: 'string',
+            queries: [ { queryType: 'equality', contention: Long('0') } ]
+          },
+          {
+            keyId: ...,
+            path: 'age',
+            bsonType: 'int',
+            queries: [ { queryType: 'range', contention: Long('8'), min: 0, max: 150 } ]
+          },
+          {
+            keyId: ...,
+            path: 'address.sign',
+            bsonType: 'long',
+            queries: [ { queryType: 'range', contention: Long('2'), min: Long('-10'), max: Long('10') } ]
+          }
+        ]
+      }
+    }
+}
+----
+====
+======
+
+[NOTE]
+====
+- It is not possible to use both QE and CSFLE within the same collection.
+- It is not possible to query a `range` indexed field with an `equality` operator.
+- It is not possible to query an `equality` indexed field with a `range` operator.
+- It is not possible to set `bypassAutoEncrytion(true)`.
+- It is not possible to use self maintained encryption keys via `@Encrypted` in combination with Queryable Encryption.
+- Contention is only optional on the server side, the clients requires you to set the value (Default us `8`).
+- Additional options for eg. `min` and `max` need to match the actual field type. Make sure to use `$numberLong` etc. to ensure target types when parsing bson String.
+- Queryable Encryption will an extra field `__safeContent__` to each of your documents.
+Unless explicitly excluded the field will be loaded into memory when retrieving results.
+====
+
+[[mongo.encryption.queryable.automatic]]
+=== Automatic Encryption (QE)
+
+MongoDB supports Queryable Encryption out of the box using the MongoDB driver with its Automatic Encryption feature.
+Automatic Encryption requires a xref:mongodb/mapping/mapping-schema.adoc[JSON Schema] that allows to perform encrypted read and write operations without the need to provide an explicit en-/decryption step.
+
+All you need to do is create the collection according to the MongoDB documentation.
+You may utilize techniques to create the required configuration outlined in the section above.
+
+[[mongo.encryption.queryable.manual]]
+=== Explicit Encryption (QE)
+
+Explicit encryption uses the MongoDB driver's encryption library (`org.mongodb:mongodb-crypt`) to perform encryption and decryption tasks based on the meta information provided by annotation within the domain model.
+
+[NOTE]
+====
+There is no official support for using Explicit Queryable Encryption.
+The audacious user may combine `@Encyrpted` and `@Queryable` with `@ValueConverter(MongoEncryptionConverter.class)` at their own risk.
+====
+
 [[mongo.encryption.explicit-setup]]
-=== MongoEncryptionConverter Setup
+[[mongo.encryption.converter-setup]]
+== MongoEncryptionConverter Setup
 
 The converter setup for `MongoEncryptionConverter` requires a few steps as several components are involved.
 The bean setup consists of the following:
@@ -124,7 +268,6 @@ The bean setup consists of the following:
 2. A `MongoEncryptionConverter` instance configured with `ClientEncryption` and a `EncryptionKeyResolver`.
 3. A `PropertyValueConverterFactory` that uses the registered `MongoEncryptionConverter` bean.
 
-A side effect of using annotated key resolution is that the `@ExplicitEncrypted` annotation does not need to specify an alt key name.
 The `EncryptionKeyResolver` uses an `EncryptionContext` providing access to the property allowing for dynamic DEK resolution.
 
 .Sample MongoEncryptionConverter Configuration

--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-search-indexes.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-search-indexes.adoc
@@ -84,7 +84,6 @@ VectorSearchOperation search = VectorSearchOperation.search("vector_index") <1>
   .vector( ... )
   .numCandidates(150)
   .limit(10)
-  .quantization(SCALAR)
   .withSearchScore("score"); <3>
 
 AggregationResults<MovieWithSearchScore> results = mongoTemplate
@@ -107,8 +106,7 @@ db.embedded_movies.aggregate([
       "path": "plot_embedding", <1>
       "queryVector": [ ... ],
       "numCandidates": 150,
-      "limit": 10,
-      "quantization": "scalar"
+      "limit": 10
     }
   },
   {

--- a/src/main/antora/modules/ROOT/pages/repositories/core-concepts.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-concepts.adoc
@@ -2,11 +2,3 @@ include::{commons}@data-commons::page$repositories/core-concepts.adoc[]
 
 [[mongodb.entity-persistence.state-detection-strategies]]
 include::{commons}@data-commons::page$is-new-state-detection.adoc[leveloffset=+1]
-
-[NOTE]
-====
-Cassandra provides no means to generate identifiers upon inserting data.
-As consequence, entities must be associated with identifier values.
-Spring Data defaults to identifier inspection to determine whether an entity is new.
-If you want to use xref:mongodb/auditing.adoc[auditing] make sure to either use xref:mongodb/template-crud-operations.adoc#mongo-template.optimistic-locking[Optimistic Locking] or implement `Persistable` for proper entity state detection.
-====


### PR DESCRIPTION
We now support configuring a `QueryResultConverter` that has access to the raw result `Document` and the mapped result object that has been materialized from `MongoConverter`:

```java
List<Optional<Jedi>> result = template.query(Person.class)
                        .as(Jedi.class)
                        .matching(query(where("firstname").is("luke")))
                        .map((document, reader) -> Optional.of(reader.get()))
                        .all();
```

This is useful to either wrap, post-process results contextually or apply further transformations based on the result `Document`. Changes apply for imperative and reactive find, geoNear and aggregations.

TODO:

- [ ] `QueryResultConverter.entity()` (returning the converted object) is a good naming fit for queries, but with projections or aggregations we might to name it differently