### PR TITLE
Fix AddFieldsOperationBuilder to treat String value as Field reference

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperation.java
@@ -31,6 +31,7 @@ import org.springframework.lang.Nullable;
  * </pre>
  *
  * @author Christoph Strobl
+ * @author Kim Sumin
  * @since 3.0
  * @see <a href="https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/">MongoDB Aggregation
  *      Framework: $addFields</a>
@@ -148,7 +149,7 @@ public class AddFieldsOperation extends DocumentEnhancingOperation {
 				@Override
 				public AddFieldsOperationBuilder withValueOf(Object value) {
 
-					valueMap.put(field, value instanceof String stringValue ? Fields.fields(stringValue) : value);
+					valueMap.put(field, value instanceof String stringValue ? Fields.field(stringValue) : value);
 					return AddFieldsOperationBuilder.this;
 				}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/AddFieldsOperationUnitTests.java
@@ -33,6 +33,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Kim Sumin
  */
 class AddFieldsOperationUnitTests {
 
@@ -126,6 +127,22 @@ class AddFieldsOperationUnitTests {
 		assertThat(fields.getField("computed")).isNotNull();
 		assertThat(fields.getField("does-not-exist")).isNull();
 	}
+
+	@Test // DATAMONGO-4933
+	void rendersStringValueAsFieldReferenceCorrectly() {
+
+		AddFieldsOperation operation = AddFieldsOperation.builder().addField("name").withValueOf("value").build();
+
+		assertThat(operation.toPipelineStages(contextFor(Scores.class)))
+				.containsExactly(Document.parse("{\"$addFields\" : {\"name\":\"$value\"}}"));
+
+		AddFieldsOperation mappedOperation = AddFieldsOperation.builder().addField("totalHomework").withValueOf("homework")
+				.build();
+
+		assertThat(mappedOperation.toPipelineStages(contextFor(ScoresWithMappedField.class)))
+				.containsExactly(Document.parse("{\"$addFields\" : {\"totalHomework\":\"$home_work\"}}"));
+	}
+
 
 	private static AggregationOperationContext contextFor(@Nullable Class<?> type) {
 


### PR DESCRIPTION
String values in MongoDB aggregation operations should be treated as field references, but the current implementation in `AddFieldsOperationBuilder` produces invalid MongoDB syntax. MongoDB expects field references in the format `$fieldName`, but the current code generates an incompatible complex object structure.