### PR TITLE
refactor: Loggers should be named for their enclosing classes

### DIFF
--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/event/LoggingEventListenerTests.java
@@ -45,7 +45,7 @@ public class LoggingEventListenerTests {
 		appender = new ListAppender<>();
 
 		// set log level for LoggingEventListener to "info" and set up an appender capturing events.
-		logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LoggingEventListener.class);
+		logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LoggingEventListenerTests.class);
 
 		logger.setAdditive(false);
 		logger.setLevel(Level.INFO);


### PR DESCRIPTION
Hope this helps :)

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass?organizationId=U3ByaW5n