### PR TITLE
Enable auto-startup for DefaultMessageListenerContainer

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/DefaultMessageListenerContainer.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/DefaultMessageListenerContainer.java
@@ -43,6 +43,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Junhyeok Lee
  * @since 2.1
  */
 public class DefaultMessageListenerContainer implements MessageListenerContainer {
@@ -62,6 +63,7 @@ public class DefaultMessageListenerContainer implements MessageListenerContainer
 	private final Lock subscriptionWrite = Lock.of(subscriptionMonitor.writeLock());
 
 	private boolean running = false;
+	private boolean autoStartup = true;
 
 	/**
 	 * Create a new {@link DefaultMessageListenerContainer}.
@@ -105,7 +107,16 @@ public class DefaultMessageListenerContainer implements MessageListenerContainer
 
 	@Override
 	public boolean isAutoStartup() {
-		return false;
+		return this.autoStartup;
+	}
+
+	/**
+	 * Set whether to auto-start this container.
+	 * <p>Default is {@code true}.
+	 * @param autoStartup {@code true} to auto-start.
+	 */
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/DefaultMessageListenerContainerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/DefaultMessageListenerContainerUnitTests.java
@@ -36,6 +36,7 @@ import org.springframework.util.ErrorHandler;
  * Unit tests for {@link DefaultMessageListenerContainer}.
  *
  * @author Christoph Strobl
+ * @author Junhyeok Lee
  */
 @ExtendWith(MockitoExtension.class)
 class DefaultMessageListenerContainerUnitTests {
@@ -78,6 +79,17 @@ class DefaultMessageListenerContainerUnitTests {
 	@Test // DATAMONGO-1803
 	void removeSubscriptionWhileRunning() throws Throwable {
 		runOnce(new RemoveSubscriptionWhileRunning(container));
+	}
+
+	@Test // GH-4403
+	void shouldHaveAutoStartupEnabledByDefault() {
+		assertThat(container.isAutoStartup()).isTrue();
+	}
+
+	@Test // GH-4403
+	void shouldAllowDisablingAutoStartup() {
+		container.setAutoStartup(false);
+		assertThat(container.isAutoStartup()).isFalse();
 	}
 
 	private static class RemoveSubscriptionWhileRunning extends MultithreadedTestCase {


### PR DESCRIPTION
This PR modifies `DefaultMessageListenerContainer` to enable auto-startup by default, allowing it to participate more fully in the Spring container-managed lifecycle.

Key changes:
* Introduced an `autoStartup` boolean property (defaulting to `true`), making `isAutoStartup()` return this value.
* A public setter `setAutoStartup(boolean)` allows users to disable this behavior if necessary.

Closes #4403

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
