### PR TITLE
Switch return type of UpdateDefinition#isIsolated to primitive

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MappedDocument.java
@@ -140,7 +140,7 @@ public class MappedDocument {
 		}
 
 		@Override
-		public Boolean isIsolated() {
+		public boolean isIsolated() {
 			return delegate.isIsolated();
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationUpdate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/AggregationUpdate.java
@@ -248,7 +248,7 @@ public class AggregationUpdate extends Aggregation implements UpdateDefinition {
 	}
 
 	@Override
-	public Boolean isIsolated() {
+	public boolean isIsolated() {
 		return isolated;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Update.java
@@ -444,7 +444,7 @@ public class Update implements UpdateDefinition {
 	}
 
 	@Override
-	public Boolean isIsolated() {
+	public boolean isIsolated() {
 		return isolated;
 	}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/UpdateDefinition.java
@@ -24,6 +24,7 @@ import org.bson.Document;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Hyunsang Han
  * @since 2.2
  */
 public interface UpdateDefinition {
@@ -34,7 +35,7 @@ public interface UpdateDefinition {
 	 *
 	 * @return {@literal true} if update isolated is set.
 	 */
-	Boolean isIsolated();
+	boolean isIsolated();
 
 	/**
 	 * @return the actual update in its native {@link Document} format. Never {@literal null}.


### PR DESCRIPTION
A simple contribution to change return type of `isIsolated` method.
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Resolves #4922
