### PR TITLE
Deprecate extended `$out` syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.x-GH-4969-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.x-GH-4969-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.x-GH-4969-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/OutOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/OutOperation.java
@@ -98,13 +98,15 @@ public class OutOperation implements AggregationOperation {
 	 * .uniqueKey("{ 'field-1' : 1, 'field-2' : 1}")
 	 * </pre>
 	 *
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @param key can be {@literal null}. Server uses {@literal _id} when {@literal null}.
 	 * @return new instance of {@link OutOperation}.
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("_ -> new")
+	@Deprecated
 	public OutOperation uniqueKey(@Nullable String key) {
 
 		Document uniqueKey = key == null ? null : BsonUtils.toDocumentOrElse(key, it -> new Document(it, 1));
@@ -123,13 +125,15 @@ public class OutOperation implements AggregationOperation {
 	 * .uniqueKeyOf(Arrays.asList("field-1", "field-2"))
 	 * </pre>
 	 *
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @param fields must not be {@literal null}.
 	 * @return new instance of {@link OutOperation}.
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("_ -> new")
+	@Deprecated
 	public OutOperation uniqueKeyOf(Iterable<String> fields) {
 
 		Assert.notNull(fields, "Fields must not be null");
@@ -142,13 +146,15 @@ public class OutOperation implements AggregationOperation {
 
 	/**
 	 * Specify how to merge the aggregation output with the target collection. <br />
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @param mode must not be {@literal null}.
 	 * @return new instance of {@link OutOperation}.
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("_ -> new")
+	@Deprecated
 	public OutOperation mode(OutMode mode) {
 
 		Assert.notNull(mode, "Mode must not be null");
@@ -157,39 +163,45 @@ public class OutOperation implements AggregationOperation {
 
 	/**
 	 * Replace the target collection. <br />
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @return new instance of {@link OutOperation}.
 	 * @see OutMode#REPLACE_COLLECTION
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("-> new")
+	@Deprecated
 	public OutOperation replaceCollection() {
 		return mode(OutMode.REPLACE_COLLECTION);
 	}
 
 	/**
 	 * Replace/Upsert documents in the target collection. <br />
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @return new instance of {@link OutOperation}.
 	 * @see OutMode#REPLACE
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("-> new")
+	@Deprecated
 	public OutOperation replaceDocuments() {
 		return mode(OutMode.REPLACE);
 	}
 
 	/**
 	 * Insert documents to the target collection. <br />
-	 * <strong>NOTE:</strong> Requires MongoDB 4.2 or later.
+	 * <strong>NOTE:</strong> Only suitable for 4.2+ to (not including) 5.0.
 	 *
 	 * @return new instance of {@link OutOperation}.
 	 * @see OutMode#INSERT
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
 	@Contract("-> new")
+	@Deprecated
 	public OutOperation insertDocuments() {
 		return mode(OutMode.INSERT);
 	}
@@ -198,7 +210,10 @@ public class OutOperation implements AggregationOperation {
 	public Document toDocument(AggregationOperationContext context) {
 
 		if (!requiresMongoDb42Format()) {
-			return new Document("$out", collectionName);
+			if (!StringUtils.hasText(databaseName)) {
+				return new Document(getOperator(), collectionName);
+			}
+			return new Document(getOperator(), new Document("db", databaseName).append("coll", collectionName));
 		}
 
 		Assert.state(mode != null, "Mode must not be null");
@@ -223,7 +238,7 @@ public class OutOperation implements AggregationOperation {
 	}
 
 	private boolean requiresMongoDb42Format() {
-		return StringUtils.hasText(databaseName) || mode != null || uniqueKey != null;
+		return mode != null || uniqueKey != null;
 	}
 
 	/**
@@ -231,7 +246,9 @@ public class OutOperation implements AggregationOperation {
 	 *
 	 * @author Christoph Strobl
 	 * @since 2.2
+	 * @deprecated no longer applicable for MongoDB 5+
 	 */
+	@Deprecated
 	public enum OutMode {
 
 		/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/OutOperationUnitTest.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/OutOperationUnitTest.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.data.mongodb.core.aggregation;
 
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
-import static org.springframework.data.mongodb.test.util.Assertions.*;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.out;
+import static org.springframework.data.mongodb.test.util.Assertions.assertThat;
+import static org.springframework.data.mongodb.test.util.Assertions.assertThatIllegalArgumentException;
 
 import java.util.Arrays;
 
@@ -84,11 +85,12 @@ public class OutOperationUnitTest {
 						.containsEntry("$out.uniqueKey", new Document("field-1", 1).append("field-2", 1));
 	}
 
-	@Test // DATAMONGO-2259
-	public void shouldErrorOnExtendedFormatWithoutMode() {
+	@Test // DATAMONGO-2259, GH-4969
+	public void shouldRenderNewExtendedFormatWithoutMode() {
 
-		assertThatThrownBy(() -> out("out-col").in("database-2").toDocument(Aggregation.DEFAULT_CONTEXT))
-				.isInstanceOf(IllegalStateException.class);
+		assertThat(out("out-col").in("database-2").toDocument(Aggregation.DEFAULT_CONTEXT))
+			.containsEntry("$out.coll", "out-col") //
+			.containsEntry("$out.db", "database-2");
 	}
 
 }


### PR DESCRIPTION
I think we should back port this change to the 4.5.x (potentially also 4.4.x) line.

Resolves: #4969 

