### PR TITLE
Always include Collection tag in MongoDB observations

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/DefaultMongoHandlerObservationConvention.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/DefaultMongoHandlerObservationConvention.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.observability;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 
 import org.springframework.data.mongodb.observability.MongoObservation.LowCardinalityCommandKeyNames;
@@ -63,6 +64,8 @@ class DefaultMongoHandlerObservationConvention implements MongoHandlerObservatio
 		if (!ObjectUtils.isEmpty(context.getCollectionName())) {
 			keyValues = keyValues
 					.and(LowCardinalityCommandKeyNames.MONGODB_COLLECTION.withValue(context.getCollectionName()));
+		} else {
+			keyValues = keyValues.and(LowCardinalityCommandKeyNames.MONGODB_COLLECTION.withValue(KeyValue.NONE_VALUE));
 		}
 
 		if(context.getCommandStartedEvent() == null) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -105,10 +105,6 @@ public class MongoObservationCommandListener implements CommandListener {
 			return; // don't instrument commands like "endSessions"
 		}
 
-		if ("hello".equals(event.getCommandName())) {
-			return; // don't instrument healthcheck
-		}
-
 		RequestContext requestContext = event.getRequestContext();
 
 		if (requestContext == null) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservationCommandListener.java
@@ -105,6 +105,10 @@ public class MongoObservationCommandListener implements CommandListener {
 			return; // don't instrument commands like "endSessions"
 		}
 
+		if ("hello".equals(event.getCommandName())) {
+			return; // don't instrument healthcheck
+		}
+
 		RequestContext requestContext = event.getRequestContext();
 
 		if (requestContext == null) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.Observation;
@@ -99,13 +100,17 @@ class MongoObservationCommandListenerTests {
 	}
 
 	@Test
-	void commandStartedShouldNotInstrumentWhenHello() {
+	void commandStartedShouldIncludeCollectionIfMissing() {
 
 		// when
 		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(), 0, 0, null, "some name", "hello", null));
 
 		// then
-		assertThat(meterRegistry).hasNoMetrics();
+		// although command 'hello' is collection-less, metric must have tag "db.mongodb.collection"
+		assertThat(meterRegistry).hasMeterWithNameAndTags(
+				"spring.data.mongodb.command.active",
+				Tags.of("db.mongodb.collection", "none"));
+
 	}
 
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/observability/MongoObservationCommandListenerTests.java
@@ -99,6 +99,16 @@ class MongoObservationCommandListenerTests {
 	}
 
 	@Test
+	void commandStartedShouldNotInstrumentWhenHello() {
+
+		// when
+		listener.commandStarted(new CommandStartedEvent(new MapRequestContext(), 0, 0, null, "some name", "hello", null));
+
+		// then
+		assertThat(meterRegistry).hasNoMetrics();
+	}
+
+	@Test
 	void successfullyCompletedCommandShouldCreateTimerWhenParentSampleInRequestContext() {
 
 		// given


### PR DESCRIPTION
When MongoObservationCommandListener is enabled according to documentation, there is a race in metrics registration:

> The meter (MeterId{name='spring.data.mongodb.command.active', tags=[tag(db.name=test),tag(db.operation=hello),tag(db.system=mongodb),tag(net.peer.name=localhost),tag(net.peer.port=27017),tag(net.transport=IP.TCP),tag(spring.data.mongodb.cluster_id=6840b93dabcd29b2f0526362)]}) registration has failed: ...

Prometheus does not allow register metric with different tags. The problem is that healthcheck calls Mongo command "hello" which does not refer to any collection. Consequently, tag "db.mongodb.collection" is absent for "hello" but present in regular commands.

Event if regular commands always wins the race (and metrics always has tag "collection"), the race must be removed.

My proposal is skip "hello" instrumentation, like "admin" commands

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
