### PR TITLE
Provide fallback for Observation KeyValues

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/observability/MongoObservation.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.data.mongodb.observability;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.docs.ObservationDocumentation;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.ObjectUtils;
 
 /**
  * A MongoDB-based {@link io.micrometer.observation.Observation}.
@@ -172,6 +175,15 @@ enum MongoObservation implements ObservationDocumentation {
 			public String asString() {
 				return "db.operation";
 			}
+		};
+
+		/**
+		 * Creates a key value for the given key name.
+		 * @param value value for key, if value is null or empty {@link KeyValue.NONE_VALUE} will be used
+		 * @return key value
+		 */
+		public KeyValue withOptionalValue(@Nullable String value) {
+			return withValue(ObjectUtils.isEmpty(value) ? KeyValue.NONE_VALUE : value);
 		}
 	}
 


### PR DESCRIPTION
Similarly to https://github.com/spring-projects/spring-data-mongodb/pull/4994 this PR adds a fallback value to all the `KeyValue`s used by `DefaultMongoHandlerObservationConvention`.

TODO:
- [ ] Read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc)
- [ ] Use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide)
- [ ] Add test cases
- [ ] Added myself as author in the headers of the classes I touched
