### PR TITLE
Polish: fix grammar in mongo-encryption.adoc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
@@ -24,7 +24,7 @@ Automatic Encryption requires a xref:mongodb/mapping/mapping-schema.adoc[JSON Sc
 
 Please refer to the xref:mongodb/mapping/mapping-schema.adoc#mongo.jsonSchema.encrypted-fields[JSON Schema] section for more information on defining a JSON Schema that holds encryption information.
 
-To make use of a the `MongoJsonSchema` it needs to be combined with `AutoEncryptionSettings` which can be done eg. via a `MongoClientSettingsBuilderCustomizer`.
+To use a `MongoJsonSchema`, you must supply it together with `AutoEncryptionSettings` which can be done eg. via a `MongoClientSettingsBuilderCustomizer`.
 
 [source,java]
 ----


### PR DESCRIPTION
Polish – Fix grammar mongo-encryption documentation

**What & Why**:

This PR polishes the mongo-encryption documentation by fixing a grammatical glitch (“a the MongoJsonSchema”) and rephrasing the usage sentence for clarity and consistency with Spring Data documentation style.

**Changes:**

- Replaced grammar error `"a the MongoJsonSchema"`→ `"a MongoJsonSchema."`

- Re‑worded sentence to:  

>To use a `MongoJsonSchema`, you must supply it together with `AutoEncryptionSettings` which can be done eg. via a `MongoClientSettingsBuilderCustomizer`.


**Impact:**

- Docs‑only; no functional or API changes.

**Verification:**

- ./mvnw clean verify completes without errors (including spring-javaformat:validate).
- Generated Javadoc renders correctly.

**Checklist:**

- [x]  ./mvnw clean verify locally.

 No tests or source files were affected other than the Javadoc.