### PR TITLE
Minor markdown bold syntax fix in the mongo encryption doc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
@@ -146,7 +146,7 @@ It's useful when you need to explicitly manage data keys, encryption algorithms,
 ** ✅ Explicit configuration avoids the risk of surprises (e.g. missing configuration because of improper annotations or class-path scanning)
 ** ⚠️ An Explicit Field Configuration can diverge from the domain model and you must keep it in sync with the domain model
 
-**Derived setup*
+**Derived setup**
 
 Derived setup relies on annotations in your domain model and automatically generates the required encrypted field configuration from it.
 This is simpler and recommended for typical Spring applications where your data model is already annotated.


### PR DESCRIPTION
Minor markdown bold syntax fix in the mongo encryption doc

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
