### PR TITLE
Require explicit representation configuration for `UUID`, `BigDecimal`, and `BigInteger`

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoConfigurationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/MongoConfigurationSupport.java
@@ -46,6 +46,7 @@ import com.mongodb.MongoClientSettings.Builder;
  * Base class for Spring Data MongoDB to be extended for JavaConfiguration usage.
  *
  * @author Mark Paluch
+ * @author Hyunsang Han
  * @since 2.0
  */
 public abstract class MongoConfigurationSupport {
@@ -226,9 +227,15 @@ public abstract class MongoConfigurationSupport {
 	protected MongoClientSettings mongoClientSettings() {
 
 		MongoClientSettings.Builder builder = MongoClientSettings.builder();
-		builder.uuidRepresentation(UuidRepresentation.STANDARD);
 		configureClientSettings(builder);
-		return builder.build();
+		
+		MongoClientSettings settings = builder.build();
+		
+		if (settings.getUuidRepresentation() == null) {
+			throw new IllegalStateException("UUID representation must be explicitly configured.");
+		}
+		
+		return settings;
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientFactoryBean.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoClientFactoryBean.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.bson.UuidRepresentation;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.dao.DataAccessException;
@@ -52,6 +51,7 @@ import com.mongodb.event.ClusterListener;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Hyunsang Han
  */
 public class MongoClientFactoryBean extends AbstractFactoryBean<MongoClient> implements PersistenceExceptionTranslator {
 
@@ -162,7 +162,6 @@ public class MongoClientFactoryBean extends AbstractFactoryBean<MongoClient> imp
 						getOrDefault(port, "" + ServerAddress.defaultPort())));
 
 		Builder builder = MongoClientSettings.builder().applyConnectionString(connectionString);
-		builder.uuidRepresentation(UuidRepresentation.STANDARD);
 
 		if (mongoClientSettings != null) {
 
@@ -305,7 +304,13 @@ public class MongoClientFactoryBean extends AbstractFactoryBean<MongoClient> imp
 			});
 		}
 
-		return builder.build();
+		MongoClientSettings settings = builder.build();
+		
+		if (settings.getUuidRepresentation() == null) {
+			throw new IllegalStateException("UUID representation must be explicitly configured.");
+		}
+		
+		return settings;
 	}
 
 	private <T> void applySettings(Consumer<T> settingsBuilder, @Nullable T value) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoCustomConversions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoCustomConversions.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Hyunsang Han
  * @since 2.0
  * @see org.springframework.data.convert.CustomConversions
  * @see org.springframework.data.mapping.model.SimpleTypeHolder
@@ -159,7 +160,7 @@ public class MongoCustomConversions extends org.springframework.data.convert.Cus
 		private static final Set<Class<?>> JAVA_DRIVER_TIME_SIMPLE_TYPES = Set.of(LocalDate.class, LocalTime.class, LocalDateTime.class);
 
 		private boolean useNativeDriverJavaTimeCodecs = false;
-		private BigDecimalRepresentation bigDecimals = BigDecimalRepresentation.DECIMAL128;
+		private @Nullable BigDecimalRepresentation bigDecimals;
 		private final List<Object> customConverters = new ArrayList<>();
 
 		private final PropertyValueConversions internalValueConversion = PropertyValueConversions.simple(it -> {});
@@ -313,8 +314,8 @@ public class MongoCustomConversions extends org.springframework.data.convert.Cus
 		}
 
 		/**
-		 * Configures the representation to for {@link java.math.BigDecimal} and {@link java.math.BigInteger} values in
-		 * MongoDB. Defaults to {@link BigDecimalRepresentation#DECIMAL128}.
+		 * Configures the representation for {@link java.math.BigDecimal} and {@link java.math.BigInteger} values in
+		 * MongoDB. This configuration is required and must be explicitly set.
 		 *
 		 * @param representation the representation to use.
 		 * @return this.
@@ -373,6 +374,10 @@ public class MongoCustomConversions extends org.springframework.data.convert.Cus
 			if (hasDefaultPropertyValueConversions()
 					&& propertyValueConversions instanceof SimplePropertyValueConversions svc) {
 				svc.init();
+			}
+
+			if (bigDecimals == null) {
+				throw new IllegalStateException("BigDecimal representation must be explicitly configured.");
 			}
 
 			List<Object> converters = new ArrayList<>(STORE_CONVERTERS.size() + 7);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoClientFactoryBeanUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoClientFactoryBeanUnitTests.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import org.bson.UuidRepresentation;
+
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
@@ -29,6 +31,7 @@ import com.mongodb.ServerAddress;
  * Unit tests for {@link MongoClientFactoryBean}.
  *
  * @author Christoph Strobl
+ * @author Hyunsang Han
  */
 class MongoClientFactoryBeanUnitTests {
 
@@ -88,5 +91,27 @@ class MongoClientFactoryBeanUnitTests {
 		factoryBean.setHost("localhost");
 		factoryBean.setPort(27017);
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(factoryBean::createInstance);
+	}
+
+	@Test // GH-5037
+	void requiresExplicitUuidRepresentationConfiguration() {
+
+		MongoClientFactoryBean factoryBean = new MongoClientFactoryBean();
+		
+		assertThatThrownBy(factoryBean::computeClientSetting)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("UUID representation must be explicitly configured");
+	}
+
+	@Test // GH-5037
+	void worksWithExplicitUuidRepresentationConfiguration() {
+
+		MongoClientFactoryBean factoryBean = new MongoClientFactoryBean();
+		factoryBean.setMongoClientSettings(
+				MongoClientSettings.builder().uuidRepresentation(UuidRepresentation.STANDARD).build());
+
+		MongoClientSettings settings = factoryBean.computeClientSetting();
+
+		assertThat(settings.getUuidRepresentation()).isEqualTo(UuidRepresentation.STANDARD);
 	}
 }


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

Remove implicit defaults for UUID, BigDecimal, and BigInteger representations to force explicit configuration.
- `MongoConfigurationSupport`: Require explicit `UuidRepresentation` configuration in `mongoClientSettings()`
- `MongoClientFactoryBean`: Require explicit `UuidRepresentation` configuration in `computeClientSetting()`
- `MongoCustomConversions`: Require explicit `BigDecimalRepresentation` configuration (covers both BigDecimal and BigInteger)

Resolves: #5037 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
