### PR TITLE
Fix BucketOperationSupport _id field exposure.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/BucketOperationSupport.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/BucketOperationSupport.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Amine Jaoui
  * @since 1.10
  */
 public abstract class BucketOperationSupport<T extends BucketOperationSupport<T, B>, B extends OutputBuilder<B, T>>
@@ -421,12 +422,13 @@ public abstract class BucketOperationSupport<T extends BucketOperationSupport<T,
 		 */
 		protected ExposedFields asExposedFields() {
 
+			// The _id is always present after the bucket operation
+			ExposedFields fields = ExposedFields.from(new ExposedField(Fields.UNDERSCORE_ID, true));
 			// The count field is included by default when the output is not specified.
 			if (isEmpty()) {
-				return ExposedFields.from(new ExposedField("count", true));
+				fields = fields.and(new ExposedField("count", true));
 			}
 
-			ExposedFields fields = ExposedFields.from();
 
 			for (Output output : outputs) {
 				fields = fields.and(output.getExposedField());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperation.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Amine Jaoui
  * @since 1.3
  * @see <a href="https://docs.mongodb.com/manual/reference/operator/aggregation/project/">MongoDB Aggregation Framework:
  *      $project</a>
@@ -1402,14 +1403,6 @@ public class ProjectionOperation implements FieldsExposingAggregationOperation {
 
 					if (SystemVariable.isReferingToSystemVariable(field.getTarget())) {
 						return field.getTarget();
-					}
-
-					if (field.getTarget().equals(Fields.UNDERSCORE_ID)) {
-						try {
-							return context.getReference(field).getReferenceValue();
-						} catch (java.lang.IllegalArgumentException e) {
-							return Fields.UNDERSCORE_ID_REF;
-						}
 					}
 
 					// check whether referenced field exists in the context


### PR DESCRIPTION
Expose _id field in BucketOperation and BucketAutoOperation to match MongoDB behavior.



MongoDB's $bucket operation always generates _id field with bucket boundaries,
  but BucketOperation.getFields() only exposed output fields like 'count'.
  This caused IllegalArgumentException when subsequent operations referenced _id.

  - Modified BucketOperationSupport.asExposedFields() to always expose _id
  - Removed defensive fallback in ProjectionOperation that masked the issue
  - Updated and added comprehensive tests for both scenarios
  - Added integration test proving bucket + addFields now works

Closes #5046

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
