### PR TITLE
Add support for property placeholder in expireAfter for MongoDB indexes

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/spel/ExpressionUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/util/spel/ExpressionUtils.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.util.spel;
 import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.expression.ValueEvaluationContext;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParserContext;
@@ -52,7 +53,7 @@ public final class ExpressionUtils {
 		return expression instanceof LiteralExpression ? null : expression;
 	}
 
-	public static @Nullable Object evaluate(String value, Supplier<EvaluationContext> evaluationContext) {
+	public static @Nullable Object evaluate(String value, Supplier<ValueEvaluationContext> evaluationContext) {
 
 		Expression expression = detectExpression(value);
 		if (expression == null) {


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

Enables property placeholder resolution (e.g., ${ttl.timeout}) in the `@Indexed(expireAfter)` attribute by replacing EvaluationContext with ValueEvaluationContext throughout the index resolution pipeline.

- `MongoPersistentEntityIndexResolver` : Updated to use ValueEvaluationContext instead of EvaluationContext for evaluating index expressions
- `ExpressionUtils` : Modified evaluate method signature to accept Supplier<ValueEvaluationContext> to support property placeholder resolution

Resolves : https://github.com/spring-projects/spring-data-mongodb/issues/4980

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
