### PR TITLE
Invoke PropertyValueConverter only for matching types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.0-4346-property-value-convert-cce-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.0-4346-property-value-convert-cce-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>5.0.0-4346-property-value-convert-cce-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -3315,6 +3315,21 @@ class MappingMongoConverterUnitTests {
 		assertThat(read.converterEnum).isEqualTo("spring");
 	}
 
+	@Test // GH-4346
+	void nullConverter() {
+
+		WithValueConverters wvc = new WithValueConverters();
+		wvc.nullConverter = null;
+
+		org.bson.Document target = new org.bson.Document();
+		converter.write(wvc, target);
+
+		assertThat(target).containsEntry("nullConverter", "W");
+
+		WithValueConverters read = converter.read(WithValueConverters.class, org.bson.Document.parse("{ nullConverter : null}"));
+		assertThat(read.nullConverter).isEqualTo("R");
+	}
+
 	@Test // GH-3596
 	void beanConverter() {
 
@@ -3357,12 +3372,12 @@ class MappingMongoConverterUnitTests {
 						new PropertyValueConverter<String, org.bson.Document, MongoConversionContext>() {
 
 							@Override
-							public @Nullable String read(org.bson.@Nullable Document nativeValue, MongoConversionContext context) {
+							public @Nullable String read(org.bson.Document nativeValue, MongoConversionContext context) {
 								return nativeValue.getString("bar");
 							}
 
 							@Override
-							public org.bson.@Nullable Document write(@Nullable String domainValue, MongoConversionContext context) {
+							public org.bson.Document write(String domainValue, MongoConversionContext context) {
 								return new org.bson.Document("bar", domainValue);
 							}
 						});
@@ -4614,6 +4629,8 @@ class MappingMongoConverterUnitTests {
 		@ValueConverter(Converter1.class) String converterWithDefaultCtor;
 
 		@ValueConverter(Converter2.class) String converterEnum;
+
+		@ValueConverter(NullReplacingValueConverter.class) String nullConverter;
 
 		String viaRegisteredConverter;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/NullReplacingValueConverter.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/NullReplacingValueConverter.java
@@ -18,23 +18,27 @@ package org.springframework.data.mongodb.core.convert;
 import org.jspecify.annotations.Nullable;
 
 /**
- * @author Christoph Strobl
+ * @author Jens Schauder
  */
-class ReversingValueConverter implements MongoValueConverter<String, String> {
+class NullReplacingValueConverter implements MongoValueConverter<String, String> {
 
-	@Nullable
 	@Override
-	public String read(String value, MongoConversionContext context) {
-		return reverse(value);
+	public @Nullable String read(String value, MongoConversionContext context) {
+		return value;
 	}
 
-	@Nullable
 	@Override
-	public String write(String value, MongoConversionContext context) {
-		return reverse(value);
+	public @Nullable String readNull(MongoConversionContext context) {
+		return "R";
 	}
 
-	private String reverse(String source) {
-		return new StringBuilder(source).reverse().toString();
+	@Override
+	public @Nullable String write(String value, MongoConversionContext context) {
+		return value;
+	}
+
+	@Override
+	public @Nullable String writeNull(MongoConversionContext context) {
+		return "W";
 	}
 }


### PR DESCRIPTION
When the type does not match we simply use the unconverted value.
This happens when comparing properties to regexes.
Applying the conversion to the String value of the regex doesn't makes sense since we are not dealing with complete values.

Users may still provide converters taking Objects and mangle Regex patterns as they desire.

Also fixed the null handling of PropertyValueConverters.

Removed a few superfluous `@Nullable` annotations where they became obvious

Closes https://github.com/spring-projects/spring-data-mongodb/issues/4346