### PR TITLE
Support showExpandedEvents in change streams.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamOptions.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ChangeStreamOptions.java
@@ -53,6 +53,7 @@ public class ChangeStreamOptions {
 	private @Nullable FullDocumentBeforeChange fullDocumentBeforeChangeLookup;
 	private @Nullable Collation collation;
 	private @Nullable Object resumeTimestamp;
+	private @Nullable Boolean showExpandedEvents;
 	private Resume resume = Resume.UNDEFINED;
 
 	protected ChangeStreamOptions() {}
@@ -106,6 +107,13 @@ public class ChangeStreamOptions {
 	 */
 	public Optional<BsonTimestamp> getResumeBsonTimestamp() {
 		return Optional.ofNullable(resumeTimestamp).map(timestamp -> asTimestampOfType(timestamp, BsonTimestamp.class));
+	}
+
+	/**
+	 * @return {@link Optional#empty()} if not set.
+	 */
+	public Optional<Boolean> getShowExpandedEvents() {
+		return Optional.ofNullable(showExpandedEvents);
 	}
 
 	/**
@@ -191,6 +199,9 @@ public class ChangeStreamOptions {
 		if (!ObjectUtils.nullSafeEquals(this.resumeTimestamp, that.resumeTimestamp)) {
 			return false;
 		}
+		if (!ObjectUtils.nullSafeEquals(this.showExpandedEvents, that.showExpandedEvents)) {
+			return false;
+		}
 		return resume == that.resume;
 	}
 
@@ -202,6 +213,7 @@ public class ChangeStreamOptions {
 		result = 31 * result + ObjectUtils.nullSafeHashCode(fullDocumentBeforeChangeLookup);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(collation);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(resumeTimestamp);
+		result = 31 * result + ObjectUtils.nullSafeHashCode(showExpandedEvents);
 		result = 31 * result + ObjectUtils.nullSafeHashCode(resume);
 		return result;
 	}
@@ -239,6 +251,7 @@ public class ChangeStreamOptions {
 		private @Nullable FullDocumentBeforeChange fullDocumentBeforeChangeLookup;
 		private @Nullable Collation collation;
 		private @Nullable Object resumeTimestamp;
+		private @Nullable Boolean showExpandedEvents;
 		private Resume resume = Resume.UNDEFINED;
 
 		private ChangeStreamOptionsBuilder() {}
@@ -433,6 +446,19 @@ public class ChangeStreamOptions {
 		}
 
 		/**
+		 * Set whether expanded change events (e.g. createIndexes, shardCollection) should be emitted.
+		 *
+		 * @param showExpandedEvents {@code true} to include expanded events.
+		 * @return this.
+		 */
+		@Contract("_ -> this")
+		public ChangeStreamOptionsBuilder showExpandedEvents(boolean showExpandedEvents) {
+
+			this.showExpandedEvents = showExpandedEvents;
+			return this;
+		}
+
+		/**
 		 * @return the built {@link ChangeStreamOptions}
 		 */
 		@Contract("-> new")
@@ -446,6 +472,7 @@ public class ChangeStreamOptions {
 			options.fullDocumentBeforeChangeLookup = this.fullDocumentBeforeChangeLookup;
 			options.collation = this.collation;
 			options.resumeTimestamp = this.resumeTimestamp;
+			options.showExpandedEvents = this.showExpandedEvents;
 			options.resume = this.resume;
 
 			return options;

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -2148,6 +2148,7 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 					publisher = options.getCollation().map(Collation::toMongoCollation).map(publisher::collation)
 							.orElse(publisher);
 					publisher = options.getResumeBsonTimestamp().map(publisher::startAtOperationTime).orElse(publisher);
+					publisher = options.getShowExpandedEvents().map(publisher::showExpandedEvents).orElse(publisher);
 
 					if (options.getFullDocumentBeforeChangeLookup().isPresent()) {
 						publisher = publisher.fullDocumentBeforeChange(options.getFullDocumentBeforeChangeLookup().get());

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamRequest.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamRequest.java
@@ -243,6 +243,7 @@ public class ChangeStreamRequest<T>
 		private @Nullable String databaseName;
 		private @Nullable String collectionName;
 		private @Nullable Duration maxAwaitTime;
+		private @Nullable Boolean showExpandedEvents;
 		private @Nullable MessageListener<ChangeStreamDocument<Document>, ? super T> listener;
 		private final ChangeStreamOptionsBuilder delegate = ChangeStreamOptions.builder();
 
@@ -467,6 +468,20 @@ public class ChangeStreamRequest<T>
 			Assert.notNull(timeout, "timeout not be null");
 
 			this.maxAwaitTime = timeout;
+			return this;
+		}
+
+		/**
+		 * Set whether expanded change events (e.g. createIndexes, shardCollection) should be emitted.
+		 *
+		 * @param showExpandedEvents {@code true} to include expanded events.
+		 * @return this.
+		 */
+		@Contract("_ -> this")
+		public ChangeStreamRequestBuilder<T> showExpandedEvents(boolean showExpandedEvents) {
+
+			this.showExpandedEvents = showExpandedEvents;
+			this.delegate.showExpandedEvents(showExpandedEvents);
 			return this;
 		}
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTask.java
@@ -90,6 +90,7 @@ class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>,
 		FullDocumentBeforeChange fullDocumentBeforeChange = null;
 		BsonTimestamp startAt = null;
 		boolean resumeAfter = true;
+		boolean showExpandedEvents = false;
 
 		if (options instanceof ChangeStreamRequest.ChangeStreamRequestOptions requestOptions) {
 
@@ -103,6 +104,10 @@ class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>,
 					collation = aggregation.getOptions().getCollation()
 							.map(org.springframework.data.mongodb.core.query.Collation::toMongoCollation).orElse(null);
 				}
+			}
+
+			if (changeStreamOptions.getShowExpandedEvents().isPresent()) {
+				showExpandedEvents = changeStreamOptions.getShowExpandedEvents().get();
 			}
 
 			if (changeStreamOptions.getResumeToken().isPresent()) {
@@ -153,6 +158,10 @@ class ChangeStreamTask extends CursorReadingTask<ChangeStreamDocument<Document>,
 
 		if (collation != null) {
 			iterable = iterable.collation(collation);
+		}
+
+		if (showExpandedEvents) {
+			iterable = iterable.showExpandedEvents(showExpandedEvents);
 		}
 
 		iterable = iterable.fullDocument(fullDocument);

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ChangeStreamOptionsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ChangeStreamOptionsUnitTests.java
@@ -53,4 +53,12 @@ public class ChangeStreamOptionsUnitTests {
 		assertThat(options.isResumeAfter()).isFalse();
 		assertThat(options.isStartAfter()).isFalse();
 	}
+
+	@Test // GH-5069
+	void shouldStoreShowExpandedEvents() {
+
+		ChangeStreamOptions options = ChangeStreamOptions.builder().showExpandedEvents(true).build();
+
+		assertThat(options.getShowExpandedEvents()).isPresent().hasValue(true);
+	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateUnitTests.java
@@ -1668,6 +1668,21 @@ public class ReactiveMongoTemplateUnitTests {
 
 	}
 
+	@Test // GH-5069
+	void changeStreamOptionShowExpandedEventsShouldBeApplied() {
+
+		when(factory.getMongoDatabase(anyString())).thenReturn(Mono.just(db));
+		when(collection.watch(any(Class.class))).thenReturn(changeStreamPublisher);
+		when(changeStreamPublisher.showExpandedEvents(anyBoolean())).thenReturn(changeStreamPublisher);
+		when(changeStreamPublisher.fullDocument(any())).thenReturn(changeStreamPublisher);
+
+		ChangeStreamOptions options = ChangeStreamOptions.builder()
+				.showExpandedEvents(true).build();
+		template.changeStream("database", "collection", options, Object.class).subscribe();
+
+		verify(changeStreamPublisher).showExpandedEvents(true);
+	}
+
 	@Test // GH-4462
 	void replaceShouldUseCollationWhenPresent() {
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTaskUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/ChangeStreamTaskUnitTests.java
@@ -140,6 +140,22 @@ class ChangeStreamTaskUnitTests {
 		verify(changeStreamIterable).fullDocumentBeforeChange(FullDocumentBeforeChange.REQUIRED);
 	}
 
+	@Test // GH-5069
+	void shouldApplyShowExpandedEventsToChangeStream() {
+		
+		when(changeStreamIterable.showExpandedEvents(true)).thenReturn(changeStreamIterable);
+
+		ChangeStreamRequest request = ChangeStreamRequest.builder() //
+				.collection("start-wars") //
+				.showExpandedEvents(true) //
+				.publishTo(message -> {}) //
+				.build();
+		
+		initTask(request, Document.class);
+
+		verify(changeStreamIterable).showExpandedEvents(true);
+	}
+
 	private MongoCursor<ChangeStreamDocument<Document>> initTask(ChangeStreamRequest request, Class<?> targetType) {
 
 		ChangeStreamTask task = new ChangeStreamTask(template, request, targetType, er -> {});


### PR DESCRIPTION
Expose showExpandedEvents in ChangeStreamOptions and propagate to sync/reactive change streams so expanded events can be consumed.

Closes #5069
Signed-off-by: Kyuhong Han roy0424@naver.com

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
