### PR TITLE
docs: fix invalid Indexed algorithm in encryption example

### DIFF
--- a/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
+++ b/src/main/antora/modules/ROOT/pages/mongodb/mongo-encryption.adoc
@@ -195,7 +195,11 @@ class Patient {
     @Encrypted(algorithm = "Unindexed")
     String pin;           <2>
 
-    @Encrypted(algorithm = "Indexed")
+
+// NOTE: "Indexed" is not a valid value for @Encrypted.algorithm.
+// Queryable Encryption indexing is controlled via @Queryable / @RangeEncrypted.
+
+    @Encrypted
     @Queryable(queryType = "equality", contentionFactor = 0)
     String ssn;           <3>
 


### PR DESCRIPTION
Fixes documentation inconsistency where @Encrypted(algorithm = "Indexed") was shown as a valid option.

"Indexed" is not a valid value for @Encrypted.algorithm.
Queryable encryption indexing is controlled via @Queryable and @RangeEncrypted.

This change updates the example and adds clarification to prevent runtime errors.
