### PR TITLE
Support `IsEmpty` and `IsNotEmpty` keywords in derived queries

### DIFF
--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/AbstractPersonRepositoryIntegrationTests.java
@@ -26,8 +26,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -93,6 +95,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Mark Paluch
  * @author Fırat KÜÇÜK
  * @author Edward Prentice
+ * @author Junhyeong Choi
  */
 @ExtendWith({ SpringExtension.class, DirtiesStateExtension.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -1829,5 +1832,118 @@ public abstract class AbstractPersonRepositoryIntegrationTests implements Dirtie
 		assertThat(repository.findAndPushShippingAddressByEmail(dave.getEmail(), address)).isEqualTo(1);
 		assertThat(repository.findById(dave.getId()).map(Person::getShippingAddresses))
 				.contains(Collections.singleton(address));
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsByFirstnameIsEmpty() {
+
+		Person emptyFirstname = new Person("", "EmptyFirstname");
+		repository.save(emptyFirstname);
+
+		List<Person> result = repository.findByFirstnameIsEmpty();
+
+		assertThat(result).hasSize(1).contains(emptyFirstname);
+	}
+
+	@Test // GH-4606
+	void findsByFirstnameIsNotEmpty() {
+
+		List<Person> result = repository.findByFirstnameIsNotEmpty();
+
+		assertThat(result).hasSize(all.size()).containsAll(all);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void blankStringIsNotConsideredEmpty() {
+
+		Person blankFirstname = new Person("   ", "BlankFirstname");
+		repository.save(blankFirstname);
+
+		List<Person> emptyResult = repository.findByFirstnameIsEmpty();
+		List<Person> notEmptyResult = repository.findByFirstnameIsNotEmpty();
+
+		assertThat(emptyResult).doesNotContain(blankFirstname);
+		assertThat(notEmptyResult).contains(blankFirstname);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsBySkillsIsEmpty() {
+
+		Person emptySkills = new Person("Empty", "Skills");
+		emptySkills.setSkills(Collections.emptyList());
+		repository.save(emptySkills);
+
+		List<Person> result = repository.findBySkillsIsEmpty();
+
+		assertThat(result).contains(emptySkills).doesNotContain(carter, boyd);
+	}
+
+	@Test // GH-4606
+	void findsBySkillsIsNotEmpty() {
+
+		List<Person> result = repository.findBySkillsIsNotEmpty();
+
+		assertThat(result).contains(carter, boyd);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsByAddressIsEmpty() {
+
+		Person emptyAddress = new Person("Empty", "Address");
+		emptyAddress.setAddress(new Address());
+		repository.save(emptyAddress);
+
+		dave.setAddress(new Address("street", "zip", "city"));
+		repository.save(dave);
+
+		List<Person> result = repository.findByAddressIsEmpty();
+
+		assertThat(result).contains(emptyAddress).doesNotContain(dave);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsByAddressIsNotEmpty() {
+
+		dave.setAddress(new Address("street", "zip", "city"));
+		repository.save(dave);
+
+		List<Person> result = repository.findByAddressIsNotEmpty();
+
+		assertThat(result).contains(dave);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsByMetadataIsEmpty() {
+
+		dave.setMetadata(new HashMap<>());
+		repository.save(dave);
+
+		oliver.setMetadata(Map.of("key", "value"));
+		repository.save(oliver);
+
+		List<Person> result = repository.findByMetadataIsEmpty();
+
+		assertThat(result).contains(dave).doesNotContain(oliver);
+	}
+
+	@Test // GH-4606
+	@DirtiesState
+	void findsByMetadataIsNotEmpty() {
+
+		dave.setMetadata(new HashMap<>());
+		repository.save(dave);
+
+		oliver.setMetadata(Map.of("key", "value"));
+		repository.save(oliver);
+
+		List<Person> result = repository.findByMetadataIsNotEmpty();
+
+		assertThat(result).contains(oliver).doesNotContain(dave);
 	}
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/Person.java
@@ -18,6 +18,7 @@ package org.springframework.data.mongodb.repository;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,6 +40,7 @@ import org.springframework.data.mongodb.core.mapping.Unwrapped;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Junhyeong Choi
  */
 @Document
 public class Person extends Contact {
@@ -80,6 +82,8 @@ public class Person extends Contact {
 	@DocumentReference(lazy = true) User lazySpiritAnimal;
 
 	int visits;
+
+	Map<String, String> metadata;
 
 	public Person() {
 
@@ -332,6 +336,14 @@ public class Person extends Contact {
 
 	public void setLazySpiritAnimal(User lazySpiritAnimal) {
 		this.lazySpiritAnimal = lazySpiritAnimal;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/PersonRepository.java
@@ -56,6 +56,7 @@ import org.springframework.data.util.Streamable;
  * @author Christoph Strobl
  * @author Fırat KÜÇÜK
  * @author Mark Paluch
+ * @author Junhyeong Choi
  */
 public interface PersonRepository extends MongoRepository<Person, String>, QuerydslPredicateExecutor<Person> {
 
@@ -509,6 +510,30 @@ public interface PersonRepository extends MongoRepository<Person, String>, Query
 	Person findByQueryWithNullEqualityCheck();
 
 	List<Person> findBySpiritAnimal(User user);
+
+	// GH-4606
+	List<Person> findByFirstnameIsEmpty();
+
+	// GH-4606
+	List<Person> findByFirstnameIsNotEmpty();
+
+	// GH-4606
+	List<Person> findBySkillsIsEmpty();
+
+	// GH-4606
+	List<Person> findBySkillsIsNotEmpty();
+
+	// GH-4606
+	List<Person> findByAddressIsEmpty();
+
+	// GH-4606
+	List<Person> findByAddressIsNotEmpty();
+
+	// GH-4606
+	List<Person> findByMetadataIsEmpty();
+
+	// GH-4606
+	List<Person> findByMetadataIsNotEmpty();
 
 	class Persons implements Streamable<Person> {
 


### PR DESCRIPTION
Add support for `IsEmpty` and `IsNotEmpty` repository query keywords in derived queries.

## Why
The documentation lists `IsEmpty` as a supported keyword, but it throws 
"Unsupported keyword" exception when used.

## Changes
- Add `IS_EMPTY` and `IS_NOT_EMPTY` case handling in `MongoQueryCreator.from()`
- Add `createIsEmptyCriteria()` and `createIsNotEmptyCriteria()` methods
- String properties: `{ field: { $eq: "" } }` / `{ field: { $ne: "" } }`
- Collection properties: `{ field: { $size: 0 } }` / `{ field: { $not: { $size: 0 } } }`

Resolves #4606