### PR TITLE
Widen operator method parameters from Criteria to CriteriaDefinition

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/Criteria.java
@@ -842,7 +842,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @return this.
 	 */
 	@Contract("_ -> this")
-	public Criteria orOperator(Criteria... criteria) {
+	public Criteria orOperator(CriteriaDefinition... criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -860,7 +860,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @since 3.2
 	 */
 	@Contract("_ -> this")
-	public Criteria orOperator(Collection<Criteria> criteria) {
+	public Criteria orOperator(Collection<? extends CriteriaDefinition> criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -878,7 +878,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @return this.
 	 */
 	@Contract("_ -> this")
-	public Criteria norOperator(Criteria... criteria) {
+	public Criteria norOperator(CriteriaDefinition... criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -896,7 +896,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @since 3.2
 	 */
 	@Contract("_ -> this")
-	public Criteria norOperator(Collection<Criteria> criteria) {
+	public Criteria norOperator(Collection<? extends CriteriaDefinition> criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -914,7 +914,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @return this.
 	 */
 	@Contract("_ -> this")
-	public Criteria andOperator(Criteria... criteria) {
+	public Criteria andOperator(CriteriaDefinition... criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -932,7 +932,7 @@ public class Criteria implements CriteriaDefinition {
 	 * @since 3.2
 	 */
 	@Contract("_ -> this")
-	public Criteria andOperator(Collection<Criteria> criteria) {
+	public Criteria andOperator(Collection<? extends CriteriaDefinition> criteria) {
 
 		Assert.notNull(criteria, "Criteria must not be null");
 
@@ -1048,9 +1048,9 @@ public class Criteria implements CriteriaDefinition {
 		return queryCriteria;
 	}
 
-	private BasicDBList createCriteriaList(Collection<Criteria> criteria) {
+	private BasicDBList createCriteriaList(Collection<? extends CriteriaDefinition> criteria) {
 		BasicDBList bsonList = new BasicDBList();
-		for (Criteria c : criteria) {
+		for (CriteriaDefinition c : criteria) {
 			bsonList.add(c.getCriteriaObject());
 		}
 		return bsonList;


### PR DESCRIPTION
Update `orOperator`, `norOperator`, `andOperator` and their `Collection` overloads to accept `CriteriaDefinition` instead of `Criteria`. This allows mixing different `CriteriaDefinition` implementations such as `Criteria` and `TextCriteria` in logical operators.

Closes gh-3895