### PR TITLE
Add collection variable to @Encrypted SpEL context

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
@@ -382,6 +382,7 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 
 			EvaluationContext ctx = getEvaluationContext(null);
 			ctx.setVariable("target", getType().getSimpleName());
+			ctx.setVariable("collection", getCollection());
 			return ctx;
 		});
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentProperty.java
@@ -270,6 +270,9 @@ public class BasicMongoPersistentProperty extends AnnotationBasedPersistentPrope
 		Lazy<EvaluationContext> evaluationContext = Lazy.of(() -> {
 			EvaluationContext ctx = getEvaluationContext(null);
 			ctx.setVariable("target", getOwner().getType().getSimpleName() + "." + getName());
+			if (getOwner() instanceof MongoPersistentEntity<?> mongoPersistentEntity) {
+				ctx.setVariable("collection", mongoPersistentEntity.getCollection());
+			}
 			return ctx;
 		});
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MappingMongoJsonSchemaCreatorUnitTests.java
@@ -164,6 +164,24 @@ class MappingMongoJsonSchemaCreatorUnitTests {
 		assertThat(schema.schemaDocument().toBsonDocument()).isEqualTo(BsonDocument.parse(ENC_FROM_METHOD_SCHEMA));
 	}
 
+	@Test // GH-4304
+	void csfleWithKeyFromCollection() {
+
+		GenericApplicationContext applicationContext = new GenericApplicationContext();
+		applicationContext.registerBean("encryptionExtension", EncryptionExtension.class, () -> new EncryptionExtension());
+		applicationContext.refresh();
+
+		MongoMappingContext mappingContext = new MongoMappingContext();
+		mappingContext.setApplicationContext(applicationContext);
+		mappingContext.afterPropertiesSet();
+
+		MongoJsonSchema schema = MongoJsonSchemaCreator.create(mappingContext) //
+				.filter(MongoJsonSchemaCreator.encryptedOnly()) //
+				.createSchemaFor(EncryptionMetadataWithCollection.class);
+
+		assertThat(schema.schemaDocument().toBsonDocument()).isEqualTo(BsonDocument.parse(ENC_FROM_COLLECTION_SCHEMA));
+	}
+
 	// --> Combining Schemas and Properties
 
 	@Test // GH-3870
@@ -648,6 +666,49 @@ class MappingMongoJsonSchemaCreatorUnitTests {
 		String provider;
 	}
 
+	static final String ENC_FROM_COLLECTION_KEY = "R2Vkm1DOCM6sBplG+MZYOQ==";
+	static final String ENC_FROM_COLLECTION_SCHEMA = "{" + //
+			"  'encryptMetadata': {" + //
+			"    'keyId': [" + //
+			"      {" + //
+			"        '$binary': {" + //
+			"          'base64': '" + ENC_FROM_COLLECTION_KEY + "'," + //
+			"          'subType': '04'" + //
+			"        }" + //
+			"      }" + //
+			"    ]" + //
+			"  }," + //
+			"  'type': 'object'," + //
+			"  'properties': {" + //
+			"    'policyNumber': {" + //
+			"      'encrypt': {" + //
+			"        'keyId': [" + //
+			"          [" + //
+			"            {" + //
+			"              '$binary': {" + //
+			"                'base64': '" + ENC_FROM_COLLECTION_KEY + "'," + //
+			"                'subType': '04'" + //
+			"              }" + //
+			"            }" + //
+			"          ]" + //
+			"        ]," + //
+			"        'bsonType': 'int'," + //
+			"        'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'" + //
+			"      }" + //
+			"    }" + //
+			"  }" + //
+			"}";
+
+	@org.springframework.data.mongodb.core.mapping.Document("patients")
+	@Encrypted(keyId = "#{mongocrypt.keyId(#collection)}")
+	static class EncryptionMetadataWithCollection {
+
+		@Encrypted(keyId = "#{mongocrypt.keyId(#collection)}", algorithm = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic") //
+		Integer policyNumber;
+
+		String provider;
+	}
+
 	public static class EncryptionExtension implements EvaluationContextExtension {
 
 		@Override
@@ -683,6 +744,10 @@ class MappingMongoJsonSchemaCreatorUnitTests {
 
 			if (target.equals("EncryptionMetadataFromMethod.policyNumber")) {
 				return ENC_FROM_METHOD_PROPOERTY_KEY;
+			}
+
+			if (target.equals("patients")) {
+				return ENC_FROM_COLLECTION_KEY;
 			}
 
 			return "xKVup8B1Q+CkHaVRx+qa+g==";


### PR DESCRIPTION
## Summary
- Add `#collection` variable to the SpEL evaluation context for `@Encrypted` `keyId` expressions
- Available in both entity-level and property-level `@Encrypted` annotations
- Enables using different encryption keys per collection

## Example

```java
@Document("patients")
@Encrypted(keyId = "#{mongocrypt.keyId(#collection)}")
class Patient {

    @Encrypted(keyId = "#{mongocrypt.keyId(#collection)}",
               algorithm = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
    Integer ssn;
}
```

## Changes
- `BasicMongoPersistentEntity`: bind `#collection` via `getCollection()` in `getEncryptionKeyIds()`
- `BasicMongoPersistentProperty`: bind `#collection` via owner entity's `getCollection()` in `getEncryptionKeyIds()`
- Added unit test `csfleWithKeyFromCollection()` in `MappingMongoJsonSchemaCreatorUnitTests`

Closes #4304