### PR TITLE
Render MongoTemplate ObjectId logs in shell format

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -136,6 +136,9 @@ import com.mongodb.client.model.*;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
 /**
  * Primary implementation of {@link MongoOperations}. It simplifies the use of imperative MongoDB usage and helps to
  * avoid common errors. It executes core MongoDB workflow, leaving application code to provide {@link Document} and
@@ -191,6 +194,9 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		SearchIndexOperationsProvider, ReadPreferenceAware {
 
 	private static final Log LOGGER = LogFactory.getLog(MongoTemplate.class);
+	private static final JsonWriterSettings DEBUG_LOG_JSON_WRITER_SETTINGS = JsonWriterSettings.builder()
+			.outputMode(JsonMode.SHELL)
+			.build();
 	private static final WriteResultChecking DEFAULT_WRITE_RESULT_CHECKING = WriteResultChecking.NONE;
 
 	private final MongoConverter mongoConverter;
@@ -594,7 +600,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format("Executing query: %s fields: %s sort: %s in collection: %s",
-					serializeToJsonSafely(queryObject), fieldsObject, serializeToJsonSafely(sortObject), collectionName));
+					serializeToJsonSafely(queryObject, DEBUG_LOG_JSON_WRITER_SETTINGS), fieldsObject,
+					serializeToJsonSafely(sortObject, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 		}
 
 		this.executeQueryInternal(new FindCallback(createDelegate(query), queryObject, fieldsObject, null),
@@ -1037,7 +1044,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug(String.format("Executing findDistinct using query %s for field: %s in collection: %s",
-						serializeToJsonSafely(mappedQuery), field, collectionName));
+						serializeToJsonSafely(mappedQuery, DEBUG_LOG_JSON_WRITER_SETTINGS), field, collectionName));
 			}
 
 			collection = createDelegate(query).prepare(collection);
@@ -1305,7 +1312,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER
-					.debug(String.format("Executing count: %s in collection: %s", serializeToJsonSafely(filter), collectionName));
+					.debug(String.format("Executing count: %s in collection: %s", serializeToJsonSafely(filter, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 		}
 
 		return countExecution.countDocuments(collectionPreparer, collectionName, filter, options);
@@ -1824,7 +1831,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 				if (LOGGER.isDebugEnabled()) {
 					LOGGER.debug(String.format("Calling update using query: %s and update: %s in collection: %s",
-							serializeToJsonSafely(queryObj), serializeToJsonSafely(pipeline), collectionName));
+							serializeToJsonSafely(queryObj, DEBUG_LOG_JSON_WRITER_SETTINGS), serializeToJsonSafely(pipeline, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 				}
 
 				collection = writeConcernToUse != null ? collection.withWriteConcern(writeConcernToUse) : collection;
@@ -1842,7 +1849,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug(String.format("Calling update using query: %s and update: %s in collection: %s",
-						serializeToJsonSafely(queryObj), serializeToJsonSafely(updateObj), collectionName));
+						serializeToJsonSafely(queryObj, DEBUG_LOG_JSON_WRITER_SETTINGS), serializeToJsonSafely(updateObj, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 			}
 
 			collection = writeConcernToUse != null ? collection.withWriteConcern(writeConcernToUse) : collection;
@@ -1932,7 +1939,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Document removeQuery = queryObject;
 
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug(String.format("Remove using query: %s in collection: %s.", serializeToJsonSafely(removeQuery),
+				LOGGER.debug(String.format("Remove using query: %s in collection: %s.", serializeToJsonSafely(removeQuery, DEBUG_LOG_JSON_WRITER_SETTINGS),
 						collectionName));
 			}
 
@@ -2319,7 +2326,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 			Document command = aggregationUtil.createCommand(collectionName, aggregation, context);
 
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug(String.format("Executing aggregation: %s", serializeToJsonSafely(command)));
+				LOGGER.debug(String.format("Executing aggregation: %s", serializeToJsonSafely(command, DEBUG_LOG_JSON_WRITER_SETTINGS)));
 			}
 
 			Document commandResult = executeCommand(command);
@@ -2331,7 +2338,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(
-					String.format("Executing aggregation: %s in collection %s", serializeToJsonSafely(pipeline), collectionName));
+					String.format("Executing aggregation: %s in collection %s", serializeToJsonSafely(pipeline, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 		}
 
 		return execute(collectionName, collection -> {
@@ -2704,7 +2711,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format("findOne using query: %s fields: %s for class: %s in collection: %s",
-					serializeToJsonSafely(query), mappedFields, entityClass, collectionName));
+					serializeToJsonSafely(query, DEBUG_LOG_JSON_WRITER_SETTINGS), mappedFields, entityClass, collectionName));
 		}
 
 		return executeFindOneInternal(new FindOneCallback(collectionPreparer, mappedQuery, mappedFields, preparer),
@@ -2764,7 +2771,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					? getMappedSortObject(sqcp.getSortObject(), entity)
 					: null;
 			LOGGER.debug(String.format("find using query: %s fields: %s sort: %s for class: %s in collection: %s",
-					serializeToJsonSafely(mappedQuery), mappedFields, serializeToJsonSafely(mappedSort), entityClass,
+					serializeToJsonSafely(mappedQuery, DEBUG_LOG_JSON_WRITER_SETTINGS), mappedFields, serializeToJsonSafely(mappedSort, DEBUG_LOG_JSON_WRITER_SETTINGS), entityClass,
 					collectionName));
 		}
 
@@ -2795,7 +2802,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					? getMappedSortObject(sqcp.getSortObject(), entity)
 					: null;
 			LOGGER.debug(String.format("find using query: %s fields: %s sort: %s for class: %s in collection: %s",
-					serializeToJsonSafely(mappedQuery), mappedFields, serializeToJsonSafely(mappedSort), sourceClass,
+					serializeToJsonSafely(mappedQuery, DEBUG_LOG_JSON_WRITER_SETTINGS), mappedFields, serializeToJsonSafely(mappedSort, DEBUG_LOG_JSON_WRITER_SETTINGS), sourceClass,
 					collectionName));
 		}
 
@@ -2880,7 +2887,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format("findAndRemove using query: %s fields: %s sort: %s for class: %s in collection: %s",
-					serializeToJsonSafely(query), fields, serializeToJsonSafely(sort), entityClass, collectionName));
+					serializeToJsonSafely(query, DEBUG_LOG_JSON_WRITER_SETTINGS), fields, serializeToJsonSafely(sort, DEBUG_LOG_JSON_WRITER_SETTINGS), entityClass, collectionName));
 		}
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityClass);
@@ -2912,8 +2919,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format(
 					"findAndModify using query: %s fields: %s sort: %s for class: %s and update: %s in collection: %s",
-					serializeToJsonSafely(mappedQuery), fields, serializeToJsonSafely(sort), entityClass,
-					serializeToJsonSafely(mappedUpdate), collectionName));
+					serializeToJsonSafely(mappedQuery, DEBUG_LOG_JSON_WRITER_SETTINGS), fields, serializeToJsonSafely(sort, DEBUG_LOG_JSON_WRITER_SETTINGS), entityClass,
+					serializeToJsonSafely(mappedUpdate, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 		}
 
 		DocumentCallback<T> callback = getResultReader(EntityProjection.nonProjecting(entityClass), collectionName,
@@ -2995,8 +3002,8 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 					.debug(String.format(
 							"findAndReplace using query: %s fields: %s sort: %s for class: %s and replacement: %s "
 									+ "in collection: %s",
-							serializeToJsonSafely(mappedQuery), serializeToJsonSafely(mappedFields),
-							serializeToJsonSafely(mappedSort), entityType, serializeToJsonSafely(replacement), collectionName));
+							serializeToJsonSafely(mappedQuery, DEBUG_LOG_JSON_WRITER_SETTINGS), serializeToJsonSafely(mappedFields, DEBUG_LOG_JSON_WRITER_SETTINGS),
+							serializeToJsonSafely(mappedSort, DEBUG_LOG_JSON_WRITER_SETTINGS), entityType, serializeToJsonSafely(replacement, DEBUG_LOG_JSON_WRITER_SETTINGS), collectionName));
 		}
 
 		DocumentCallback<R> callback = getResultReader(projection, collectionName, resultConverter);
@@ -3017,7 +3024,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 				}));
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format("replace one using query: %s for class: %s in collection: %s",
-					serializeToJsonSafely(updateContext.getMappedQuery(entity)), entityType, collectionName));
+					serializeToJsonSafely(updateContext.getMappedQuery(entity), DEBUG_LOG_JSON_WRITER_SETTINGS), entityType, collectionName));
 		}
 
 		return execute(collectionName, replaceCallback);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/SerializationUtils.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/query/SerializationUtils.java
@@ -28,6 +28,8 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Contract;
 import org.springframework.util.ObjectUtils;
 
+import org.bson.json.JsonWriterSettings;
+
 /**
  * Utility methods for JSON serialization.
  *
@@ -36,6 +38,8 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  */
 public abstract class SerializationUtils {
+	
+	private static final JsonWriterSettings DEFAULT_JSON_WRITER_SETTINGS = JsonWriterSettings.builder().build();
 
 	private SerializationUtils() {
 
@@ -112,46 +116,67 @@ public abstract class SerializationUtils {
 	 */
 	@Contract("null -> null; !null -> !null")
 	public static @Nullable String serializeToJsonSafely(@Nullable Object value) {
+		return serializeToJsonSafely(value, DEFAULT_JSON_WRITER_SETTINGS);
+	}
+	
+	public static @Nullable String serializeToJsonSafely(@Nullable Object value, JsonWriterSettings settings) {
 
 		if (value == null) {
 			return null;
 		}
 
 		try {
-			String json = value instanceof Document document ? document.toJson() : serializeValue(value);
+			String json = value instanceof Document document ? document.toJson(settings) : serializeValue(value, settings);
 			return json.replaceAll("\":", "\" :").replaceAll("\\{\"", "{ \"");
 		} catch (Exception e) {
 
-			if (value instanceof Collection<?> collection) {
-				return toString(collection);
-			} else if (value instanceof Map<?,?> map) {
-				return toString(map);
+			if (value instanceof Collection collection) {
+				return toString(collection, settings);
+			} else if (value instanceof Map<?, ?> map) {
+				return toString(map, settings);
 			} else if (ObjectUtils.isArray(value)) {
-				return toString(Arrays.asList(ObjectUtils.toObjectArray(value)));
+				return toString(Arrays.asList(ObjectUtils.toObjectArray(value)), settings);
 			} else {
 				return String.format("{ \"$java\" : %s }", value);
 			}
 		}
 	}
 
+
 	public static String serializeValue(@Nullable Object value) {
+		return serializeValue(value, DEFAULT_JSON_WRITER_SETTINGS);
+	}
+
+	public static String serializeValue(@Nullable Object value, JsonWriterSettings settings) {
 
 		if (value == null) {
 			return "null";
 		}
 
-		String documentJson = new Document("toBeEncoded", value).toJson();
+		String documentJson = new Document("toBeEncoded", value).toJson(settings);
 		return documentJson.substring(documentJson.indexOf(':') + 1, documentJson.length() - 1).trim();
 	}
 
 	private static String toString(Map<?, ?> source) {
-		return iterableToDelimitedString(source.entrySet(), "{ ", " }",
-				entry -> String.format("\"%s\" : %s", entry.getKey(), serializeToJsonSafely(entry.getValue())));
+		return toString(source, DEFAULT_JSON_WRITER_SETTINGS);
 	}
+
+	private static String toString(Map<?, ?> source, JsonWriterSettings settings) {
+
+		return iterableToDelimitedString(source.entrySet(), "{ ", " }",
+				entry -> String.format("\"%s\" : %s", entry.getKey(),
+						serializeToJsonSafely(entry.getValue(), settings)));
+	}
+
 
 	@SuppressWarnings("NullAway")
 	private static String toString(Collection<?> source) {
-		return iterableToDelimitedString(source, "[ ", " ]", SerializationUtils::serializeToJsonSafely);
+		return toString(source, DEFAULT_JSON_WRITER_SETTINGS);
+	}
+
+	@SuppressWarnings("NullAway")
+	private static String toString(Collection<?> source, JsonWriterSettings settings) {
+		return iterableToDelimitedString(source, "[ ", " ]", value -> serializeToJsonSafely(value, settings));
 	}
 
 	/**

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/SerializationUtilsUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/query/SerializationUtilsUnitTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.core.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SerializationUtils}.
+ *
+ * @author Your Full Name
+ */
+class SerializationUtilsUnitTests {
+
+	@Test // GH-4873
+	void serializesObjectIdUsingShellFormat() {
+
+		ObjectId objectId = new ObjectId("507f1f77bcf86cd799439011");
+
+		JsonWriterSettings settings = JsonWriterSettings.builder()
+				.outputMode(JsonMode.SHELL)
+				.build();
+
+		assertThat(SerializationUtils.serializeToJsonSafely(new Document("_id", objectId), settings))
+				.contains("ObjectId(\"507f1f77bcf86cd799439011\")")
+				.doesNotContain("$oid");
+	}
+}


### PR DESCRIPTION
Closes #4873

This change updates MongoTemplate debug query logging to render BSON ObjectId values using Mongo shell-style JSON formatting.

Before:

```json
{ "_id" : { "$oid" : "507f1f77bcf86cd799439011" } }