### PR TITLE
Introduce explicit index field matching methods

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
@@ -41,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author dragonfsky
  */
 public class IndexInfo {
 
@@ -182,16 +184,80 @@ public class IndexInfo {
 	}
 
 	/**
-	 * Returns whether the index is covering exactly the fields given independently of the order.
+	 * Returns whether the index contains all given field keys independently of their position. Field keys are compared as
+	 * a set and therefore repeated input keys are ignored.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @since 5.1
 	 */
-	public boolean isIndexForFields(Collection<String> keys) {
+	public boolean containsAllFields(Collection<String> keys) {
 
 		Assert.notNull(keys, "Collection of keys must not be null");
 
-		return this.indexFields.stream().map(IndexField::getKey).collect(Collectors.toSet()).containsAll(keys);
+		return getIndexFieldKeys().containsAll(keys);
+	}
+
+	/**
+	 * Returns whether the index contains all given field keys independently of their position. Field keys are compared as
+	 * a set and therefore repeated input keys are ignored.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @deprecated since 5.1. Use {@link #containsAllFields(Collection)}, {@link #isIndexForFieldsExactly(Collection)}, or
+	 *             {@link #coversFields(Collection)} to express the intended index field matching semantics.
+	 */
+	@Deprecated(since = "5.1")
+	public boolean isIndexForFields(Collection<String> keys) {
+		return containsAllFields(keys);
+	}
+
+	/**
+	 * Returns whether the index matches exactly the given field keys independently of their order. Field keys are compared
+	 * as a set and therefore repeated input keys are ignored.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 5.1
+	 */
+	public boolean isIndexForFieldsExactly(Collection<String> keys) {
+
+		Assert.notNull(keys, "Collection of keys must not be null");
+
+		Set<String> indexFieldKeys = getIndexFieldKeys();
+		Set<String> keysToCheck = keys.stream().collect(Collectors.toSet());
+
+		return indexFieldKeys.size() == keysToCheck.size() && indexFieldKeys.containsAll(keysToCheck);
+	}
+
+	/**
+	 * Returns whether the given field keys are covered by this index according to compound-index prefix field matching.
+	 * Field keys are compared as a set and therefore repeated input keys are ignored. This method matches
+	 * {@link IndexField#getKey() index field keys} only and does not evaluate special query semantics of text, geo, or
+	 * wildcard indexes.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 5.1
+	 */
+	public boolean coversFields(Collection<String> keys) {
+
+		Assert.notNull(keys, "Collection of keys must not be null");
+
+		Set<String> keysToCheck = keys.stream().collect(Collectors.toSet());
+
+		if (keysToCheck.size() > indexFields.size()) {
+			return false;
+		}
+
+		Set<String> indexFieldPrefix = indexFields.stream().limit(keysToCheck.size()).map(IndexField::getKey)
+				.collect(Collectors.toSet());
+
+		return indexFieldPrefix.containsAll(keysToCheck);
+	}
+
+	private Set<String> getIndexFieldKeys() {
+		return this.indexFields.stream().map(IndexField::getKey).collect(Collectors.toSet());
 	}
 
 	public String getName() {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/IndexInfo.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
@@ -41,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Dongliang Xie
  */
 public class IndexInfo {
 
@@ -182,16 +184,80 @@ public class IndexInfo {
 	}
 
 	/**
-	 * Returns whether the index is covering exactly the fields given independently of the order.
+	 * Returns whether the index contains all given field keys independently of their position. Field keys are compared as
+	 * a set and therefore repeated input keys are ignored.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @since 5.2
 	 */
-	public boolean isIndexForFields(Collection<String> keys) {
+	public boolean containsAllFields(Collection<String> keys) {
 
 		Assert.notNull(keys, "Collection of keys must not be null");
 
-		return this.indexFields.stream().map(IndexField::getKey).collect(Collectors.toSet()).containsAll(keys);
+		return getIndexFieldKeys().containsAll(keys);
+	}
+
+	/**
+	 * Returns whether the index contains all given field keys independently of their position. Field keys are compared as
+	 * a set and therefore repeated input keys are ignored.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @deprecated since 5.2. Use {@link #containsAllFields(Collection)}, {@link #isIndexForFieldsExactly(Collection)}, or
+	 *             {@link #coversFields(Collection)} to express the intended index field matching semantics.
+	 */
+	@Deprecated(since = "5.2")
+	public boolean isIndexForFields(Collection<String> keys) {
+		return containsAllFields(keys);
+	}
+
+	/**
+	 * Returns whether the index matches exactly the given field keys independently of their order. Field keys are compared
+	 * as a set and therefore repeated input keys are ignored.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 5.2
+	 */
+	public boolean isIndexForFieldsExactly(Collection<String> keys) {
+
+		Assert.notNull(keys, "Collection of keys must not be null");
+
+		Set<String> indexFieldKeys = getIndexFieldKeys();
+		Set<String> keysToCheck = keys.stream().collect(Collectors.toSet());
+
+		return indexFieldKeys.equals(keysToCheck);
+	}
+
+	/**
+	 * Returns whether the given field keys are covered by this index according to compound-index prefix field matching.
+	 * Field keys are compared as a set and therefore repeated input keys are ignored. This method matches
+	 * {@link IndexField#getKey() index field keys} only and does not evaluate special query semantics of text, geo, or
+	 * wildcard indexes.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 5.2
+	 */
+	public boolean coversFields(Collection<String> keys) {
+
+		Assert.notNull(keys, "Collection of keys must not be null");
+
+		Set<String> keysToCheck = keys.stream().collect(Collectors.toSet());
+
+		if (keysToCheck.size() > this.indexFields.size()) {
+			return false;
+		}
+
+		Set<String> indexFieldPrefix = this.indexFields.stream().limit(keysToCheck.size()).map(IndexField::getKey)
+				.collect(Collectors.toSet());
+
+		return indexFieldPrefix.containsAll(keysToCheck);
+	}
+
+	private Set<String> getIndexFieldKeys() {
+		return this.indexFields.stream().map(IndexField::getKey).collect(Collectors.toSet());
 	}
 
 	public String getName() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Sort.Direction;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Stefan Tirea
+ * @author dragonfsky
  */
 class IndexInfoUnitTests {
 
@@ -50,14 +51,52 @@ class IndexInfoUnitTests {
 			   }
 			""";
 
-	@Test
-	void isIndexForFieldsCorrectly() {
+	@Test // GH-5187
+	@SuppressWarnings("deprecation")
+	void isIndexForFieldsRetainsContainsAllBehavior() {
 
 		IndexField fooField = IndexField.create("foo", Direction.ASC);
 		IndexField barField = IndexField.create("bar", Direction.DESC);
 
 		IndexInfo info = new IndexInfo(Arrays.asList(fooField, barField), "myIndex", false, false, "");
 		assertThat(info.isIndexForFields(Arrays.asList("foo", "bar"))).isTrue();
+		assertThat(info.isIndexForFields(Arrays.asList("foo"))).isTrue();
+	}
+
+	@Test // GH-5187
+	void containsAllFieldsReturnsTrueForFieldSubset() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC)), "myIndex", false, false, "");
+
+		assertThat(info.containsAllFields(Arrays.asList("foo"))).isTrue();
+		assertThat(info.containsAllFields(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.containsAllFields(Arrays.asList("foo", "baz"))).isFalse();
+	}
+
+	@Test // GH-5187
+	void isIndexForFieldsExactlyRequiresSameFields() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC)), "myIndex", false, false, "");
+
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo", "bar"))).isTrue();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo"))).isFalse();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo", "bar", "baz"))).isFalse();
+	}
+
+	@Test // GH-5187
+	void coversFieldsOnlyMatchesIndexPrefixes() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC), IndexField.create("baz", Direction.ASC)), "myIndex", false,
+				false, "");
+
+		assertThat(info.coversFields(Arrays.asList("foo"))).isTrue();
+		assertThat(info.coversFields(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.coversFields(Arrays.asList("bar"))).isFalse();
+		assertThat(info.coversFields(Arrays.asList("foo", "baz"))).isFalse();
 	}
 
 	@Test // DATAMONGO-2170

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/IndexInfoUnitTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Sort.Direction;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Stefan Tirea
+ * @author Dongliang Xie
  */
 class IndexInfoUnitTests {
 
@@ -50,14 +51,54 @@ class IndexInfoUnitTests {
 			   }
 			""";
 
-	@Test
-	void isIndexForFieldsCorrectly() {
+	@Test // GH-5187
+	@SuppressWarnings("deprecation")
+	void isIndexForFieldsRetainsContainsAllBehavior() {
 
 		IndexField fooField = IndexField.create("foo", Direction.ASC);
 		IndexField barField = IndexField.create("bar", Direction.DESC);
 
 		IndexInfo info = new IndexInfo(Arrays.asList(fooField, barField), "myIndex", false, false, "");
 		assertThat(info.isIndexForFields(Arrays.asList("foo", "bar"))).isTrue();
+		assertThat(info.isIndexForFields(Arrays.asList("foo"))).isTrue();
+		assertThat(info.isIndexForFields(Arrays.asList("bar"))).isTrue();
+	}
+
+	@Test // GH-5187
+	void containsAllFieldsReturnsTrueForFieldSubset() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC)), "myIndex", false, false, "");
+
+		assertThat(info.containsAllFields(Arrays.asList("foo"))).isTrue();
+		assertThat(info.containsAllFields(Arrays.asList("bar"))).isTrue();
+		assertThat(info.containsAllFields(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.containsAllFields(Arrays.asList("foo", "baz"))).isFalse();
+	}
+
+	@Test // GH-5187
+	void isIndexForFieldsExactlyRequiresSameFields() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC)), "myIndex", false, false, "");
+
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo", "bar"))).isTrue();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo"))).isFalse();
+		assertThat(info.isIndexForFieldsExactly(Arrays.asList("foo", "bar", "baz"))).isFalse();
+	}
+
+	@Test // GH-5187
+	void coversFieldsOnlyMatchesIndexPrefixes() {
+
+		IndexInfo info = new IndexInfo(Arrays.asList(IndexField.create("foo", Direction.ASC),
+				IndexField.create("bar", Direction.DESC), IndexField.create("baz", Direction.ASC)), "myIndex", false,
+				false, "");
+
+		assertThat(info.coversFields(Arrays.asList("foo"))).isTrue();
+		assertThat(info.coversFields(Arrays.asList("bar", "foo"))).isTrue();
+		assertThat(info.coversFields(Arrays.asList("bar"))).isFalse();
+		assertThat(info.coversFields(Arrays.asList("foo", "baz"))).isFalse();
 	}
 
 	@Test // DATAMONGO-2170

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
@@ -41,6 +41,7 @@ import com.mongodb.client.MongoCollection;
  * Integration test for index creation for query methods.
  *
  * @author Oliver Gierke
+ * @author dragonfsky
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -84,7 +85,7 @@ public class RepositoryIndexCreationIntegrationTests {
 	private static void assertHasIndexForField(List<IndexInfo> indexInfo, String... fields) {
 
 		for (IndexInfo info : indexInfo) {
-			if (info.isIndexForFields(Arrays.asList(fields))) {
+			if (info.containsAllFields(Arrays.asList(fields))) {
 				return;
 			}
 		}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/RepositoryIndexCreationIntegrationTests.java
@@ -84,7 +84,7 @@ public class RepositoryIndexCreationIntegrationTests {
 	private static void assertHasIndexForField(List<IndexInfo> indexInfo, String... fields) {
 
 		for (IndexInfo info : indexInfo) {
-			if (info.isIndexForFields(Arrays.asList(fields))) {
+			if (info.containsAllFields(Arrays.asList(fields))) {
 				return;
 			}
 		}


### PR DESCRIPTION
Closes #5187

Keeps the existing subset-matching behavior for compatibility, deprecates the ambiguous method, and adds explicit methods for:

- subset matching regardless of position
- exact field-name matching regardless of order
- compound-index prefix coverage

The internal index assertion now uses the explicit subset method.

Validation:

- ./mvnw -pl spring-data-mongodb -Dtest=IndexInfoUnitTests clean test (14 tests passed)

Checklist:

- [x] You have read the Spring Data contribution guidelines.
- [x] You use the code formatters provided by the project and have not submitted unrelated formatting changes.
- [x] You submit test cases that back your changes.
- [x] You added yourself as author in the headers of the classes you touched.