### PR TITLE
Support array-backed Point mapping

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/GeoConverters.java
@@ -45,7 +45,10 @@ import org.springframework.data.mongodb.core.geo.GeoJsonMultiPolygon;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.geo.GeoJsonPolygon;
 import org.springframework.data.mongodb.core.geo.Sphere;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.GeoCommand;
+import org.springframework.data.mongodb.util.BsonUtils;
 import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
@@ -60,6 +63,7 @@ import com.mongodb.Function;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Thiago Diniz da Silveira
+ * @author dragonfsky
  * @since 1.5
  */
 @SuppressWarnings("ConstantConditions")
@@ -146,6 +150,31 @@ abstract class GeoConverters {
 			}
 
 			return new Point(toPrimitiveDoubleValue(source.get("x")), toPrimitiveDoubleValue(source.get("y")));
+		}
+	}
+
+	/**
+	 * Converts a {@link List} of coordinates into a {@link Point}.
+	 *
+	 * @author dragonfsky
+	 * @since 5.1
+	 */
+	@ReadingConverter
+	enum ListToPointConverter implements Converter<List<Number>, @Nullable Point> {
+
+		INSTANCE;
+
+		@Override
+		@SuppressWarnings("NullAway")
+		public Point convert(List<Number> source) {
+
+			if (ObjectUtils.isEmpty(source)) {
+				return null;
+			}
+
+			Assert.isTrue(source.size() == 2, "Source must contain 2 elements");
+
+			return new Point(toPrimitiveDoubleValue(source.get(0)), toPrimitiveDoubleValue(source.get(1)));
 		}
 	}
 
@@ -726,6 +755,28 @@ abstract class GeoConverters {
 
 	static List<Double> toList(Point point) {
 		return Arrays.asList(point.getX(), point.getY());
+	}
+
+	static boolean isArrayBackedPoint(MongoPersistentProperty property, @Nullable Object value) {
+		return value instanceof Point && isArrayBackedPointProperty(property);
+	}
+
+	static boolean isArrayBackedPointProperty(MongoPersistentProperty property) {
+		return property.hasExplicitWriteTarget() && property.getMongoField().getFieldType() == FieldType.ARRAY
+				&& Point.class.isAssignableFrom(property.getType());
+	}
+
+	static List<Double> writeArrayBackedPoint(Point point) {
+		return toList(point);
+	}
+
+	@SuppressWarnings("unchecked")
+	static @Nullable Point readArrayBackedPoint(Object source) {
+
+		Collection<?> coordinates = BsonUtils.asCollection(source);
+		List<?> coordinateList = coordinates instanceof List<?> list ? list : new ArrayList<>(coordinates);
+
+		return ListToPointConverter.INSTANCE.convert((List<Number>) coordinateList);
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MappingMongoConverter.java
@@ -60,6 +60,7 @@ import org.springframework.data.convert.PropertyValueConverter;
 import org.springframework.data.convert.TypeMapper;
 import org.springframework.data.convert.ValueConversionContext;
 import org.springframework.data.core.TypeInformation;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.InstanceCreatorMetadata;
 import org.springframework.data.mapping.MappingException;
@@ -1339,6 +1340,11 @@ public class MappingMongoConverter extends AbstractMongoConverter
 			return;
 		}
 
+		if (GeoConverters.isArrayBackedPoint(property, value)) {
+			accessor.put(property, GeoConverters.writeArrayBackedPoint((Point) value));
+			return;
+		}
+
 		accessor.put(property, getPotentiallyConvertedSimpleWrite(value,
 				property.hasExplicitWriteTarget() ? property.getFieldType() : Object.class));
 	}
@@ -2006,6 +2012,10 @@ public class MappingMongoConverter extends AbstractMongoConverter
 
 			if (value == null) {
 				return null;
+			}
+
+			if (GeoConverters.isArrayBackedPointProperty(property)) {
+				return (T) GeoConverters.readArrayBackedPoint(value);
 			}
 
 			ConversionContext contextToUse = context.forProperty(property);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java
@@ -48,6 +48,7 @@ import org.springframework.data.core.PropertyPath;
 import org.springframework.data.core.PropertyReferenceException;
 import org.springframework.data.core.TypeInformation;
 import org.springframework.data.domain.Example;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
@@ -923,6 +924,31 @@ public class QueryMapper {
 		if (value == null || documentField.getProperty() == null || !documentField.getProperty().hasExplicitWriteTarget()
 				|| value instanceof Document || value instanceof DBObject || Quirks.skipConversion(value)) {
 			return value;
+		}
+
+		if (GeoConverters.isArrayBackedPoint(documentField.getProperty(), value)) {
+			return GeoConverters.writeArrayBackedPoint((Point) value);
+		}
+
+		if (GeoConverters.isArrayBackedPointProperty(documentField.getProperty())
+				&& value instanceof Collection<?> source) {
+
+			List<Object> converted = new ArrayList<>(source.size());
+			boolean hasPoint = false;
+
+			for (Object candidate : source) {
+
+				if (candidate instanceof Point point) {
+					converted.add(GeoConverters.writeArrayBackedPoint(point));
+					hasPoint = true;
+				} else {
+					converted.add(candidate);
+				}
+			}
+
+			if (hasPoint) {
+				return converted;
+			}
 		}
 
 		if (!conversionService.canConvert(value.getClass(), documentField.getProperty().getFieldType())) {

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/UpdateMapper.java
@@ -31,6 +31,7 @@ import org.springframework.data.convert.ValueConversionContext;
 import org.springframework.data.core.TypeInformation;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.convert.MongoConversionContext.WriteOperatorContext;
@@ -236,6 +237,12 @@ public class UpdateMapper extends QueryMapper {
 		}
 
 		TypeInformation<?> typeHint = field == null ? TypeInformation.OBJECT : field.getTypeHint();
+
+		if (field != null && field.getProperty() != null
+				&& GeoConverters.isArrayBackedPoint(field.getProperty(), value)) {
+			return GeoConverters.writeArrayBackedPoint((Point) value);
+		}
+
 		return converter.convertToMongoType(value, typeHint);
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoConvertersUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/GeoConvertersUnitTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.mongodb.core.query.GeoCommand;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author dragonfsky
  * @since 1.5
  */
 public class GeoConvertersUnitTests {
@@ -150,6 +151,13 @@ public class GeoConvertersUnitTests {
 
 		assertThat(DocumentToPointConverter.INSTANCE.convert(new Document().append("x", 1L).append("y", 2L)))
 				.isEqualTo(new Point(1, 2));
+	}
+
+	@Test // GH-4997
+	public void convertsCoordinateListToPointCorrectly() {
+
+		assertThat(ListToPointConverter.INSTANCE.convert(Arrays.asList(-73.99171, 40.738868)))
+				.isEqualTo(new Point(-73.99171, 40.738868));
 	}
 
 	@Test // DATAMONGO-1607

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/MappingMongoConverterUnitTests.java
@@ -126,6 +126,7 @@ import com.mongodb.DBRef;
  * @author Roman Puchkovskiy
  * @author Heesu Jung
  * @author Julia Lee
+ * @author dragonfsky
  */
 @ExtendWith(MockitoExtension.class)
 class MappingMongoConverterUnitTests {
@@ -1550,6 +1551,40 @@ class MappingMongoConverterUnitTests {
 
 		assertThat(result).isNotNull();
 		assertThat(result.box).isEqualTo(object.box);
+	}
+
+	@Test // GH-4997
+	void shouldReadEntityWithGeoPointFromArrayCoordinates() {
+
+		org.bson.Document document = new org.bson.Document("point", Arrays.asList(-73.99171, 40.738868));
+
+		ClassWithArrayBackedGeoPoint result = converter.read(ClassWithArrayBackedGeoPoint.class, document);
+
+		assertThat(result.point).isEqualTo(new Point(-73.99171, 40.738868));
+	}
+
+	@Test // GH-4997
+	void shouldWriteArrayBackedGeoPointAsArrayCoordinates() {
+
+		ClassWithArrayBackedGeoPoint object = new ClassWithArrayBackedGeoPoint();
+		object.point = new Point(-73.99171, 40.738868);
+
+		org.bson.Document document = new org.bson.Document();
+		converter.write(object, document);
+
+		assertThat(document.get("point")).isEqualTo(Arrays.asList(-73.99171, 40.738868));
+	}
+
+	@Test // GH-4997
+	void shouldKeepDefaultGeoPointRepresentation() {
+
+		ClassWithGeoPoint object = new ClassWithGeoPoint();
+		object.point = new Point(-73.99171, 40.738868);
+
+		org.bson.Document document = new org.bson.Document();
+		converter.write(object, document);
+
+		assertThat(document.get("point")).isEqualTo(toDocument(object.point));
 	}
 
 	@Test // DATAMONGO-858
@@ -4057,6 +4092,16 @@ class MappingMongoConverterUnitTests {
 	class ClassWithGeoBox {
 
 		Box box;
+	}
+
+	class ClassWithGeoPoint {
+
+		Point point;
+	}
+
+	class ClassWithArrayBackedGeoPoint {
+
+		@Field(targetType = FieldType.ARRAY) Point point;
 	}
 
 	class ClassWithGeoCircle {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/QueryMapperUnitTests.java
@@ -1000,6 +1000,30 @@ public class QueryMapperUnitTests {
 		assertThat(document).containsEntry("legacyPoint.y", 20D);
 	}
 
+	@Test // GH-4997
+	void shouldMapArrayBackedPointQueryToCoordinateArray() {
+
+		Query query = query(where("arrayBackedPoint").is(new Point(-73.99171, 40.738868)));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(ClassWithGeoTypes.class));
+
+		assertThat(document).containsEntry("arrayBackedPoint", Arrays.asList(-73.99171, 40.738868));
+	}
+
+	@Test // GH-4997
+	void shouldMapArrayBackedPointInQueryToCoordinateArrays() {
+
+		Query query = query(where("arrayBackedPoint").in(new Point(-73.99171, 40.738868), new Point(10D, 20D)));
+
+		org.bson.Document document = mapper.getMappedObject(query.getQueryObject(),
+				context.getPersistentEntity(ClassWithGeoTypes.class));
+
+		List<List<Double>> expected = Arrays.asList(Arrays.asList(-73.99171, 40.738868),
+				Arrays.asList(10D, 20D));
+		assertThat(getAsDocument(document, "arrayBackedPoint").get("$in")).isEqualTo(expected);
+	}
+
 	@Test // GH-3544
 	void exampleWithCombinedCriteriaShouldBeMappedCorrectly() {
 
@@ -1902,6 +1926,7 @@ public class QueryMapperUnitTests {
 
 		double[] justAnArray;
 		Point legacyPoint;
+		@Field(targetType = FieldType.ARRAY) Point arrayBackedPoint;
 		GeoJsonPoint geoJsonPoint;
 		@Field("geoJsonPointWithNameViaFieldAnnotation") GeoJsonPoint namedGeoJsonPoint;
 	}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/convert/UpdateMapperUnitTests.java
@@ -44,10 +44,12 @@ import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mongodb.core.DocumentTestUtils;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.Unwrapped;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -147,6 +149,18 @@ class UpdateMapperUnitTests {
 
 		Document set = getAsDocument(mappedObject, "$set");
 		assertThat(set.get("_class")).isNull();
+	}
+
+	@Test // GH-4997
+	void updateMapperShouldMapArrayBackedPointToCoordinateArray() {
+
+		Update update = Update.update("point", new Point(-73.99171, 40.738868));
+
+		Document mappedObject = mapper.getMappedObject(update.getUpdateObject(),
+				context.getPersistentEntity(ClassWithArrayBackedGeoPoint.class));
+
+		Document set = getAsDocument(mappedObject, "$set");
+		assertThat(set.get("point")).isEqualTo(Arrays.asList(-73.99171, 40.738868));
 	}
 
 	@Test // DATAMONGO-407
@@ -1829,5 +1843,10 @@ class UpdateMapperUnitTests {
 
 		@ValueConverter(ReversingValueConverter.class)
 		String text;
+	}
+
+	static class ClassWithArrayBackedGeoPoint {
+
+		@Field(targetType = FieldType.ARRAY) Point point;
 	}
 }


### PR DESCRIPTION
Closes #4997

This PR adds opt-in support for array-backed `Point` mapping through `@Field(targetType = FieldType.ARRAY)`.

With the annotation, coordinate arrays such as `[-73.99171, 40.738868]` are read into `Point` and written back as coordinate arrays. Query and update mapping for the same property also keeps the array representation.

The default `Point` mapping remains unchanged and continues to use the existing `{ x, y }` document representation.

Tests:
- `./mvnw -pl spring-data-mongodb -Dtest=GeoConvertersUnitTests,MappingMongoConverterUnitTests,QueryMapperUnitTests,UpdateMapperUnitTests -Dmaven.compiler.proc=none test`
- `git diff --check`

Checklist:
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Do not submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
