### PR TITLE
Translate transient WriteConflict to ConcurrencyFailureException

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoExceptionTranslator.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import com.mongodb.ClientBulkWriteException;
 import org.bson.BsonInvalidOperationException;
 import org.jspecify.annotations.Nullable;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -50,6 +51,7 @@ import com.mongodb.bulk.BulkWriteError;
  * @author Michal Vich
  * @author Christoph Strobl
  * @author Brice Vandeputte
+ * @author Seonwoo Jung
  */
 public class MongoExceptionTranslator implements PersistenceExceptionTranslator {
 
@@ -120,6 +122,10 @@ public class MongoExceptionTranslator implements PersistenceExceptionTranslator 
 				}
 			}
 
+			if (isTransientFailure(ex)) {
+				return new ConcurrencyFailureException(ex.getMessage(), ex);
+			}
+
 			return new DataIntegrityViolationException(ex.getMessage(), ex);
 		}
 
@@ -142,6 +148,9 @@ public class MongoExceptionTranslator implements PersistenceExceptionTranslator 
 				return new PermissionDeniedDataAccessException(ex.getMessage(), ex);
 			}
 			if (MongoDbErrorCodes.isDataIntegrityViolationError(mongoException)) {
+				if (isTransientFailure(mongoException)) {
+					return new ConcurrencyFailureException(mongoException.getMessage(), mongoException);
+				}
 				return new DataIntegrityViolationException(mongoException.getMessage(), mongoException);
 			}
 			if (MongoDbErrorCodes.isClientSessionFailure(mongoException)) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoExceptionTranslatorUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoExceptionTranslatorUnitTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DuplicateKeyException;
@@ -39,7 +40,9 @@ import com.mongodb.MongoInternalException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketReadTimeoutException;
 import com.mongodb.MongoSocketWriteException;
+import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 
 /**
  * Unit tests for {@link MongoExceptionTranslator}.
@@ -48,6 +51,7 @@ import com.mongodb.ServerAddress;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Brice Vandeputte
+ * @author Seonwoo Jung
  */
 class MongoExceptionTranslatorUnitTests {
 
@@ -191,6 +195,42 @@ class MongoExceptionTranslatorUnitTests {
 		DataAccessException translatedException = translator.translateExceptionIfPossible(exception);
 
 		expectExceptionWithCauseMessage(translatedException, UncategorizedMongoDbException.class);
+	}
+
+	@Test // GH-5150
+	void translateTransientWriteConflictMongoException() {
+
+		MongoException source = new MongoException(112, "WriteConflict");
+		source.addLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL);
+
+		DataAccessException translated = translator.translateExceptionIfPossible(source);
+
+		expectExceptionWithCauseMessage(translated, ConcurrencyFailureException.class, "WriteConflict");
+		assertThat(translator.isTransientFailure(translated)).isTrue();
+	}
+
+	@Test // GH-5150
+	void translateTransientMongoWriteException() {
+
+		WriteError writeError = new WriteError(112, "WriteConflict", new BsonDocument());
+		MongoWriteException source = new MongoWriteException(writeError, new ServerAddress());
+		source.addLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL);
+
+		DataAccessException translated = translator.translateExceptionIfPossible(source);
+
+		expectExceptionWithCauseMessage(translated, ConcurrencyFailureException.class, "WriteConflict");
+		assertThat(translator.isTransientFailure(translated)).isTrue();
+	}
+
+	@Test // GH-5150
+	void translateNonTransientWriteConflictMongoException() {
+
+		MongoException source = new MongoException(112, "WriteConflict");
+
+		DataAccessException translated = translator.translateExceptionIfPossible(source);
+
+		expectExceptionWithCauseMessage(translated,
+				org.springframework.dao.DataIntegrityViolationException.class, "WriteConflict");
 	}
 
 	private void checkTranslatedMongoException(Class<? extends Exception> clazz, int code) {


### PR DESCRIPTION
WriteConflict (code 112) returned with a \`TransientTransactionError\` label is
a retryable concurrency failure, but \`MongoExceptionTranslator\` mapped it to
\`DataIntegrityViolationException\` — a \`NonTransientDataAccessException\` —
which silently breaks retry policies keyed on Spring's exception hierarchy.

This change checks \`isTransientFailure(ex)\` before falling through to
\`DataIntegrityViolationException\` and returns \`ConcurrencyFailureException\`
(a \`TransientDataAccessException\`) instead. The check is applied in both
the \`DATA_INTEGRITY_EXCEPTIONS\` branch (real \`MongoWriteException\`) and the
\`isDataIntegrityViolationError\` fall-through branch (plain \`MongoException\`
carrying a data-integrity error code).

Scope note: \`MongoBulkWriteException\` continues to return
\`BulkOperationException\` because bulk failures require per-write inspection
and were deemed out of scope for this fix.

Closes #5150