### PR TITLE
Add missing exclusion of legacy MongoDB v3 driver to Gradle build script snippet

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
@@ -215,12 +215,12 @@ Gradle::
 [source,groovy,indent=0,subs="verbatim,quotes",role="secondary"]
 ----
 dependencies {
-    implementation "com.querydsl:querydsl-mongodb:${querydslVersion}"
+    implementation "com.querydsl:querydsl-mongodb:$querydslVersion"
 
-    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:$querydslVersion:jakarta"
     annotationProcessor "org.springframework.data:spring-data-mongodb"
 
-    testAnnotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    testAnnotationProcessor "com.querydsl:querydsl-apt:$querydslVersion:jakarta"
     testAnnotationProcessor "org.springframework.data:spring-data-mongodb"
 }
 

--- a/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
@@ -215,13 +215,13 @@ Gradle::
 [source,groovy,indent=0,subs="verbatim,quotes",role="secondary"]
 ----
 dependencies {
-    implementation 'com.querydsl:querydsl-mongodb:${querydslVersion}'
+    implementation "com.querydsl:querydsl-mongodb:${querydslVersion}"
 
-    annotationProcessor 'com.querydsl:querydsl-apt:${querydslVersion}:jakarta'
-    annotationProcessor 'org.springframework.data:spring-data-mongodb'
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "org.springframework.data:spring-data-mongodb"
 
-    testAnnotationProcessor 'com.querydsl:querydsl-apt:${querydslVersion}:jakarta'
-    testAnnotationProcessor 'org.springframework.data:spring-data-mongodb'
+    testAnnotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    testAnnotationProcessor "org.springframework.data:spring-data-mongodb"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-extensions.adoc
@@ -215,7 +215,9 @@ Gradle::
 [source,groovy,indent=0,subs="verbatim,quotes",role="secondary"]
 ----
 dependencies {
-    implementation "com.querydsl:querydsl-mongodb:$querydslVersion"
+    implementation("com.querydsl:querydsl-mongodb:$querydslVersion") {
+        exclude group: "org.mongodb", module: "mongo-java-driver"
+    }
 
     annotationProcessor "com.querydsl:querydsl-apt:$querydslVersion:jakarta"
     annotationProcessor "org.springframework.data:spring-data-mongodb"


### PR DESCRIPTION
[Maven snippet](https://docs.spring.io/spring-data/mongodb/reference/repositories/core-extensions.html#mongodb.repositories.queries.type-safe.apt) has this `<exclusion>`, while Gradle one is missing it. In practice you will face problems with classes loaded in classpath if you don't exclude that legacy `org.mongodb:mongo-java-driver` in Gradle too.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
