### PR TITLE
Add isNull() to ComparisonOperators

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ComparisonOperators.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/aggregation/ComparisonOperators.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  * Gateway to {@literal comparison expressions}.
  *
  * @author Christoph Strobl
+ * @author sathish256
  * @since 1.10
  */
 public class ComparisonOperators {
@@ -145,6 +146,18 @@ public class ComparisonOperators {
 		 */
 		public Eq equalToValue(Object value) {
 			return createEq().equalToValue(value);
+		}
+
+		/**
+		 * Creates new {@link AggregationExpression} that compares two values and returns {@literal true} when the first
+		 * value is equal to {@literal null}.
+		 *
+		 * @return new instance of {@link Eq}.
+		 * @since 5.1
+		 */
+		@Contract(" -> new")
+		public Eq isNull() {
+			return createEq().isNull();
 		}
 
 		@SuppressWarnings("NullAway")
@@ -504,6 +517,21 @@ public class ComparisonOperators {
 
 			Assert.notNull(value, "Value must not be null");
 			return new Eq(append(value, Expand.KEEP_SOURCE));
+		}
+
+		/**
+		 * Creates new {@link Eq} with all previously added arguments appending {@literal null}. Renders to
+		 * {@code {$eq: [..., null]}}.
+		 *
+		 * @return new instance of {@link Eq}.
+		 * @since 5.1
+		 */
+		@Contract(" -> new")
+		public Eq isNull() {
+
+			List<Object> args = values();
+			args.add(null);
+			return new Eq(args);
 		}
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/aggregation/ProjectionOperationUnitTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
  * @author Christoph Strobl
  * @author Divya Srivastava
  * @author Mark Paluch
+ * @author sathish256
  */
 public class ProjectionOperationUnitTests {
 
@@ -1506,6 +1507,15 @@ public class ProjectionOperationUnitTests {
 				.toDocument(Aggregation.DEFAULT_CONTEXT);
 
 		assertThat(agg).isEqualTo(Document.parse("{ $project: { eq250: { $eq: [\"$qty\", [250]]} } }"));
+	}
+
+	@Test // GH-3473
+	void shouldRenderEqNullAggregationExpression() {
+
+		Document agg = project().and(ComparisonOperators.valueOf("qty").isNull()).as("isNull")
+				.toDocument(Aggregation.DEFAULT_CONTEXT);
+
+		assertThat(agg).isEqualTo(Document.parse("{ $project: { isNull: { $eq: [\"$qty\", null]} } }"));
 	}
 
 	@Test // DATAMONGO-1536


### PR DESCRIPTION
Adds an additive `isNull()` builder to `ComparisonOperators` (and its `Eq` operator) so a field or expression can be compared to `null` in aggregation expressions:

```java
ComparisonOperators.valueOf("qty").isNull(); // { $eq: [ "$qty", null ] }
```

This renders to the output requested in the issue and avoids the previous workaround of passing a `null`-returning expression (`equalTo(ctx -> null)`). The existing `equalToValue(...)` contract (which rejects `null`) is left unchanged.

A unit test is added in `ProjectionOperationUnitTests` (`// GH-3473`).

Closes #3473