### PR TITLE
Remove locking in `CursorReadingTask.getState()`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-mongodb-parent</artifactId>
-	<version>5.1.0-SNAPSHOT</version>
+	<version>5.1.0-GH-5201-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data MongoDB</name>

--- a/spring-data-mongodb-distribution/pom.xml
+++ b/spring-data-mongodb-distribution/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.1.0-SNAPSHOT</version>
+		<version>5.1.0-GH-5201-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/pom.xml
+++ b/spring-data-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-mongodb-parent</artifactId>
-		<version>5.1.0-SNAPSHOT</version>
+		<version>5.1.0-GH-5201-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/CursorReadingTask.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/messaging/CursorReadingTask.java
@@ -41,6 +41,8 @@ import com.mongodb.client.MongoCursor;
  */
 abstract class CursorReadingTask<T, R> implements Task {
 
+	// ensure happens-before ordering to avoid asynchronous operations leak while
+	// synchronous operations such as close suggest a completed state.
 	private final Lock lock = Lock.of(new ReentrantLock());
 
 	private final MongoTemplate template;
@@ -49,7 +51,7 @@ abstract class CursorReadingTask<T, R> implements Task {
 	private final ErrorHandler errorHandler;
 	private final CountDownLatch awaitStart = new CountDownLatch(1);
 
-	private State state = State.CREATED;
+	private volatile State state = State.CREATED;
 
 	private @Nullable MongoCursor<T> cursor;
 
@@ -177,7 +179,7 @@ abstract class CursorReadingTask<T, R> implements Task {
 
 	@Override
 	public State getState() {
-		return lock.execute(() -> state);
+		return state;
 	}
 
 	@Override

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/CursorReadingTaskUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/messaging/CursorReadingTaskUnitTests.java
@@ -21,8 +21,12 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.mtc.MultithreadedTestCase;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -121,6 +125,40 @@ public class CursorReadingTaskUnitTests {
 		task.run();
 		verify(errorHandler).handleError(errorCaptor.capture());
 		assertThat(errorCaptor.getValue()).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test // GH-5201
+	public void getStateDoesNotBlockWhileReadingFromCursor() throws Exception {
+
+		when(cursor.getServerCursor()).thenReturn(new ServerCursor(10, new ServerAddress("mock")));
+
+		CountDownLatch tryNextEntered = new CountDownLatch(1);
+		CountDownLatch releaseTryNext = new CountDownLatch(1);
+
+		when(cursor.tryNext()).thenAnswer(invocation -> {
+
+			tryNextEntered.countDown();
+			assertThat(releaseTryNext.await(5, TimeUnit.SECONDS)).isTrue();
+			return null;
+		});
+
+		Thread taskThread = new Thread(task::run, "cursor-reading-task-test");
+		taskThread.start();
+
+		try {
+
+			assertThat(task.awaitStart(Duration.ofSeconds(5))).isTrue();
+			assertThat(tryNextEntered.await(5, TimeUnit.SECONDS)).isTrue();
+
+			CompletableFuture<State> state = CompletableFuture.supplyAsync(task::getState);
+
+			assertThat(state.get(1, TimeUnit.SECONDS)).isEqualTo(State.RUNNING);
+		} finally {
+
+			releaseTryNext.countDown();
+			task.cancel();
+			taskThread.join(5000);
+		}
 	}
 
 	private static class MultithreadedStopRunningWhileEmittingMessages extends MultithreadedTestCase {


### PR DESCRIPTION
`CursorReadingTask` used a single lock to guard both the lifecycle state and access to the underlying `MongoCursor`.
As the cursor read happens through a long-polling `tryNext()` call that can block for up to maxAwaitTime, any concurrent getState() invocation (e.g. via `Subscription.isActive()`) had to wait for the in-flight poll to complete before it could obtain the lock, contradicting the non-blocking nature of the operation.

We now hold the state in a volatile field and read it without acquiring the lock so that getState() returns immediately regardless of an ongoing cursor read. Lifecycle transitions remain guarded by the lock to keep state changes and cursor handling consistent.

Closes #5201