### PR TITLE
GH-5166 - Apply BeforeConvertCallback result in MongoTemplate.replace()

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/MongoTemplate.java
@@ -186,6 +186,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author Michael Krog
  * @author Jakub Zurawa
  * @author Florian Lüdiger
+ * @author Sujay HK
  */
 public class MongoTemplate implements MongoOperations, ApplicationContextAware, IndexOperationsProvider,
 		SearchIndexOperationsProvider, ReadPreferenceAware {
@@ -2184,7 +2185,7 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 	}
 
 	protected <S, T> UpdateResult replace(Query query, Class<S> entityType, T replacement, ReplaceOptions options,
-			String collectionName) {
+										  String collectionName) {
 
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(replacement, "Replacement must not be null");
@@ -2195,10 +2196,10 @@ public class MongoTemplate implements MongoOperations, ApplicationContextAware, 
 		Assert.isTrue(query.getLimit() <= 1, "Query must not define a limit other than 1 ore none");
 		Assert.isTrue(query.getSkip() <= 0, "Query must not define skip");
 
+		replacement = maybeCallBeforeConvert(replacement, collectionName);
 		UpdateContext updateContext = queryOperations.replaceSingleContext(query,
 				operations.forEntity(replacement).toMappedDocument(this.mongoConverter), options.isUpsert());
 
-		replacement = maybeCallBeforeConvert(replacement, collectionName);
 		Document mappedReplacement = updateContext.getMappedUpdate(mappingContext.getPersistentEntity(entityType));
 		maybeEmitEvent(new BeforeSaveEvent<>(replacement, mappedReplacement, collectionName));
 		replacement = maybeCallBeforeSave(replacement, mappedReplacement, collectionName);

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/ReactiveMongoTemplate.java
@@ -194,6 +194,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
  * @author Yadhukrishna S Pai
  * @author Florian Lüdiger
  * @author Kyuhong Han
+ * @author Sujay HK
  * @since 2.0
  */
 public class ReactiveMongoTemplate implements ReactiveMongoOperations, ApplicationContextAware {
@@ -2095,25 +2096,29 @@ public class ReactiveMongoTemplate implements ReactiveMongoOperations, Applicati
 	}
 
 	protected <S, T> Mono<UpdateResult> replace(Query query, Class<S> entityType, T replacement, ReplaceOptions options,
-			String collectionName) {
+												String collectionName) {
 
 		MongoPersistentEntity<?> entity = mappingContext.getPersistentEntity(entityType);
-		UpdateContext updateContext = queryOperations.replaceSingleContext(query,
-				operations.forEntity(replacement).toMappedDocument(this.mongoConverter), options.isUpsert());
 
-		return createMono(collectionName, collection -> {
+		return maybeCallBeforeConvert(replacement, collectionName).flatMap(converted -> {
 
-			Document mappedUpdate = updateContext.getMappedUpdate(entity);
+			UpdateContext updateContext = queryOperations.replaceSingleContext(query,
+					operations.forEntity(converted).toMappedDocument(this.mongoConverter), options.isUpsert());
 
-			MongoAction action = new MongoAction(writeConcern, MongoActionOperation.REPLACE, collectionName, entityType,
-					mappedUpdate, updateContext.getQueryObject());
+			return createMono(collectionName, collection -> {
 
-			MongoCollection<Document> collectionToUse = createCollectionPreparer(query, action).prepare(collection);
+				Document mappedUpdate = updateContext.getMappedUpdate(entity);
 
-			return collectionToUse.replaceOne(updateContext.getMappedQuery(entity), mappedUpdate,
-					updateContext.getReplaceOptions(entity, it -> {
-						it.upsert(options.isUpsert());
-					}));
+				MongoAction action = new MongoAction(writeConcern, MongoActionOperation.REPLACE, collectionName, entityType,
+						mappedUpdate, updateContext.getQueryObject());
+
+				MongoCollection<Document> collectionToUse = createCollectionPreparer(query, action).prepare(collection);
+
+				return collectionToUse.replaceOne(updateContext.getMappedQuery(entity), mappedUpdate,
+						updateContext.getReplaceOptions(entity, it -> {
+							it.upsert(options.isUpsert());
+						}));
+			});
 		});
 	}
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/MongoTemplateTests.java
@@ -73,6 +73,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.mongodb.InvalidMongoDbApiUsageException;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
@@ -95,8 +96,10 @@ import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldName.Type;
 import org.springframework.data.mongodb.core.mapping.MongoId;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeSaveEvent;
 import org.springframework.data.mongodb.core.query.BasicQuery;
@@ -144,6 +147,7 @@ import com.mongodb.client.result.UpdateResult;
  * @author duozhilin
  * @author Jakub Zurawa
  * @author Florian Lüdiger
+ * @author Sujay HK
  */
 public class MongoTemplateTests {
 
@@ -4099,6 +4103,29 @@ public class MongoTemplateTests {
 		assertThat(loaded.mapValue).isEqualTo(sourceMap);
 	}
 
+	@Test // GH-5166
+	void beforeConvertCallbackIsAppliedOnReplace() {
+
+		PersonWithConvertedName person = new PersonWithConvertedName("sujay");
+		template.insert(person);
+
+		// Register a BeforeConvertCallback that uppercases the name
+		template.setEntityCallbacks(EntityCallbacks.create(
+				(BeforeConvertCallback<PersonWithConvertedName>) (entity, collection) -> {
+					entity.name = entity.name.toUpperCase();
+					return entity;
+				}
+		));
+
+		PersonWithConvertedName replacement = new PersonWithConvertedName("sujay");
+		replacement.id = person.id;
+
+		template.replace(query(where("id").is(person.id)), replacement);
+
+		PersonWithConvertedName found = template.findById(person.id, PersonWithConvertedName.class);
+		assertThat(found.name).isEqualTo("SUJAY"); // will FAIL before the fix
+	}
+
 	private AtomicReference<ImmutableVersioned> createAfterSaveReference() {
 
 		AtomicReference<ImmutableVersioned> saved = new AtomicReference<>();
@@ -4111,6 +4138,17 @@ public class MongoTemplateTests {
 		});
 
 		return saved;
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document
+	static class PersonWithConvertedName {
+
+		@Id String id;
+		String name;
+
+		PersonWithConvertedName(String name) {
+			this.name = name;
+		}
 	}
 
 	static class TypeWithNumbers {
@@ -4813,6 +4851,7 @@ public class MongoTemplateTests {
 
 			person.setId(UUID.randomUUID());
 		}
+
 	}
 
 	public static class Message {
@@ -5097,4 +5136,5 @@ public class MongoTemplateTests {
 			return Objects.hash(id, value, mapValue);
 		}
 	}
+
 }

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/ReactiveMongoTemplateTests.java
@@ -71,6 +71,8 @@ import org.springframework.data.mongodb.core.mapping.MongoId;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
+import org.springframework.data.mongodb.core.mapping.event.ReactiveBeforeConvertCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.NearQuery;
 import org.springframework.data.mongodb.core.query.Query;
@@ -89,6 +91,7 @@ import com.mongodb.reactivestreams.client.MongoCollection;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Sujay HK
  */
 public class ReactiveMongoTemplateTests {
 
@@ -2101,6 +2104,28 @@ public class ReactiveMongoTemplateTests {
 		template.save(source).as(StepVerifier::create).expectNextCount(1).verifyComplete();
 	}
 
+	@Test // GH-5166
+	void beforeConvertCallbackIsAppliedOnReplace() {
+
+		PersonWithConvertedName person = new PersonWithConvertedName("sujay");
+		template.insert(person).block();
+
+		template.setEntityCallbacks(ReactiveEntityCallbacks.create(
+				(ReactiveBeforeConvertCallback<PersonWithConvertedName>) (entity, collection) -> {
+					entity.name = entity.name.toUpperCase();
+					return Mono.just(entity);
+				}
+		));
+
+		PersonWithConvertedName replacement = new PersonWithConvertedName("sujay");
+		replacement.id = person.id;
+
+		template.replace(query(where("id").is(person.id)), replacement).block();
+
+		PersonWithConvertedName found = template.findById(person.id, PersonWithConvertedName.class).block();
+		assertThat(found.name).isEqualTo("SUJAY");
+	}
+
 	static class NonAutogeneratableId {
 
 		@Id IdObject id;
@@ -2133,6 +2158,17 @@ public class ReactiveMongoTemplateTests {
 
 		public void setVersion(int version) {
 			this.version = version;
+		}
+	}
+
+	@org.springframework.data.mongodb.core.mapping.Document
+	static class PersonWithConvertedName {
+
+		@Id String id;
+		String name;
+
+		PersonWithConvertedName(String name) {
+			this.name = name;
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the Spring Data contribution guidelines.
- [x] You use the code formatters provided here and have them applied 
      to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [] You added yourself as author in the headers of the classes you 
      touched. Amend the date range in the Apache license header if 
      needed. For new types, add the license header (copy from another 
      file and set the current year only).

## What

`MongoTemplate.replace()` and `ReactiveMongoTemplate.replace()` call
`maybeCallBeforeConvert` but the returned (potentially modified) entity
is not used for BSON mapping. `replaceSingleContext` was already called
with the original entity before the callback fires, so the callback
result is silently discarded.

## Why

The `BeforeConvertCallback` contract requires that the entity returned
by the callback is the one that gets mapped and persisted. The same
class of bug was previously fixed for `doInsert()` in #2481.

## Fix

Move `maybeCallBeforeConvert` before `replaceSingleContext` in
`MongoTemplate.replace()` so the post-callback entity is used for
document mapping.

In `ReactiveMongoTemplate.replace()`, wrap the context creation and
collection operation inside `.flatMap()` on the callback result, since
`maybeCallBeforeConvert` returns `Mono<T>` in the reactive stack.

Tests added in `MongoTemplateTests` and `ReactiveMongoTemplateTests`
to verify the callback result is applied before the replacement is
persisted. Full test suite passes (6303 tests, 0 failures).

Closes #5166