### PR TITLE
Honor standalone @Collation on entities and propagate to repository base methods

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntity.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.core.TypeInformation;
 import org.springframework.data.expression.ValueEvaluationContext;
@@ -96,13 +97,24 @@ public class BasicMongoPersistentEntity<T> extends BasicPersistentEntity<T, Mong
 			this.collection = StringUtils.hasText(document.collection()) ? document.collection() : fallback;
 			this.language = StringUtils.hasText(document.language()) ? document.language() : "";
 			this.expression = detectExpression(document.collection());
-			this.collation = document.collation();
-			this.collationExpression = detectExpression(document.collation());
 		} else {
 
 			this.collection = fallback;
 			this.language = "";
 			this.expression = null;
+		}
+
+		// Pick up the standalone @Collation annotation independently of @Document. @Document.collation
+		// remains supported because @Document is meta-annotated with @Collation and Document#collation
+		// is declared as @AliasFor(annotation = Collation.class, attribute = "value"), so the merged
+		// lookup returns the same value in either case.
+		org.springframework.data.mongodb.core.annotation.Collation collationAnnotation = AnnotatedElementUtils
+				.findMergedAnnotation(rawType, org.springframework.data.mongodb.core.annotation.Collation.class);
+
+		if (collationAnnotation != null && StringUtils.hasText(collationAnnotation.value())) {
+			this.collation = collationAnnotation.value();
+			this.collationExpression = detectExpression(collationAnnotation.value());
+		} else {
 			this.collation = null;
 			this.collationExpression = null;
 		}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java
@@ -124,6 +124,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 
 		return Optional.ofNullable(
@@ -136,6 +137,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 
 		return mongoOperations.exists(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
@@ -158,6 +160,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 	public long count() {
 
 		Query query = new Query();
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.count(query, entityInformation.getCollectionName());
 	}
@@ -168,6 +171,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 	}
@@ -193,6 +197,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 		Assert.notNull(ids, "The given Iterable of ids must not be null");
 
 		Query query = getIdQuery(ids);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 	}
@@ -209,6 +214,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 	public void deleteAll() {
 
 		Query query = new Query();
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 
 		mongoOperations.remove(query, entityInformation.getCollectionName());
@@ -385,6 +391,7 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 	private Query getIdQuery(Iterable<? extends ID> ids) {
 
 		Query query = new Query(new Criteria(entityInformation.getIdAttribute()).in(toCollection(ids)));
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return query;
 	}
@@ -400,8 +407,16 @@ public class SimpleMongoRepository<T, ID> implements MongoRepository<T, ID> {
 			return Collections.emptyList();
 		}
 
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.find(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
+	}
+
+	private void applyDefaultCollation(Query query) {
+
+		if (entityInformation.hasCollation() && !query.getCollation().isPresent()) {
+			query.collation(entityInformation.getCollation());
+		}
 	}
 
 	/**

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepository.java
@@ -130,6 +130,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.findOne(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 	}
@@ -142,6 +143,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		return Mono.from(publisher).flatMap(id -> {
 			Query query = getIdQuery(id);
+			applyDefaultCollation(query);
 			readPreference.ifPresent(query::withReadPreference);
 			return mongoOperations.findOne(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 		});
@@ -153,6 +155,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.exists(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 	}
@@ -165,6 +168,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		return Mono.from(publisher).flatMap(id -> {
 			Query query = getIdQuery(id);
+			applyDefaultCollation(query);
 			readPreference.ifPresent(query::withReadPreference);
 			return mongoOperations.exists(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 		});
@@ -191,6 +195,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Optional<ReadPreference> readPreference = getReadPreference();
 		return Flux.from(ids).buffer().flatMapSequential(listOfIds -> {
 			Query query = getIdQuery(listOfIds);
+			applyDefaultCollation(query);
 			readPreference.ifPresent(query::withReadPreference);
 			return mongoOperations.find(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 		});
@@ -200,6 +205,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 	public Mono<Long> count() {
 
 		Query query = new Query();
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.count(query, entityInformation.getCollectionName());
 	}
@@ -217,6 +223,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 		Assert.notNull(id, "The given id must not be null");
 
 		Query query = getIdQuery(id);
+		applyDefaultCollation(query);
 		readPreference.ifPresent(query::withReadPreference);
 		return mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName()).then();
 	}
@@ -230,6 +237,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 		return Mono.from(publisher).flatMap(id -> {
 			Query query = getIdQuery(id);
+			applyDefaultCollation(query);
 			readPreference.ifPresent(query::withReadPreference);
 			return mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
 		}).then();
@@ -272,6 +280,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 	private Mono<Void> deleteAllById(Iterable<? extends ID> ids, Optional<ReadPreference> readPreference) {
 
 		Query query = getIdQuery(ids);
+		applyDefaultCollation(query);
 		readPreference.ifPresent(query::withReadPreference);
 
 		return mongoOperations.remove(query, entityInformation.getJavaType(), entityInformation.getCollectionName()).then();
@@ -302,6 +311,7 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 	@Override
 	public Mono<Void> deleteAll() {
 		Query query = new Query();
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.remove(query, entityInformation.getCollectionName()).then(Mono.empty());
 	}
@@ -444,8 +454,16 @@ public class SimpleReactiveMongoRepository<T, ID extends Serializable> implement
 
 	private Flux<T> findAll(Query query) {
 
+		applyDefaultCollation(query);
 		getReadPreference().ifPresent(query::withReadPreference);
 		return mongoOperations.find(query, entityInformation.getJavaType(), entityInformation.getCollectionName());
+	}
+
+	private void applyDefaultCollation(Query query) {
+
+		if (entityInformation.hasCollation() && !query.getCollation().isPresent()) {
+			query.collation(entityInformation.getCollation());
+		}
 	}
 
 	private Optional<ReadPreference> getReadPreference() {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/mapping/BasicMongoPersistentEntityUnitTests.java
@@ -296,6 +296,24 @@ public class BasicMongoPersistentEntityUnitTests {
 		assertThat(entity.getCollation()).isEqualTo(Collation.of("en_US"));
 	}
 
+	@Test // GH-4535
+	void readsStandaloneCollationAnnotation() {
+
+		BasicMongoPersistentEntity<WithStandaloneCollation> entity = new BasicMongoPersistentEntity<>(
+				TypeInformation.of(WithStandaloneCollation.class));
+
+		assertThat(entity.getCollation()).isEqualTo(Collation.of("en_US"));
+	}
+
+	@Test // GH-4535
+	void readsStandaloneCollationAnnotationWithoutDocumentAnnotation() {
+
+		BasicMongoPersistentEntity<WithStandaloneCollationOnly> entity = new BasicMongoPersistentEntity<>(
+				TypeInformation.of(WithStandaloneCollationOnly.class));
+
+		assertThat(entity.getCollation()).isEqualTo(Collation.of("en_US"));
+	}
+
 	@Test // DATAMONGO-2341
 	void detectsShardedEntityCorrectly() {
 
@@ -397,6 +415,13 @@ public class BasicMongoPersistentEntityUnitTests {
 
 	@Document(collation = "{ 'locale' : 'en_US' }")
 	class WithDocumentCollation {}
+
+	@Document
+	@org.springframework.data.mongodb.core.annotation.Collation("en_US")
+	class WithStandaloneCollation {}
+
+	@org.springframework.data.mongodb.core.annotation.Collation("en_US")
+	class WithStandaloneCollationOnly {}
 
 	@Sharded
 	private class WithDefaultShardKey {}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepositoryUnitTests.java
@@ -145,6 +145,105 @@ public class SimpleMongoRepositoryUnitTests {
 		assertThat(query.getValue().getCollation()).contains(collation);
 	}
 
+	@ParameterizedTest // GH-4535
+	@MethodSource("findCallsThatAcceptDefaultCollation")
+	void shouldAddDefaultCollationToFindMethods(
+			Consumer<SimpleMongoRepository<Object, Object>> findCall) {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+
+		findCall.accept(repository);
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).find(query.capture(), any(), any());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToFindById() {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getIdAttribute()).thenReturn("id");
+
+		repository.findById("42");
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).findOne(query.capture(), any(), any());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToExistsById() {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getIdAttribute()).thenReturn("id");
+
+		repository.existsById("42");
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).exists(query.capture(), any(), any());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToCount() {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getCollectionName()).thenReturn("documents");
+
+		repository.count();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).count(query.capture(), any(String.class));
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToDeleteById() {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getIdAttribute()).thenReturn("id");
+		when(entityInformation.getJavaType()).thenReturn(Object.class);
+		when(entityInformation.getCollectionName()).thenReturn("documents");
+
+		repository.deleteById("42");
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).remove(query.capture(), any(Class.class), any(String.class));
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToDeleteAll() {
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getCollectionName()).thenReturn("documents");
+
+		repository.deleteAll();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).remove(query.capture(), any(String.class));
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
 	@ParameterizedTest // GH-2971
 	@MethodSource("findAllCalls")
 	void shouldAddReadPreferenceToFindAllMethods(Consumer<SimpleMongoRepository<Object, Object>> findCall)
@@ -217,6 +316,16 @@ public class SimpleMongoRepositoryUnitTests {
 				Arguments.of(findAllWithExample), //
 				Arguments.of(findAllWithExampleAndSort), //
 				Arguments.of(findAllWithExampleAndPage));
+	}
+
+	private static Stream<Arguments> findCallsThatAcceptDefaultCollation() {
+
+		Consumer<SimpleMongoRepository<Object, Object>> findAll = SimpleMongoRepository::findAll;
+		Consumer<SimpleMongoRepository<Object, Object>> findAllWithSort = repo -> repo.findAll(Sort.by("age"));
+		Consumer<SimpleMongoRepository<Object, Object>> findAllWithPage = repo -> repo
+				.findAll(PageRequest.of(1, 20, Sort.by("age")));
+
+		return Stream.of(Arguments.of(findAll), Arguments.of(findAllWithSort), Arguments.of(findAllWithPage));
 	}
 
 	static class TestDummy {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepositoryUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/support/SimpleReactiveMongoRepositoryUnitTests.java
@@ -150,6 +150,61 @@ class SimpleReactiveMongoRepositoryUnitTests {
 		assertThat(query.getValue().getCollation()).contains(collation);
 	}
 
+	@Test // GH-4535
+	void shouldAddDefaultCollationToFindById() {
+
+		when(mongoOperations.findOne(any(), any(), any())).thenReturn(mono);
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getIdAttribute()).thenReturn("id");
+
+		repository.findById("42").subscribe();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).findOne(query.capture(), any(), any());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToCount() {
+
+		when(mongoOperations.count(any(), anyString())).thenReturn(mono);
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getCollectionName()).thenReturn("testdummy");
+
+		repository.count().subscribe();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).count(query.capture(), anyString());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
+	@Test // GH-4535
+	void shouldAddDefaultCollationToDeleteAll() {
+
+		when(mongoOperations.remove(any(Query.class), anyString())).thenReturn(mono);
+		when(mono.then(any(Mono.class))).thenReturn(Mono.empty());
+
+		Collation collation = Collation.of("en_US");
+		when(entityInformation.hasCollation()).thenReturn(true);
+		when(entityInformation.getCollation()).thenReturn(collation);
+		when(entityInformation.getCollectionName()).thenReturn("testdummy");
+
+		repository.deleteAll().subscribe();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(mongoOperations).remove(query.capture(), anyString());
+
+		assertThat(query.getValue().getCollation()).contains(collation);
+	}
+
 	@ParameterizedTest // GH-2971
 	@MethodSource("findAllCalls")
 	void shouldAddReadPreferenceToFindAllMethods(


### PR DESCRIPTION
## What this addresses

`@Collation` on an entity is not picked up unless it is set through `@Document(collation = ...)`, and even when it _is_ picked up, the entity collation only reaches `Example`-based repository methods. Plain CRUD methods (`findById`, `findAll`, `count`, `deleteAll`, …) are dispatched without it, so the resulting MongoDB operation runs with no collation even though the entity declares one.

Closes: #4535

## Root cause

Two cooperating gaps in the entity → repository wiring:

1. `BasicMongoPersistentEntity` only consults `@Document.collation()`. The standalone `@Collation` annotation in `org.springframework.data.mongodb.core.annotation` is the canonical source (it is what `@Document.collation()` is itself `@AliasFor` for), yet it is ignored unless `@Document` is present and uses the `collation` attribute. So `@Collation(\"en_US\")` on a type — with or without an accompanying `@Document` — silently has no effect.

2. `SimpleMongoRepository` / `SimpleReactiveMongoRepository` only propagate `entityInformation.getCollation()` on the `Example`-based query path. The basic CRUD methods (`findById`, `existsById`, `findAll`, `findAll(Sort)`, `findAll(Pageable)`, `findAllById`, `count`, `deleteById`, `deleteAllById`, `deleteAll`) build their `Query` without `.collation(...)`, so even if (1) is fixed, the collation is dropped at the repository boundary.

These are exactly the two locations called out in the issue thread.

## Change summary

**`BasicMongoPersistentEntity`** — resolve collation via `AnnotatedElementUtils.findMergedAnnotation(rawType, Collation.class)`. Because `@Document` is meta-annotated with `@Collation` and `Document#collation` is declared as `@AliasFor(annotation = Collation.class, attribute = \"value\")`, the merged lookup returns the same value whether the user writes `@Document(collation = \"en_US\")` or `@Collation(\"en_US\")` (with or without `@Document`). Existing `@Document.collation()` behavior — literal value, SpEL expression, JSON document form — is preserved.

**`SimpleMongoRepository`** and **`SimpleReactiveMongoRepository`** — add a small `applyDefaultCollation(Query)` helper and invoke it from every base CRUD method that builds a `Query` (and from the shared `findAll(Query)` / `getIdQuery(Iterable)` helpers that funnel `findAll` and `findAllById`). The helper only sets the collation when one is defined and the query does not already carry one, so an explicit `Query.collation(...)` from a caller still wins.

## Why this is the right fix

The maintainer (christophstrobl) diagnosed exactly this shape on the issue: \"`BasicPersistentEntity` did not properly consider `@Collation` but was only looking for `@Document` and the collation was not properly passed on in `SimpleMongoRepository`.\" The change is additive — annotation handling extends to a strictly larger set of users (the existing `@Document(collation=...)` users keep getting the same `Collation` instance), and collation propagation aligns the base CRUD methods with the `Example`-based methods that have always carried it. Behavior for users that do not declare an entity collation is unchanged: `entityInformation.hasCollation()` returns `false` and `applyDefaultCollation` is a no-op.

## Tests

New tests added:

- `BasicMongoPersistentEntityUnitTests`:
  - `readsStandaloneCollationAnnotation` — `@Document` + standalone `@Collation(\"en_US\")` resolves to `Collation.of(\"en_US\")`.
  - `readsStandaloneCollationAnnotationWithoutDocumentAnnotation` — `@Collation(\"en_US\")` without `@Document` resolves correctly.
- `SimpleMongoRepositoryUnitTests`:
  - `shouldAddDefaultCollationToFindMethods` (parameterized over `findAll()`, `findAll(Sort)`, `findAll(Pageable)`).
  - `shouldAddDefaultCollationToFindById`, `shouldAddDefaultCollationToExistsById`, `shouldAddDefaultCollationToCount`, `shouldAddDefaultCollationToDeleteById`, `shouldAddDefaultCollationToDeleteAll`.
- `SimpleReactiveMongoRepositoryUnitTests`:
  - `shouldAddDefaultCollationToFindById`, `shouldAddDefaultCollationToCount`, `shouldAddDefaultCollationToDeleteAll`.

Existing collation tests (`DATAMONGO-1854`, `DATAMONGO-2565`) continue to pass; they cover `@Document(collation = ...)` literal/JSON/SpEL forms.

## Verification done

- ✅ Reviewed the issue thread and confirmed the maintainer-pinpointed root cause matches the code state on `main` (BasicMongoPersistentEntity ignores standalone `@Collation`; SimpleMongoRepository drops collation on base CRUD methods).
- ✅ Searched `gh pr list` and PR search on `spring-projects/spring-data-mongodb` for any in-flight PR referencing #4535 — none.
- ✅ Confirmed no \"I'm working on this\" claim from another contributor in the last 21 days (last comments are user bumps from 2025-03 and 2025-07-19).
- ✅ Grepped `main` for `BasicMongoPersistentEntity`, `SimpleMongoRepository`, `SimpleReactiveMongoRepository`, and `entityInformation.getCollation()` to confirm the bug pattern is still present.
- ✅ Targeted Maven build: `./mvnw -pl spring-data-mongodb test -Dtest='BasicMongoPersistentEntityUnitTests,SimpleMongoRepositoryUnitTests,SimpleReactiveMongoRepositoryUnitTests'` → 61 tests, all green.
- ✅ Broader regression: `./mvnw -pl spring-data-mongodb test -Dtest='BasicMongoPersistent*,*Mongo*Repository*UnitTests,*MongoQuery*UnitTests'` → 365 tests, all green.

## Scope notes

The issue also mentions `@Collation` on the repository interface and on individual query methods. Those flow through `MongoQueryMethod` (a separate code path from `BasicMongoPersistentEntity` / `SimpleMongoRepository`) and were intentionally left out to keep this change focused on the entity-level case the maintainer explicitly confirmed; method-level `@Collation` already works through the `@Query(collation = ...)` alias.