### PR TITLE
Fix false cycle detection for generic types with different type arguments.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolver.java
@@ -79,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Perryman
  * @author Stefan Tirea
  * @author Sangbeen Moon
+ * @author Kamil Krzywanski
  * @since 1.5
  */
 public class MongoPersistentEntityIndexResolver implements IndexResolver {
@@ -860,6 +861,7 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 		 *
 		 * @author Christoph Strobl
 		 * @author Mark Paluch
+		 * @author Kamil Krzywanski
 		 */
 		static class Path {
 
@@ -905,7 +907,7 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 				elements.addAll(this.elements);
 				elements.add(breadcrumb);
 
-				return new Path(elements, this.elements.contains(breadcrumb));
+				return new Path(elements, containsCycleCandidate(this.elements, breadcrumb));
 			}
 
 			/**
@@ -936,7 +938,7 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 
 				for (int i = 0; i < this.elements.size(); i++) {
 
-					int index = indexOf(this.elements, this.elements.get(i), i + 1);
+					int index = indexOfCycleCandidate(this.elements, this.elements.get(i), i + 1);
 
 					if (index != -1) {
 						return toPath(this.elements.subList(i, index + 1).iterator());
@@ -946,15 +948,51 @@ public class MongoPersistentEntityIndexResolver implements IndexResolver {
 				return toString();
 			}
 
-			private static <T> int indexOf(List<T> haystack, T needle, int offset) {
+			/**
+			 * Cycle detection cannot rely on {@link PersistentProperty#equals(Object)} alone: that equality is based on the
+			 * reflected field and therefore collapses generic types that share the same raw owner type (for example
+			 * {@code Selection<FruitBasket>} vs {@code Selection<String>}). Comparing the property name together with the
+			 * owner's resolved {@link TypeInformation} keeps genuine recursion (same parameterized type reappearing) while
+			 * allowing the same generic type to appear with different type arguments.
+			 *
+			 * @see <a href="https://github.com/spring-projects/spring-data-mongodb/issues/5213">GH-5213</a>
+			 */
+			private static boolean containsCycleCandidate(List<PersistentProperty<?>> elements,
+					PersistentProperty<?> breadcrumb) {
+
+				for (PersistentProperty<?> element : elements) {
+					if (isSameCycleCandidate(element, breadcrumb)) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			private static int indexOfCycleCandidate(List<PersistentProperty<?>> haystack, PersistentProperty<?> needle,
+					int offset) {
 
 				for (int i = offset; i < haystack.size(); i++) {
-					if (haystack.get(i).equals(needle)) {
+					if (isSameCycleCandidate(haystack.get(i), needle)) {
 						return i;
 					}
 				}
 
 				return -1;
+			}
+
+			private static boolean isSameCycleCandidate(PersistentProperty<?> left, PersistentProperty<?> right) {
+
+				if (left == right) {
+					return true;
+				}
+
+				if (!ObjectUtils.nullSafeEquals(left.getName(), right.getName())) {
+					return false;
+				}
+
+				return ObjectUtils.nullSafeEquals(left.getOwner().getTypeInformation(),
+						right.getOwner().getTypeInformation());
 			}
 
 			private static String toPath(Iterator<PersistentProperty<?>> iterator) {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/MongoPersistentEntityIndexResolverUnitTests.java
@@ -66,6 +66,7 @@ import org.springframework.mock.env.MockEnvironment;
  * @author Mark Paluch
  * @author Dave Perryman
  * @author Stefan Tirea
+ * @author Kamil Krzywanski
  */
 @RunWith(Suite.class)
 @SuiteClasses({ IndexResolutionTests.class, GeoSpatialIndexResolutionTests.class, CompoundIndexResolutionTests.class,
@@ -1235,6 +1236,27 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 			assertThat(indexDefinitions).isEmpty();
 		}
 
+		@Test // GH-5213
+		public void shouldNotDetectCycleForGenericTypeUsedWithDifferentTypeArguments() {
+
+			List<IndexDefinitionHolder> indexDefinitions = prepareMappingContextAndResolveIndexForType(FruitShop.class);
+
+			assertThat(indexDefinitions).hasSize(1);
+			assertIndexPathAndCollection("fruitBaskets.include.fruit.include.name", "fruitShop", indexDefinitions.get(0));
+		}
+
+		@Test // GH-5213
+		public void shouldStillDetectGenuineCycleThroughGenericType() {
+
+			List<IndexDefinitionHolder> indexDefinitions = prepareMappingContextAndResolveIndexForType(
+					GenericTreeDocument.class);
+
+			// Indexes on the first occurrence of the generic type are kept; further recursion into the same
+			// parameterized type is treated as a cycle and stops.
+			assertThat(indexDefinitions).hasSize(1);
+			assertIndexPathAndCollection("children.name", "genericTreeDocument", indexDefinitions.get(0));
+		}
+
 		@Test // DATAMONGO-962
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public void shouldCatchCyclicReferenceExceptionOnRoot() {
@@ -1669,6 +1691,43 @@ public class MongoPersistentEntityIndexResolverUnitTests {
 
 			List<SelfCyclingViaCollectionType> cyclic;
 
+		}
+
+		/**
+		 * Reproducer for GH-5213: the same generic type appears twice with different type arguments.
+		 * That is not a structural cycle and nested {@link Indexed} fields must still be discovered.
+		 */
+		@Document
+		static class FruitShop {
+
+			Selection<FruitBasket> fruitBaskets;
+		}
+
+		static class FruitBasket {
+			Selection<IndexedItem> fruit;
+		}
+
+		static class IndexedItem {
+			@Indexed String name;
+		}
+
+		static class Selection<T> {
+			T include;
+		}
+
+		/**
+		 * Genuine cycle through a generic type: {@code GenericTreeDocument -> Box<GenericTreeDocument> -> GenericTreeDocument}.
+		 * Index resolution must still stop recursion after discovering indexes one level into the cycle.
+		 */
+		@Document
+		static class GenericTreeDocument {
+
+			Box<GenericTreeDocument> children;
+		}
+
+		static class Box<T> {
+			@Indexed String name;
+			T value;
 		}
 
 		@Document

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/PathUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/PathUnitTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.mongodb.core.index;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +27,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import org.springframework.core.ResolvableType;
 import org.springframework.data.core.TypeInformation;
 import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver.CycleGuard.Path;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 
@@ -87,16 +89,28 @@ public class PathUnitTests {
 		assertThat(Path.of(foo).append(bar).append(bar2).isCycle()).isFalse();
 	}
 
+	/**
+	 * Uses real mapping properties so equality matches production: {@code Selection.include} is backed by the same
+	 * reflected field for every parameterization of {@code Selection}, which is what triggered the GH-5213 false cycle.
+	 */
 	@Test // GH-5213
 	public void isCycleShouldReturnFalseForSamePropertyNameOnGenericOwnersWithDifferentTypeArguments() {
 
-		TypeInformation<?> selectionOfBasket = parameterized(Selection.class, FruitBasket.class);
-		TypeInformation<?> selectionOfString = parameterized(Selection.class, String.class);
+		MongoMappingContext context = createMappingContext(FruitShop.class);
 
-		MongoPersistentProperty includeBasket = createPersistentPropertyMock(mockOwner(selectionOfBasket), "include");
-		MongoPersistentProperty fruit = createPersistentPropertyMock(mockOwner(TypeInformation.of(FruitBasket.class)),
-				"fruit");
-		MongoPersistentProperty includeString = createPersistentPropertyMock(mockOwner(selectionOfString), "include");
+		MongoPersistentProperty fruitBaskets = context.getRequiredPersistentEntity(FruitShop.class)
+				.getRequiredPersistentProperty("fruitBaskets");
+		MongoPersistentProperty includeBasket = context.getRequiredPersistentEntity(fruitBaskets.getTypeInformation())
+				.getRequiredPersistentProperty("include");
+		MongoPersistentProperty fruit = context.getRequiredPersistentEntity(includeBasket.getTypeInformation())
+				.getRequiredPersistentProperty("fruit");
+		MongoPersistentProperty includeString = context.getRequiredPersistentEntity(fruit.getTypeInformation())
+				.getRequiredPersistentProperty("include");
+
+		// Precondition of the bug: property equality collapses generic type arguments.
+		assertThat(includeBasket).isEqualTo(includeString);
+		assertThat(includeBasket.getOwner().getTypeInformation())
+				.isNotEqualTo(includeString.getOwner().getTypeInformation());
 
 		Path path = Path.of(includeBasket).append(fruit).append(includeString);
 
@@ -105,24 +119,35 @@ public class PathUnitTests {
 		assertThat(path.toString()).isEqualTo("include -> fruit -> include");
 	}
 
+	/**
+	 * Genuine recursion through the same parameterized type must still be reported as a cycle. Real mapping properties
+	 * are used so the path is built the same way index resolution walks the entity graph.
+	 */
 	@Test // GH-5213
 	public void isCycleShouldReturnTrueForSamePropertyNameOnGenericOwnersWithSameTypeArguments() {
 
-		TypeInformation<?> selectionOfNode = parameterized(Selection.class, TreeNode.class);
+		MongoMappingContext context = createMappingContext(TreeNode.class);
 
-		MongoPersistentProperty includeOne = createPersistentPropertyMock(mockOwner(selectionOfNode), "include");
-		MongoPersistentProperty child = createPersistentPropertyMock(mockOwner(TypeInformation.of(TreeNode.class)),
-				"child");
-		MongoPersistentProperty includeTwo = createPersistentPropertyMock(mockOwner(selectionOfNode), "include");
+		MongoPersistentProperty child = context.getRequiredPersistentEntity(TreeNode.class)
+				.getRequiredPersistentProperty("child");
+		MongoPersistentProperty include = context.getRequiredPersistentEntity(child.getTypeInformation())
+				.getRequiredPersistentProperty("include");
 
-		Path path = Path.of(includeOne).append(child).append(includeTwo);
+		// Re-entering Selection<TreeNode> yields the same property (equal and same TypeInformation).
+		assertThat(include.getOwner().getTypeInformation()).isEqualTo(child.getTypeInformation());
+
+		Path path = Path.of(include).append(child).append(include);
 
 		assertThat(path.isCycle()).isTrue();
 		assertThat(path.toCyclePath()).isEqualTo("include -> child -> include");
 	}
 
-	private static TypeInformation<?> parameterized(Class<?> rawType, Class<?> typeArgument) {
-		return TypeInformation.of(ResolvableType.forClassWithGenerics(rawType, typeArgument));
+	private static MongoMappingContext createMappingContext(Class<?>... types) {
+
+		MongoMappingContext context = new MongoMappingContext();
+		context.setInitialEntitySet(Set.of(types));
+		context.afterPropertiesSet();
+		return context;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -144,12 +169,16 @@ public class PathUnitTests {
 		return property;
 	}
 
-	static class Selection<T> {
-		T include;
+	static class FruitShop {
+		Selection<FruitBasket> fruitBaskets;
 	}
 
 	static class FruitBasket {
 		Selection<String> fruit;
+	}
+
+	static class Selection<T> {
+		T include;
 	}
 
 	static class TreeNode {

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/PathUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/core/index/PathUnitTests.java
@@ -25,6 +25,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.core.ResolvableType;
+import org.springframework.data.core.TypeInformation;
 import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver.CycleGuard.Path;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -34,6 +36,7 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Kamil Krzywanski
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class PathUnitTests {
@@ -44,6 +47,7 @@ public class PathUnitTests {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void setUp() {
 		when(entityMock.getType()).thenReturn((Class) Object.class);
+		doReturn(TypeInformation.of(Object.class)).when(entityMock).getTypeInformation();
 	}
 
 	@Test // DATAMONGO-962, DATAMONGO-1782
@@ -77,9 +81,56 @@ public class PathUnitTests {
 
 		MongoPersistentProperty foo = createPersistentPropertyMock(entityMock, "foo");
 		MongoPersistentProperty bar = createPersistentPropertyMock(entityMock, "bar");
-		MongoPersistentProperty bar2 = createPersistentPropertyMock(mock(MongoPersistentEntity.class), "bar");
+
+		MongoPersistentProperty bar2 = createPersistentPropertyMock(mockOwner(TypeInformation.of(String.class)), "bar");
 
 		assertThat(Path.of(foo).append(bar).append(bar2).isCycle()).isFalse();
+	}
+
+	@Test // GH-5213
+	public void isCycleShouldReturnFalseForSamePropertyNameOnGenericOwnersWithDifferentTypeArguments() {
+
+		TypeInformation<?> selectionOfBasket = parameterized(Selection.class, FruitBasket.class);
+		TypeInformation<?> selectionOfString = parameterized(Selection.class, String.class);
+
+		MongoPersistentProperty includeBasket = createPersistentPropertyMock(mockOwner(selectionOfBasket), "include");
+		MongoPersistentProperty fruit = createPersistentPropertyMock(mockOwner(TypeInformation.of(FruitBasket.class)),
+				"fruit");
+		MongoPersistentProperty includeString = createPersistentPropertyMock(mockOwner(selectionOfString), "include");
+
+		Path path = Path.of(includeBasket).append(fruit).append(includeString);
+
+		assertThat(path.isCycle()).isFalse();
+		assertThat(path.toCyclePath()).isEqualTo("");
+		assertThat(path.toString()).isEqualTo("include -> fruit -> include");
+	}
+
+	@Test // GH-5213
+	public void isCycleShouldReturnTrueForSamePropertyNameOnGenericOwnersWithSameTypeArguments() {
+
+		TypeInformation<?> selectionOfNode = parameterized(Selection.class, TreeNode.class);
+
+		MongoPersistentProperty includeOne = createPersistentPropertyMock(mockOwner(selectionOfNode), "include");
+		MongoPersistentProperty child = createPersistentPropertyMock(mockOwner(TypeInformation.of(TreeNode.class)),
+				"child");
+		MongoPersistentProperty includeTwo = createPersistentPropertyMock(mockOwner(selectionOfNode), "include");
+
+		Path path = Path.of(includeOne).append(child).append(includeTwo);
+
+		assertThat(path.isCycle()).isTrue();
+		assertThat(path.toCyclePath()).isEqualTo("include -> child -> include");
+	}
+
+	private static TypeInformation<?> parameterized(Class<?> rawType, Class<?> typeArgument) {
+		return TypeInformation.of(ResolvableType.forClassWithGenerics(rawType, typeArgument));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static MongoPersistentEntity<?> mockOwner(TypeInformation<?> typeInformation) {
+
+		MongoPersistentEntity owner = mock(MongoPersistentEntity.class);
+		doReturn(typeInformation).when(owner).getTypeInformation();
+		return owner;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -91,5 +142,17 @@ public class PathUnitTests {
 		when(property.getName()).thenReturn(fieldname);
 
 		return property;
+	}
+
+	static class Selection<T> {
+		T include;
+	}
+
+	static class FruitBasket {
+		Selection<String> fruit;
+	}
+
+	static class TreeNode {
+		Selection<TreeNode> child;
 	}
 }


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

## Summary

Fixes a spurious cycle detection in `MongoPersistentEntityIndexResolver.CycleGuard.Path` when the same generic type appears more than once with different type arguments (for example `Selection<FruitBasket>` and `Selection<String>`).

Previously, cycle detection relied on `PersistentProperty.equals()`, which is based on the reflected field and therefore collapses parameterized owners that share the same raw type. That stopped index resolution early and caused nested `@Indexed` fields to be ignored, with a misleading `Found cycle` log message.

Cycle detection now compares the property name together with the owner's resolved `TypeInformation`, so:

- distinct type arguments are not treated as a cycle (nested indexes are discovered)
- genuine recursion through the same parameterized type still stops as before

## Related issue

Closes #5213

## Test plan

- [x] Added `PathUnitTests` for same property name on generic owners with different / same type arguments
- [x] Added `MongoPersistentEntityIndexResolverUnitTests` covering the GH-5213 repro (`FruitShop`) and a genuine generic cycle (`GenericTreeDocument`)
- [x] `./mvnw -pl spring-data-mongodb -Dtest=PathUnitTests,MongoPersistentEntityIndexResolverUnitTests test` — 101 tests, 0 failures