### PR TITLE
Support Set return types in MongoDB AOT repositories.

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/MongoCodeBlocks.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/aot/MongoCodeBlocks.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mongodb.repository.aot;
 
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.bson.Document;
@@ -48,6 +49,7 @@ import org.springframework.util.StringUtils;
  * {@link CodeBlock} generator for common tasks.
  *
  * @author Christoph Strobl
+ * @author maryantocinn
  * @since 5.0
  */
 class MongoCodeBlocks {
@@ -237,8 +239,8 @@ class MongoCodeBlocks {
 	}
 
 	/**
-	 * Wraps the given {@link CodeBlock} representing an {@link Iterable} into a {@link Streamable} if the
-	 * {@link MethodReturn} indicates so.
+	 * Adapts the given {@link CodeBlock} representing an {@link Iterable} to the declared collection return type if
+	 * necessary.
 	 */
 	public static CodeBlock potentiallyWrapStreamable(MethodReturn methodReturn, CodeBlock returningIterable) {
 
@@ -253,6 +255,11 @@ class MongoCodeBlocks {
 			return CodeBlock.of(
 					"($1T) $2T.getSharedInstance().convert($3T.of($4L), $5T.valueOf($3T.class), $5T.valueOf($1T.class))",
 					returnType, DefaultConversionService.class, Streamable.class, returningIterable, TypeDescriptor.class);
+		}
+
+		if (ClassUtils.isAssignable(Set.class, returnType)) {
+			return CodeBlock.of("$2T.getSharedInstance().convert($3L, $1T.class)", returnType,
+					DefaultConversionService.class, returningIterable);
 		}
 
 		return returningIterable;

--- a/spring-data-mongodb/src/test/java/example/aot/UserRepository.java
+++ b/spring-data-mongodb/src/test/java/example/aot/UserRepository.java
@@ -52,12 +52,15 @@ import org.springframework.data.util.Streamable;
 
 /**
  * @author Christoph Strobl
+ * @author maryantocinn
  */
 public interface UserRepository extends CrudRepository<User, String> {
 
 	/* Derived Queries */
 
 	List<User> findUserNoArgumentsBy();
+
+	Set<User> findUserSetBy();
 
 	Streamable<User> streamUserNoArgumentsBy();
 
@@ -233,6 +236,8 @@ public interface UserRepository extends CrudRepository<User, String> {
 	/* Projecting Queries */
 
 	List<UserProjection> findUserProjectionByLastnameStartingWith(String lastname);
+
+	Set<UserProjection> findUserProjectionSetByLastnameStartingWith(String lastname);
 
 	Page<UserProjection> findUserProjectionByLastnameStartingWith(String lastname, Pageable page);
 

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/aot/MongoRepositoryContributorTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/aot/MongoRepositoryContributorTests.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.bson.BsonString;
@@ -79,6 +80,7 @@ import com.mongodb.client.model.SearchIndexType;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author maryantocinn
  */
 @Testcontainers(disabledWithoutDocker = true)
 @SpringJUnitConfig(classes = MongoRepositoryContributorTests.MongoRepositoryContributorConfiguration.class)
@@ -198,6 +200,15 @@ class MongoRepositoryContributorTests {
 
 		List<User> users = fragment.findUserNoArgumentsBy();
 		assertThat(users).hasSize(7).hasOnlyElementsOfType(User.class);
+	}
+
+	@Test // GH-5225
+	void testDerivedQueryAsSet() {
+
+		Set<User> users = fragment.findUserSetBy();
+
+		assertThat(users).isInstanceOf(Set.class).extracting(User::getUsername).containsExactlyInAnyOrder("luke", "leia",
+				"han", "chewbacca", "yoda", "vader", "kylo");
 	}
 
 	@Test
@@ -561,6 +572,14 @@ class MongoRepositoryContributorTests {
 
 		List<UserProjection> users = fragment.findUserProjectionByLastnameStartingWith("S");
 		assertThat(users).extracting(UserProjection::getUsername).containsExactlyInAnyOrder("han", "kylo", "luke", "vader");
+	}
+
+	@Test // GH-5225
+	void testDerivedQueryReturningSetOfProjections() {
+
+		Set<UserProjection> users = fragment.findUserProjectionSetByLastnameStartingWith("S");
+		assertThat(users).isInstanceOf(Set.class).extracting(UserProjection::getUsername)
+				.containsExactlyInAnyOrder("han", "kylo", "luke", "vader");
 	}
 
 	@Test

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/aot/QueryMethodContributionUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/repository/aot/QueryMethodContributionUnitTests.java
@@ -64,6 +64,7 @@ import org.springframework.javapoet.MethodSpec;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Tomasz Forys
+ * @author maryantocinn
  */
 class QueryMethodContributionUnitTests {
 
@@ -397,6 +398,17 @@ class QueryMethodContributionUnitTests {
 
 		assertThat(methodSpec.toString()) //
 				.containsSubsequence("return", "Streamable.of(", "all())");
+	}
+
+	@Test // GH-5225
+	void rendersSetReturnType() throws NoSuchMethodException {
+
+		MethodSpec methodSpec = codeOf(UserRepository.class, "findUserSetBy");
+
+		assertThat(methodSpec.toString()) //
+				.contains("DefaultConversionService.getSharedInstance().convert(") //
+				.containsSubsequence("return", "all()", "Set.class") //
+				.doesNotContain("return finder.matching(filterQuery).all()");
 	}
 
 	@Test // GH-5089


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

## Summary

Fixes AOT-generated repository implementations for query methods returning `Set<T>`.

`ExecutableFindOperation.TerminatingResults#all()` returns a `List<T>`. Previously, the generated method returned that value directly even when the repository method declared a `Set<T>`, causing the generated source to fail compilation because `List<T>` cannot be converted to `Set<T>`.

The generated code now uses `DefaultConversionService` to adapt the result to the declared `Set` return type. This applies to both entity and projection query results.

## Related issue

Closes #5225

## Test plan

- Added a generated-code unit test verifying that `Set` return types use `DefaultConversionService`.
- Added integration tests for derived queries returning sets of entities and projections.
- Verified the original reproducer compiles its generated AOT sources against the fixed snapshot.
- Ran:

  `./mvnw -pl spring-data-mongodb -Dtest=MongoRepositoryContributorTests,QueryMethodContributionUnitTests test`

```text
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.data.mongodb.repository.aot.QueryMethodContributionUnitTests
[INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.937 s -- in org.springframework.data.mongodb.repository.aot.QueryMethodContributionUnitTests
[INFO] Running org.springframework.data.mongodb.repository.aot.MongoRepositoryContributorTests
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.16 s -- in org.springframework.data.mongodb.repository.aot.MongoRepositoryContributorTests
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 122, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:01 min
[INFO] Finished at: 2026-07-21T15:43:51+07:00
[INFO] ------------------------------------------------------------------------
[INFO] 13 goals, 13 executed
```
