### PR TITLE
Extending the spring cache abstraction to using mongo as the cache datastore [DATAMONGO-2062]

### DIFF
--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCache.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCache.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import com.mongodb.client.result.DeleteResult;
+import org.jspecify.annotations.Nullable;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.SimpleValueWrapper;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.Assert;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A {@link Cache} backed by a MongoDB collection.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public class MongoCache implements Cache {
+
+	private final String name;
+	private final MongoOperations mongoOperations;
+	private final MongoCacheConfiguration configuration;
+	private final Clock clock;
+	private final ConcurrentMap<String, Object> valueLoaderLocks = new ConcurrentHashMap<>();
+
+	/**
+	 * Create a cache using {@link MongoCacheConfiguration#defaultCacheConfig()}.
+	 *
+	 * @param name must not be {@literal null} or empty.
+	 * @param mongoOperations must not be {@literal null}.
+	 */
+	public MongoCache(String name, MongoOperations mongoOperations) {
+		this(name, mongoOperations, MongoCacheConfiguration.defaultCacheConfig());
+	}
+
+	/**
+	 * Create a cache with the given configuration.
+	 *
+	 * @param name must not be {@literal null} or empty.
+	 * @param mongoOperations must not be {@literal null}.
+	 * @param configuration must not be {@literal null}.
+	 */
+	public MongoCache(String name, MongoOperations mongoOperations, MongoCacheConfiguration configuration) {
+		this(name, mongoOperations, configuration, Clock.systemUTC());
+	}
+
+	MongoCache(String name, MongoOperations mongoOperations, MongoCacheConfiguration configuration, Clock clock) {
+
+		Assert.hasText(name, "Cache name must not be empty");
+		Assert.notNull(mongoOperations, "MongoOperations must not be null");
+		Assert.notNull(configuration, "MongoCacheConfiguration must not be null");
+		Assert.notNull(clock, "Clock must not be null");
+
+		this.name = name;
+		this.mongoOperations = mongoOperations;
+		this.configuration = configuration;
+		this.clock = clock;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public Object getNativeCache() {
+		return this.mongoOperations;
+	}
+
+	@Override
+	public @Nullable ValueWrapper get(Object key) {
+
+		MongoCacheEntry entry = lookup(key);
+		return entry != null ? new SimpleValueWrapper(fromStoreValue(entry)) : null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T get(Object key, @Nullable Class<T> type) {
+
+		MongoCacheEntry entry = lookup(key);
+		if (entry == null) {
+			return null;
+		}
+
+		Object value = fromStoreValue(entry);
+		if (value != null && type != null && !type.isInstance(value)) {
+			throw new IllegalStateException("Cached value is not of required type [" + type.getName() + "]: " + value);
+		}
+
+		return type != null ? type.cast(value) : (T) value;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T get(Object key, Callable<T> valueLoader) {
+
+		Assert.notNull(valueLoader, "Value loader must not be null");
+
+		ValueWrapper wrapper = get(key);
+		if (wrapper != null) {
+			return (T) wrapper.get();
+		}
+
+		String keyId = MongoCacheKey.id(this.name, key);
+		Object lock = this.valueLoaderLocks.computeIfAbsent(keyId, ignored -> new Object());
+
+		try {
+			synchronized (lock) {
+
+				wrapper = get(key);
+				if (wrapper != null) {
+					return (T) wrapper.get();
+				}
+
+				T value = valueLoader.call();
+				put(key, value);
+				return value;
+			}
+		} catch (Exception ex) {
+			throw new ValueRetrievalException(key, valueLoader, ex);
+		} finally {
+			this.valueLoaderLocks.remove(keyId, lock);
+		}
+	}
+
+	@Override
+	public void put(Object key, @Nullable Object value) {
+
+		Assert.notNull(key, "Cache key must not be null");
+		if (value == null && !this.configuration.isAllowNullValues()) {
+			throw new IllegalArgumentException("This MongoCache is configured to not allow null values");
+		}
+
+		Instant now = this.clock.instant();
+		MongoCacheEntry entry = new MongoCacheEntry();
+		entry.setId(MongoCacheKey.id(this.name, key));
+		entry.setCacheName(this.name);
+		entry.setCacheKey(MongoCacheKey.description(key));
+		entry.setValue(value);
+		entry.setNullValue(value == null);
+		entry.setCreatedAt(now);
+		entry.setUpdatedAt(now);
+		entry.setExpiresAt(expiresAt(now));
+
+		this.mongoOperations.save(entry, this.configuration.getCollectionName());
+	}
+
+	@Override
+	public @Nullable ValueWrapper putIfAbsent(Object key, @Nullable Object value) {
+
+		ValueWrapper existing = get(key);
+		if (existing != null) {
+			return existing;
+		}
+
+		put(key, value);
+		return null;
+	}
+
+	@Override
+	public void evict(Object key) {
+		removeById(MongoCacheKey.id(this.name, key));
+	}
+
+	@Override
+	public boolean evictIfPresent(Object key) {
+		return removeById(MongoCacheKey.id(this.name, key)).getDeletedCount() > 0;
+	}
+
+	@Override
+	public void clear() {
+		invalidate();
+	}
+
+	@Override
+	public boolean invalidate() {
+		return this.mongoOperations.remove(Query.query(Criteria.where("cacheName").is(this.name)),
+				this.configuration.getCollectionName()).getDeletedCount() > 0;
+	}
+
+	private @Nullable MongoCacheEntry lookup(Object key) {
+
+		Assert.notNull(key, "Cache key must not be null");
+		MongoCacheEntry entry = this.mongoOperations.findById(MongoCacheKey.id(this.name, key), MongoCacheEntry.class,
+				this.configuration.getCollectionName());
+
+		if (entry == null) {
+			return null;
+		}
+
+		if (entry.isExpired(this.clock.instant())) {
+			removeById(Objects.requireNonNull(entry.getId()));
+			return null;
+		}
+
+		return entry;
+	}
+
+	private @Nullable Object fromStoreValue(MongoCacheEntry entry) {
+		return entry.isNullValue() ? null : entry.getValue();
+	}
+
+	private @Nullable Instant expiresAt(Instant createdAt) {
+
+		Duration timeToLive = this.configuration.getTimeToLive();
+		return timeToLive == null || timeToLive.isZero() ? null : createdAt.plus(timeToLive);
+	}
+
+	private DeleteResult removeById(String id) {
+		return this.mongoOperations.remove(Query.query(Criteria.where("_id").is(id)), this.configuration.getCollectionName());
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheConfiguration.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheConfiguration.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+
+import java.time.Duration;
+
+/**
+ * Immutable configuration for {@link MongoCache} instances.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public class MongoCacheConfiguration {
+
+	/**
+	 * The default collection name used to store cache entries.
+	 */
+	public static final String DEFAULT_COLLECTION_NAME = "spring_cache";
+
+	private final String collectionName;
+	private final boolean allowNullValues;
+	private final boolean createIndexes;
+	private final @Nullable Duration timeToLive;
+
+	private MongoCacheConfiguration(String collectionName, boolean allowNullValues, boolean createIndexes,
+			@Nullable Duration timeToLive) {
+
+		this.collectionName = collectionName;
+		this.allowNullValues = allowNullValues;
+		this.createIndexes = createIndexes;
+		this.timeToLive = timeToLive;
+	}
+
+	/**
+	 * Create a {@link MongoCacheConfiguration} using the default settings.
+	 *
+	 * @return a new {@link MongoCacheConfiguration}.
+	 */
+	public static MongoCacheConfiguration defaultCacheConfig() {
+		return new MongoCacheConfiguration(DEFAULT_COLLECTION_NAME, true, true, null);
+	}
+
+	/**
+	 * Return a new configuration that stores cache entries in {@code collectionName}.
+	 *
+	 * @param collectionName must not be {@literal null} or empty.
+	 * @return a new {@link MongoCacheConfiguration}.
+	 */
+	public MongoCacheConfiguration withCollectionName(String collectionName) {
+
+		Assert.hasText(collectionName, "Collection name must not be null or empty");
+		return new MongoCacheConfiguration(collectionName, this.allowNullValues, this.createIndexes, this.timeToLive);
+	}
+
+	/**
+	 * Return a new configuration that expires entries after {@code timeToLive}. A zero duration disables expiry.
+	 *
+	 * @param timeToLive must not be {@literal null} or negative.
+	 * @return a new {@link MongoCacheConfiguration}.
+	 */
+	public MongoCacheConfiguration entryTtl(Duration timeToLive) {
+
+		Assert.notNull(timeToLive, "Time to live must not be null");
+		Assert.isTrue(!timeToLive.isNegative(), "Time to live must not be negative");
+		return new MongoCacheConfiguration(this.collectionName, this.allowNullValues, this.createIndexes, timeToLive);
+	}
+
+	/**
+	 * Return a new configuration that rejects {@literal null} cache values.
+	 *
+	 * @return a new {@link MongoCacheConfiguration}.
+	 */
+	public MongoCacheConfiguration disableCachingNullValues() {
+		return new MongoCacheConfiguration(this.collectionName, false, this.createIndexes, this.timeToLive);
+	}
+
+	/**
+	 * Return a new configuration that does not create indexes when the cache manager is initialized.
+	 *
+	 * @return a new {@link MongoCacheConfiguration}.
+	 */
+	public MongoCacheConfiguration disableIndexCreation() {
+		return new MongoCacheConfiguration(this.collectionName, this.allowNullValues, false, this.timeToLive);
+	}
+
+	/**
+	 * Return the name of the collection used for cache entries.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public String getCollectionName() {
+		return this.collectionName;
+	}
+
+	/**
+	 * Return whether {@literal null} cache values may be stored.
+	 *
+	 * @return {@literal true} if {@literal null} values may be stored.
+	 */
+	public boolean isAllowNullValues() {
+		return this.allowNullValues;
+	}
+
+	/**
+	 * Return whether the cache manager creates the cache indexes automatically.
+	 *
+	 * @return {@literal true} if the cache manager creates indexes.
+	 */
+	public boolean isCreateIndexes() {
+		return this.createIndexes;
+	}
+
+	/**
+	 * Return the configured entry TTL. A {@literal null} value or {@link Duration#ZERO} denotes entries that do not
+	 * expire.
+	 *
+	 * @return can be {@literal null}.
+	 */
+	public @Nullable Duration getTimeToLive() {
+		return this.timeToLive;
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheEntry.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheEntry.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.annotation.Id;
+
+import java.time.Instant;
+
+/**
+ * Persistent representation of a cache entry.
+ *
+ * @author Anıl Şenocak
+ */
+class MongoCacheEntry {
+
+	@Id private @Nullable String id;
+	private @Nullable String cacheName;
+	private @Nullable String cacheKey;
+	private @Nullable Object value;
+	private boolean nullValue;
+	private @Nullable Instant createdAt;
+	private @Nullable Instant updatedAt;
+	private @Nullable Instant expiresAt;
+
+	@Nullable String getId() {
+		return this.id;
+	}
+
+	void setId(String id) {
+		this.id = id;
+	}
+
+	@Nullable String getCacheName() {
+		return this.cacheName;
+	}
+
+	void setCacheName(String cacheName) {
+		this.cacheName = cacheName;
+	}
+
+	@Nullable String getCacheKey() {
+		return this.cacheKey;
+	}
+
+	void setCacheKey(String cacheKey) {
+		this.cacheKey = cacheKey;
+	}
+
+	@Nullable Object getValue() {
+		return this.value;
+	}
+
+	void setValue(@Nullable Object value) {
+		this.value = value;
+	}
+
+	boolean isNullValue() {
+		return this.nullValue;
+	}
+
+	void setNullValue(boolean nullValue) {
+		this.nullValue = nullValue;
+	}
+
+	@Nullable Instant getCreatedAt() {
+		return this.createdAt;
+	}
+
+	void setCreatedAt(Instant createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	@Nullable Instant getUpdatedAt() {
+		return this.updatedAt;
+	}
+
+	void setUpdatedAt(Instant updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+
+	@Nullable Instant getExpiresAt() {
+		return this.expiresAt;
+	}
+
+	void setExpiresAt(@Nullable Instant expiresAt) {
+		this.expiresAt = expiresAt;
+	}
+
+	boolean isExpired(Instant now) {
+		return this.expiresAt != null && !this.expiresAt.isAfter(now);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheKey.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheKey.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.springframework.util.Assert;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+
+/**
+ * @author Anıl Şenocak
+ */
+final class MongoCacheKey {
+
+	private static final byte SEPARATOR = 0;
+
+	private MongoCacheKey() {}
+
+	static String id(String cacheName, Object key) {
+
+		Assert.hasText(cacheName, "Cache name must not be empty");
+		Assert.notNull(key, "Cache key must not be null");
+
+		MessageDigest digest = sha256();
+		update(digest, cacheName);
+		digest.update(SEPARATOR);
+		update(digest, key.getClass().getName());
+		digest.update(SEPARATOR);
+		digest.update(keyBytes(key));
+
+		return cacheName + "::" + HexFormat.of().formatHex(digest.digest());
+	}
+
+	static String description(Object key) {
+		Assert.notNull(key, "Cache key must not be null");
+		return key.getClass().getName() + ":" + key;
+	}
+
+	private static MessageDigest sha256() {
+
+		try {
+			return MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-256 digest is not available", ex);
+		}
+	}
+
+	private static void update(MessageDigest digest, String value) {
+		digest.update(value.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static byte[] keyBytes(Object key) {
+
+		if (key instanceof Serializable serializable) {
+			try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+					ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+
+				output.writeObject(serializable);
+				output.flush();
+				return bytes.toByteArray();
+			} catch (IOException ex) {
+				// Fall back to a stable textual representation for non-serializable object graphs.
+			}
+		}
+
+		return Objects.toString(key).getBytes(StandardCharsets.UTF_8);
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheManager.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/MongoCacheManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.Assert;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A {@link CacheManager} that creates {@link MongoCache MongoCaches} backed by a shared MongoDB collection.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public class MongoCacheManager implements CacheManager {
+
+	private static final String CACHE_NAME_INDEX = "mongo_cache_cache_name";
+	private static final String EXPIRY_INDEX = "mongo_cache_expires_at";
+
+	private final MongoOperations mongoOperations;
+	private final MongoCacheConfiguration configuration;
+	private final Clock clock;
+	private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
+
+	/**
+	 * Create a cache manager using {@link MongoCacheConfiguration#defaultCacheConfig()}.
+	 *
+	 * @param mongoOperations must not be {@literal null}.
+	 */
+	public MongoCacheManager(MongoOperations mongoOperations) {
+		this(mongoOperations, MongoCacheConfiguration.defaultCacheConfig());
+	}
+
+	/**
+	 * Create a cache manager with the given configuration.
+	 *
+	 * @param mongoOperations must not be {@literal null}.
+	 * @param configuration must not be {@literal null}.
+	 */
+	public MongoCacheManager(MongoOperations mongoOperations, MongoCacheConfiguration configuration) {
+		this(mongoOperations, configuration, Clock.systemUTC());
+	}
+
+	MongoCacheManager(MongoOperations mongoOperations, MongoCacheConfiguration configuration, Clock clock) {
+
+		Assert.notNull(mongoOperations, "MongoOperations must not be null");
+		Assert.notNull(configuration, "MongoCacheConfiguration must not be null");
+		Assert.notNull(clock, "Clock must not be null");
+
+		this.mongoOperations = mongoOperations;
+		this.configuration = configuration;
+		this.clock = clock;
+
+		if (configuration.isCreateIndexes()) {
+			createIndexes();
+		}
+	}
+
+	@Override
+	public Cache getCache(String name) {
+
+		Assert.hasText(name, "Cache name must not be empty");
+		return this.caches.computeIfAbsent(name,
+				cacheName -> new MongoCache(cacheName, this.mongoOperations, this.configuration, this.clock));
+	}
+
+	@Override
+	public Collection<String> getCacheNames() {
+		return Collections.unmodifiableSet(new LinkedHashSet<>(this.caches.keySet()));
+	}
+
+	/**
+	 * Remove all entries managed by this cache manager from its configured collection.
+	 *
+	 * @return {@literal true} if at least one cache entry was removed.
+	 */
+	public boolean clearAll() {
+		return this.mongoOperations.remove(new Query(), this.configuration.getCollectionName()).getDeletedCount() > 0;
+	}
+
+	private void createIndexes() {
+
+		IndexOperations indexOperations = this.mongoOperations.indexOps(this.configuration.getCollectionName());
+		indexOperations.ensureIndex(new Index().on("cacheName", Direction.ASC).named(CACHE_NAME_INDEX));
+		indexOperations.ensureIndex(new Index().on("expiresAt", Direction.ASC).expire(Duration.ZERO).named(EXPIRY_INDEX));
+	}
+}

--- a/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/package-info.java
+++ b/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/cache/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring Cache support backed by MongoDB.
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.data.mongodb.cache;

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheConfigurationUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheConfigurationUnitTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Unit tests for {@link MongoCacheConfiguration}.
+ *
+ * @author Anıl Şenocak
+ */
+class MongoCacheConfigurationUnitTests {
+
+	@Test
+	void shouldUseDefaults() {
+
+		MongoCacheConfiguration configuration = MongoCacheConfiguration.defaultCacheConfig();
+
+		assertThat(configuration.getCollectionName()).isEqualTo(MongoCacheConfiguration.DEFAULT_COLLECTION_NAME);
+		assertThat(configuration.isAllowNullValues()).isTrue();
+		assertThat(configuration.isCreateIndexes()).isTrue();
+		assertThat(configuration.getTimeToLive()).isNull();
+	}
+
+	@Test
+	void shouldCreateIndependentConfiguredInstances() {
+
+		MongoCacheConfiguration defaults = MongoCacheConfiguration.defaultCacheConfig();
+		MongoCacheConfiguration configuration = defaults.withCollectionName("cache_entries").entryTtl(Duration.ofMinutes(5))
+				.disableCachingNullValues().disableIndexCreation();
+
+		assertThat(defaults.getCollectionName()).isEqualTo(MongoCacheConfiguration.DEFAULT_COLLECTION_NAME);
+		assertThat(defaults.getTimeToLive()).isNull();
+		assertThat(defaults.isAllowNullValues()).isTrue();
+		assertThat(defaults.isCreateIndexes()).isTrue();
+		assertThat(configuration.getCollectionName()).isEqualTo("cache_entries");
+		assertThat(configuration.getTimeToLive()).isEqualTo(Duration.ofMinutes(5));
+		assertThat(configuration.isAllowNullValues()).isFalse();
+		assertThat(configuration.isCreateIndexes()).isFalse();
+	}
+
+	@Test
+	void shouldRejectInvalidSettings() {
+
+		MongoCacheConfiguration configuration = MongoCacheConfiguration.defaultCacheConfig();
+
+		assertThatIllegalArgumentException().isThrownBy(() -> configuration.withCollectionName(" "));
+		assertThatIllegalArgumentException().isThrownBy(() -> configuration.entryTtl(Duration.ofSeconds(-1)));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheIntegrationTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheIntegrationTests.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.test.util.MongoTestTemplate;
+import org.springframework.data.mongodb.test.util.Template;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+/**
+ * Integration tests for {@link MongoCache} using a real MongoDB server.
+ *
+ * @author Anıl Şenocak
+ */
+class MongoCacheIntegrationTests {
+
+	private static final String COLLECTION_NAME = "mongo_cache_integration_tests";
+
+	@Template(initialEntitySet = CachedValue.class) static MongoTestTemplate mongoTemplate;
+
+	private MongoCacheManager cacheManager;
+
+	@BeforeEach
+	void setUp() {
+
+		mongoTemplate.dropCollection(COLLECTION_NAME);
+		cacheManager = new MongoCacheManager(mongoTemplate,
+				MongoCacheConfiguration.defaultCacheConfig().withCollectionName(COLLECTION_NAME));
+	}
+
+	@AfterEach
+	void tearDown() {
+		mongoTemplate.dropCollection(COLLECTION_NAME);
+	}
+
+	@Test
+	void shouldPersistAndRehydrateValuesThroughMongoDB() {
+
+		Cache cache = cacheManager.getCache("users");
+		CachedValue expected = new CachedValue("Ada Lovelace");
+
+		cache.put("ada", expected);
+
+		Document entry = mongoTemplate.findById(MongoCacheKey.id("users", "ada"), Document.class, COLLECTION_NAME);
+		assertThat(entry).isNotNull().containsEntry("cacheName", "users").containsEntry("cacheKey", "java.lang.String:ada")
+				.containsEntry("nullValue", false);
+		assertThat(cache.get("ada", CachedValue.class)).isEqualTo(expected);
+	}
+
+	@Test
+	void shouldRetainCachedNullValuesAcrossMongoDBReads() {
+
+		Cache cache = cacheManager.getCache("users");
+
+		cache.put("missing", null);
+
+		Cache.ValueWrapper cached = cache.get("missing");
+		Document entry = mongoTemplate.findById(MongoCacheKey.id("users", "missing"), Document.class, COLLECTION_NAME);
+		assertThat(cached).isNotNull();
+		assertThat(cached.get()).isNull();
+		assertThat(entry).isNotNull().containsEntry("nullValue", true);
+	}
+
+	@Test
+	void shouldRemoveExpiredEntriesOnRead() {
+
+		Cache cache = cacheManager.getCache("users");
+		String id = MongoCacheKey.id("users", "expired");
+		cache.put("expired", "value");
+		mongoTemplate.updateFirst(query(where("_id").is(id)), Update.update("expiresAt", Instant.now().minusSeconds(1)),
+				COLLECTION_NAME);
+
+		assertThat(cache.get("expired")).isNull();
+		assertThat(mongoTemplate.count(query(where("_id").is(id)), COLLECTION_NAME)).isZero();
+	}
+
+	@Test
+	void shouldPersistConfiguredEntryExpiry() {
+
+		Duration ttl = Duration.ofMinutes(5);
+		MongoCacheManager ttlCacheManager = new MongoCacheManager(mongoTemplate,
+				MongoCacheConfiguration.defaultCacheConfig().withCollectionName(COLLECTION_NAME).entryTtl(ttl));
+		Cache cache = ttlCacheManager.getCache("users");
+		Instant beforePut = Instant.now();
+
+		cache.put("ada", new CachedValue("Ada Lovelace"));
+
+		Instant afterPut = Instant.now();
+		MongoCacheEntry entry = mongoTemplate.findById(MongoCacheKey.id("users", "ada"), MongoCacheEntry.class,
+				COLLECTION_NAME);
+		assertThat(entry).isNotNull();
+		assertThat(entry.getExpiresAt()).isBetween(beforePut.plus(ttl).minusMillis(1), afterPut.plus(ttl).plusMillis(1));
+	}
+
+	@Test
+	void shouldKeepExistingValueWhenPuttingIfAbsentAndEvictIt() {
+
+		Cache cache = cacheManager.getCache("users");
+		CachedValue initial = new CachedValue("Ada Lovelace");
+
+		assertThat(cache.putIfAbsent("ada", initial)).isNull();
+		Cache.ValueWrapper existing = cache.putIfAbsent("ada", new CachedValue("Grace Hopper"));
+
+		assertThat(existing).isNotNull();
+		assertThat(existing.get()).isEqualTo(initial);
+		assertThat(cache.evictIfPresent("ada")).isTrue();
+		assertThat(cache.get("ada")).isNull();
+		assertThat(cache.evictIfPresent("ada")).isFalse();
+	}
+
+	@Test
+	void shouldInvalidateOneCacheWithoutAffectingOthersAndClearAllEntries() {
+
+		Cache users = cacheManager.getCache("users");
+		Cache products = cacheManager.getCache("products");
+		users.put("ada", new CachedValue("Ada Lovelace"));
+		products.put("book", new CachedValue("Analytical Engine"));
+
+		assertThat(users.invalidate()).isTrue();
+		assertThat(mongoTemplate.count(query(where("cacheName").is("users")), COLLECTION_NAME)).isZero();
+		assertThat(mongoTemplate.count(query(where("cacheName").is("products")), COLLECTION_NAME)).isEqualTo(1);
+		assertThat(cacheManager.clearAll()).isTrue();
+		assertThat(mongoTemplate.count(new org.springframework.data.mongodb.core.query.Query(), COLLECTION_NAME)).isZero();
+	}
+
+	static class CachedValue {
+
+		private String name;
+
+		CachedValue() {}
+
+		CachedValue(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			CachedValue that = (CachedValue) o;
+			return Objects.equals(this.name, that.name);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.name);
+		}
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheManagerUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheManagerUnitTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import com.mongodb.client.result.DeleteResult;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MongoCacheManager}.
+ *
+ * @author Anıl Şenocak
+ */
+@ExtendWith(MockitoExtension.class)
+class MongoCacheManagerUnitTests {
+
+	@Mock MongoOperations mongoOperations;
+	@Mock IndexOperations indexOperations;
+
+	@Test
+	void shouldReturnTheSameCacheForTheSameName() {
+
+		MongoCacheManager manager = new MongoCacheManager(this.mongoOperations,
+				MongoCacheConfiguration.defaultCacheConfig().disableIndexCreation());
+
+		Cache first = manager.getCache("users");
+		Cache second = manager.getCache("users");
+
+		assertThat(first).isSameAs(second);
+		assertThat(manager.getCacheNames()).containsExactly("users");
+	}
+
+	@Test
+	void shouldClearAllEntriesFromTheConfiguredCollection() {
+
+		when(this.mongoOperations.remove(any(Query.class), eq("cache_entries"))).thenReturn(DeleteResult.acknowledged(2));
+		MongoCacheManager manager = new MongoCacheManager(this.mongoOperations,
+				MongoCacheConfiguration.defaultCacheConfig().withCollectionName("cache_entries").disableIndexCreation());
+
+		assertThat(manager.clearAll()).isTrue();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(this.mongoOperations).remove(query.capture(), eq("cache_entries"));
+		assertThat(query.getValue().getQueryObject()).isEmpty();
+	}
+
+	@Test
+	void shouldCreateIndexesForEvictionAndExpiry() {
+
+		when(this.mongoOperations.indexOps("cache_entries")).thenReturn(this.indexOperations);
+		when(this.indexOperations.ensureIndex(any(IndexDefinition.class))).thenReturn("index");
+
+		new MongoCacheManager(this.mongoOperations,
+				MongoCacheConfiguration.defaultCacheConfig().withCollectionName("cache_entries").entryTtl(Duration.ofSeconds(45)));
+
+		ArgumentCaptor<IndexDefinition> indexes = ArgumentCaptor.forClass(IndexDefinition.class);
+		verify(this.indexOperations, times(2)).ensureIndex(indexes.capture());
+		IndexDefinition cacheName = indexes.getAllValues().stream()
+				.filter(index -> index.getIndexKeys().containsKey("cacheName")).findFirst().orElseThrow();
+		IndexDefinition expiry = indexes.getAllValues().stream()
+				.filter(index -> index.getIndexKeys().containsKey("expiresAt")).findFirst().orElseThrow();
+
+		assertThat(cacheName.getIndexKeys()).isEqualTo(new Document("cacheName", 1));
+		assertThat(cacheName.getIndexOptions()).containsEntry("name", "mongo_cache_cache_name");
+		assertThat(expiry.getIndexKeys()).isEqualTo(new Document("expiresAt", 1));
+		assertThat(expiry.getIndexOptions()).containsEntry("name", "mongo_cache_expires_at")
+				.containsEntry("expireAfterSeconds", Duration.ZERO.getSeconds());
+	}
+
+	@Test
+	void shouldNotCreateIndexesWhenDisabled() {
+
+		new MongoCacheManager(this.mongoOperations,
+				MongoCacheConfiguration.defaultCacheConfig().disableIndexCreation());
+
+		verify(this.mongoOperations, never()).indexOps(any(String.class));
+	}
+}

--- a/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheUnitTests.java
+++ b/spring-data-mongodb/src/test/java/org/springframework/data/mongodb/cache/MongoCacheUnitTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mongodb.cache;
+
+import com.mongodb.client.result.DeleteResult;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MongoCache}.
+ *
+ * @author Anıl Şenocak
+ */
+@ExtendWith(MockitoExtension.class)
+class MongoCacheUnitTests {
+
+	@Mock MongoOperations mongoOperations;
+
+	@Test
+	void shouldStoreEntryWithComputedExpiry() {
+
+		Instant now = Instant.parse("2026-07-21T12:00:00Z");
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig().withCollectionName("cache_entries")
+				.entryTtl(Duration.ofMinutes(5)), now);
+		ArgumentCaptor<MongoCacheEntry> entry = ArgumentCaptor.forClass(MongoCacheEntry.class);
+
+		cache.put("id-1", "Ada");
+
+		verify(this.mongoOperations).save(entry.capture(), eq("cache_entries"));
+		assertThat(entry.getValue().getId()).isEqualTo(MongoCacheKey.id("users", "id-1"));
+		assertThat(entry.getValue().getCacheName()).isEqualTo("users");
+		assertThat(entry.getValue().getCacheKey()).isEqualTo(MongoCacheKey.description("id-1"));
+		assertThat(entry.getValue().getValue()).isEqualTo("Ada");
+		assertThat(entry.getValue().isNullValue()).isFalse();
+		assertThat(entry.getValue().getCreatedAt()).isEqualTo(now);
+		assertThat(entry.getValue().getUpdatedAt()).isEqualTo(now);
+		assertThat(entry.getValue().getExpiresAt()).isEqualTo(now.plus(Duration.ofMinutes(5)));
+	}
+
+	@Test
+	void shouldRejectNullValuesWhenConfigured() {
+
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig().disableCachingNullValues(), Instant.now());
+
+		assertThatIllegalArgumentException().isThrownBy(() -> cache.put("id-1", null))
+				.withMessage("This MongoCache is configured to not allow null values");
+	}
+
+	@Test
+	void shouldReturnCachedNullValue() {
+
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig(), Instant.now());
+		MongoCacheEntry entry = entry("users::entry", null, true, null);
+		when(this.mongoOperations.findById(MongoCacheKey.id("users", "id-1"), MongoCacheEntry.class,
+				MongoCacheConfiguration.DEFAULT_COLLECTION_NAME)).thenReturn(entry);
+
+		Cache.ValueWrapper value = cache.get("id-1");
+
+		assertThat(value).isNotNull();
+		assertThat(value.get()).isNull();
+	}
+
+	@Test
+	void shouldRejectMismatchedRequiredType() {
+
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig(), Instant.now());
+		when(this.mongoOperations.findById(MongoCacheKey.id("users", "id-1"), MongoCacheEntry.class,
+				MongoCacheConfiguration.DEFAULT_COLLECTION_NAME)).thenReturn(entry("users::entry", 42, false, null));
+
+		assertThatIllegalStateException().isThrownBy(() -> cache.get("id-1", String.class))
+				.withMessageContaining("Cached value is not of required type");
+	}
+
+	@Test
+	void shouldTreatExpiredEntriesAsCacheMissesAndRemoveThem() {
+
+		Instant now = Instant.parse("2026-07-21T12:00:00Z");
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig().withCollectionName("cache_entries"), now);
+		MongoCacheEntry entry = entry("users::expired", "value", false, now.minusSeconds(1));
+		when(this.mongoOperations.findById(MongoCacheKey.id("users", "id-1"), MongoCacheEntry.class, "cache_entries"))
+				.thenReturn(entry);
+		when(this.mongoOperations.remove(any(Query.class), eq("cache_entries"))).thenReturn(DeleteResult.acknowledged(1));
+
+		assertThat(cache.get("id-1")).isNull();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(this.mongoOperations).remove(query.capture(), eq("cache_entries"));
+		assertThat(query.getValue().getQueryObject()).containsEntry("_id", "users::expired");
+	}
+
+	@Test
+	void shouldLoadAValueOnlyOnceForTheSameKey() {
+
+		Instant now = Instant.parse("2026-07-21T12:00:00Z");
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig(), now);
+		when(this.mongoOperations.findById(MongoCacheKey.id("users", "id-1"), MongoCacheEntry.class,
+				MongoCacheConfiguration.DEFAULT_COLLECTION_NAME)).thenReturn(null, null,
+						entry("users::stored", "Ada", false, now.plusSeconds(120)));
+		AtomicInteger invocations = new AtomicInteger();
+
+		String first = cache.get("id-1", () -> {
+			invocations.incrementAndGet();
+			return "Ada";
+		});
+		String second = cache.get("id-1", () -> {
+			invocations.incrementAndGet();
+			return "Grace";
+		});
+
+		assertThat(first).isEqualTo("Ada");
+		assertThat(second).isEqualTo("Ada");
+		assertThat(invocations).hasValue(1);
+		verify(this.mongoOperations).save(any(MongoCacheEntry.class), eq(MongoCacheConfiguration.DEFAULT_COLLECTION_NAME));
+	}
+
+	@Test
+	void shouldInvalidateOnlyEntriesFromItsCache() {
+
+		MongoCache cache = cache(MongoCacheConfiguration.defaultCacheConfig().withCollectionName("cache_entries"), Instant.now());
+		when(this.mongoOperations.remove(any(Query.class), eq("cache_entries"))).thenReturn(DeleteResult.acknowledged(3));
+
+		assertThat(cache.invalidate()).isTrue();
+
+		ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+		verify(this.mongoOperations).remove(query.capture(), eq("cache_entries"));
+		Document queryObject = query.getValue().getQueryObject();
+		assertThat(queryObject).containsEntry("cacheName", "users");
+	}
+
+	private MongoCache cache(MongoCacheConfiguration configuration, Instant now) {
+		return new MongoCache("users", this.mongoOperations, configuration, Clock.fixed(now, ZoneOffset.UTC));
+	}
+
+	private MongoCacheEntry entry(String id, Object value, boolean nullValue, Instant expiresAt) {
+
+		MongoCacheEntry entry = new MongoCacheEntry();
+		entry.setId(id);
+		entry.setCacheName("users");
+		entry.setValue(value);
+		entry.setNullValue(nullValue);
+		entry.setExpiresAt(expiresAt);
+		return entry;
+	}
+}


### PR DESCRIPTION
This implementation provides a `MongoCacheManager` and `MongoCache` implementation that integrate with the Spring Cache abstraction, allowing applications to use MongoDB as a distributed cache store.

Spring Session already supports MongoDB as a session store, while the Spring Cache abstraction currently lacks a MongoDB-backed implementation. This contribution enables applications already using MongoDB to leverage it as their cache provider without introducing an additional caching infrastructure.

#2928

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).